### PR TITLE
Add switch default branch support, cast-to-record inference, stdlib enhancements, and new tests

### DIFF
--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -960,6 +960,17 @@ public class PirGenerator {
                 return extractReturnType(methodType.get());
             }
         }
+        // Handle cast expressions: (RecordType)(Object) data → resolve the target type
+        // This enables `var sd = (StateDatum)(Object) rawDatum;` to infer RecordType
+        if (expr instanceof CastExpr ce) {
+            try {
+                var castType = typeResolver.resolve(ce.getType());
+                if (!(castType instanceof PirType.DataType)) return castType;
+            } catch (IllegalArgumentException _) {
+                // Unknown target (e.g., Object) — fall through
+            }
+            return resolveExpressionType(ce.getExpression());
+        }
         return new PirType.DataType();
     }
 
@@ -1136,6 +1147,17 @@ public class PirGenerator {
                         "@NewType records have a single field, so the constructor takes 1 argument.", oce);
             }
             return generateExpression(oce.getArguments().get(0));
+        }
+
+        // Ledger hash types (ScriptHash, PubKeyHash, etc.) resolve to ByteStringType.
+        // Their constructors are identity — the single field IS the underlying byte[].
+        try {
+            var resolvedType = typeResolver.resolve(ct);
+            if (resolvedType instanceof PirType.ByteStringType && oce.getArguments().size() == 1) {
+                return generateExpression(oce.getArguments().get(0));
+            }
+        } catch (IllegalArgumentException _) {
+            // Not a known type — continue to other checks
         }
 
         // Handle new BigInteger("12345") → integer constant
@@ -2559,12 +2581,12 @@ public class PirGenerator {
 
         var desugarer = new PatternMatchDesugarer(typeResolver);
         var matchEntries = new ArrayList<PatternMatchDesugarer.MatchEntry>();
+        PirTerm defaultBranchBody = null;
 
         for (var entry : se.getEntries()) {
             if (entry.isDefault()) {
-                collectError("The 'default' branch is not supported in switch on sealed interfaces. "
-                                + "The default branch body is not compiled and would be silently ignored.",
-                        "Use explicit cases for all variants of '" + sumType.name() + "' instead.", se);
+                // Compile the default branch body for use as catch-all for unmatched variants
+                defaultBranchBody = generateSwitchEntryBody(entry);
                 continue;
             }
             for (var label : entry.getLabels()) {
@@ -2607,10 +2629,19 @@ public class PirGenerator {
             }
         }
 
-        // Exhaustiveness check: verify all constructors are covered or a default branch exists
-        boolean hasDefault = se.getEntries().stream().anyMatch(
-                com.github.javaparser.ast.stmt.SwitchEntry::isDefault);
-        if (!hasDefault) {
+        if (defaultBranchBody != null) {
+            // Fill missing variants with the default branch body
+            var coveredCases = matchEntries.stream()
+                    .map(PatternMatchDesugarer.MatchEntry::variantName)
+                    .collect(java.util.stream.Collectors.toSet());
+            for (var ctor : sumType.constructors()) {
+                if (!coveredCases.contains(ctor.name())) {
+                    matchEntries.add(new PatternMatchDesugarer.MatchEntry(
+                            ctor.name(), List.of(), defaultBranchBody));
+                }
+            }
+        } else {
+            // Exhaustiveness check: verify all constructors are covered
             var coveredCases = matchEntries.stream()
                     .map(PatternMatchDesugarer.MatchEntry::variantName)
                     .collect(java.util.stream.Collectors.toSet());

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -774,6 +774,14 @@ public class PirGenerator {
                         }
                     }
                 }
+                // Chained .hash() on a ledger hash / @NewType that already resolved to
+                // ByteStringType.  The parent accessor already applied UnBData, so
+                // the .hash() accessor is an identity — skip the TypeMethodRegistry
+                // dispatch which would apply a redundant UnBData.
+                if (scopeType instanceof PirType.ByteStringType
+                        && methodName.equals("hash")) {
+                    return scope;
+                }
             }
 
             // Dispatch instance methods via TypeMethodRegistry
@@ -823,6 +831,12 @@ public class PirGenerator {
                     if (scopeExpr instanceof NameExpr ne
                             && hofUnwrappedVars.contains(ne.getNameAsString())) {
                         return scope; // HOF-unwrapped — identity
+                    }
+                    // Chained accessor: parent MethodCallExpr already produced a raw
+                    // bytestring (via field extraction / wrapDecode), so another
+                    // UnBData would be a double-unwrap.
+                    if (scopeExpr instanceof MethodCallExpr) {
+                        return scope;
                     }
                     // Standard field extraction: UnBData (same semantics as .hash() for non-HOF context)
                     return new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnBData), scope);

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolver.java
@@ -328,6 +328,10 @@ public class TypeResolver {
                         new PirType.Field("second", secondType),
                         new PirType.Field("third", thirdType)));
             }
+            case "AssetEntry" -> new PirType.RecordType("AssetEntry", List.of(
+                    new PirType.Field("policyId", new PirType.ByteStringType()),
+                    new PirType.Field("tokenName", new PirType.ByteStringType()),
+                    new PirType.Field("amount", new PirType.IntegerType())));
             case "Optional" -> {
                 PirType elemType = new PirType.DataType();
                 var optArgs = ct.getTypeArguments();

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/PlutusDataConversionTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/PlutusDataConversionTest.java
@@ -198,6 +198,122 @@ class PlutusDataConversionTest {
         }
 
         @Test
+        void castToRecordFieldAccess() {
+            // (RecordType)(Object) rawData → field access should work
+            // Cast is identity at UPLC level, but explicit type annotation
+            // registers RecordType in symbol table, enabling field extraction
+            var source = """
+                    import com.bloxbean.cardano.julc.ledger.*;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        record MyDatum(BigInteger count, byte[] owner) {}
+
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            MyDatum datum = (MyDatum)(Object) redeemer;
+                            return datum.count() > 0;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var datumData = PlutusData.constr(0, PlutusData.integer(42), PlutusData.bytes(new byte[28]));
+            var ctx = PlutusData.constr(0, PlutusData.integer(0), datumData, PlutusData.integer(0));
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "Cast-to-record field access should work. Got: " + result);
+        }
+
+        @Test
+        void castToRecordWithVarFieldAccess() {
+            // var datum = (RecordType)(Object) rawData → field access should work
+            // Tests that resolveExpressionType handles CastExpr for var type inference
+            var source = """
+                    import com.bloxbean.cardano.julc.ledger.*;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        record MyDatum(BigInteger count, byte[] owner) {}
+
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            var datum = (MyDatum)(Object) redeemer;
+                            return datum.count() > 0;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var datumData = PlutusData.constr(0, PlutusData.integer(42), PlutusData.bytes(new byte[28]));
+            var ctx = PlutusData.constr(0, PlutusData.integer(0), datumData, PlutusData.integer(0));
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "var + cast-to-record field access should work. Got: " + result);
+        }
+
+        @Test
+        void castToRecordMultiFieldAccess() {
+            // Test accessing multiple fields after cast, including deep fields
+            var source = """
+                    import com.bloxbean.cardano.julc.ledger.*;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        record StateDatum(byte[] id, byte[] owner, BigInteger fee,
+                                          BigInteger feeInterval, BigInteger ttl) {}
+
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            StateDatum sd = (StateDatum)(Object) redeemer;
+                            BigInteger fee = sd.fee();
+                            BigInteger ttl = sd.ttl();
+                            return fee > 0 && ttl > 100;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var datumData = PlutusData.constr(0,
+                    PlutusData.bytes(new byte[32]),   // id
+                    PlutusData.bytes(new byte[28]),   // owner
+                    PlutusData.integer(1000),         // fee
+                    PlutusData.integer(5),            // feeInterval
+                    PlutusData.integer(999999));      // ttl
+            var ctx = PlutusData.constr(0, PlutusData.integer(0), datumData, PlutusData.integer(0));
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "Multi-field access after cast should work. Got: " + result);
+        }
+
+        @Test
+        void nestedRecordConstruction() {
+            // new Credential.ScriptCredential(new ScriptHash(hash)) should compile correctly:
+            // ScriptHash(hash) is identity (hash type → ByteStringType)
+            // ScriptCredential(hash) → Constr(1, [BData(hash)])
+            var source = """
+                    import com.bloxbean.cardano.julc.ledger.*;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] hash = Builtins.unBData(redeemer);
+                            Credential cred = new Credential.ScriptCredential(new ScriptHash(hash));
+                            // ScriptCredential = Constr(1, [BData(hash)])
+                            // Verify by checking that equalsData matches the expected encoding
+                            PlutusData expected = Builtins.constrData(1,
+                                    Builtins.mkCons(Builtins.bData(hash), Builtins.mkNilData()));
+                            return Builtins.equalsData(cred, expected);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.bytes(new byte[28]);
+            var ctx = PlutusData.constr(0, PlutusData.integer(0), redeemer, PlutusData.integer(0));
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "Nested record construction should produce correct encoding. Got: " + result);
+        }
+
+        @Test
         void userDefinedSealedInterfaceFromPlutusData() {
             // User-defined sealed interfaces support fromPlutusData
             var source = """

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
@@ -579,6 +579,135 @@ class StdlibCompileEvalTest {
             var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
             assertTrue(result.isSuccess(), "findMintOutput pattern should work. Got: " + result);
         }
+
+        @Test
+        void reverseWorks() {
+            // Test ListsLib.reverse — build [1,2,3], reverse to [3,2,1], check head==3
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            PlutusData.ListData list = Builtins.mkCons(Builtins.iData(1),
+                                Builtins.mkCons(Builtins.iData(2),
+                                Builtins.mkCons(Builtins.iData(3), Builtins.mkNilData())));
+                            PlutusData.ListData rev = ListsLib.reverse(list);
+                            return Builtins.unIData(Builtins.headList(rev)) == 3;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "reverse([1,2,3]) head should be 3. Got: " + result);
+        }
+
+        @Test
+        void flattenPolicyWorks() {
+            // Test flattenPolicy directly — flatten a single policy's inner map
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            // redeemer = Map[(policy, Map[(token, 100)])]
+                            var outerPairs = Builtins.unMapData(redeemer);
+                            var outerPair = Builtins.headList(outerPairs);
+                            var policyData = Builtins.fstPair(outerPair);
+                            PlutusData.MapData innerMap = (PlutusData.MapData) Builtins.sndPair(outerPair);
+                            PlutusData.ListData acc = Builtins.mkNilData();
+                            PlutusData.ListData result = ValuesLib.flattenPolicy(policyData, innerMap, acc);
+                            return !Builtins.nullList(result);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var value = PlutusData.map(
+                    new PlutusData.Pair(
+                            PlutusData.bytes(new byte[]{1, 2, 3}),
+                            PlutusData.map(
+                                    new PlutusData.Pair(PlutusData.bytes(new byte[]{4, 5, 6}), PlutusData.integer(100))
+                            )
+                    )
+            );
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(value)));
+            assertTrue(result.isSuccess(), "flattenPolicy should return non-empty list. Got: " + result);
+        }
+
+        @Test
+        void flattenReturnsNonEmptyList() {
+            // Test calling ValuesLib.flatten as a library method
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            PlutusData.ListData flat = ValuesLib.flatten(redeemer);
+                            return !Builtins.nullList(flat);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var value = PlutusData.map(
+                    new PlutusData.Pair(
+                            PlutusData.bytes(new byte[]{1, 2, 3}),
+                            PlutusData.map(
+                                    new PlutusData.Pair(PlutusData.bytes(new byte[]{4, 5, 6}), PlutusData.integer(100))
+                            )
+                    )
+            );
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(value)));
+            assertTrue(result.isSuccess(), "ValuesLib.flatten should return non-empty list. Got: " + result);
+        }
+
+        @Test
+        void flattenWithAssetEntryCast() {
+            // Test that flatten() result can be cast to JulcList<AssetEntry> for typed field access
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.core.types.AssetEntry;
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            JulcList<AssetEntry> entries = (JulcList<AssetEntry>)(Object) ValuesLib.flatten(redeemer);
+                            boolean found = false;
+                            for (AssetEntry entry : entries) {
+                                if (entry.amount().compareTo(BigInteger.valueOf(100)) == 0) {
+                                    found = true;
+                                }
+                            }
+                            return found;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var value = PlutusData.map(
+                    new PlutusData.Pair(
+                            PlutusData.bytes(new byte[]{1, 2, 3}),
+                            PlutusData.map(
+                                    new PlutusData.Pair(PlutusData.bytes(new byte[]{4, 5, 6}), PlutusData.integer(100))
+                            )
+                    )
+            );
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(value)));
+            assertTrue(result.isSuccess(), "flatten + AssetEntry cast should enable typed field access. Got: " + result);
+        }
     }
 
     // =========================================================================
@@ -4723,6 +4852,166 @@ class StdlibCompileEvalTest {
             var program = compileValidatorWithLibs(validator, userLib);
             var evalResult = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
             assertTrue(evalResult.isSuccess(), "Nested library calls should resolve types recursively. Got: " + evalResult);
+        }
+    }
+
+    // =========================================================================
+    // ByteStringLib — toHex and intToDecimalString
+    // =========================================================================
+
+    @Nested
+    class ByteStringLibEval {
+
+        // All tests pack input + expected into redeemer as Constr(0, [input, expected])
+        // and use mockCtx(redeemer) for proper PlutusV3 single-arg evaluation.
+
+        @Test
+        void toHexDeadBeef() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            var fields = Builtins.constrFields(redeemer);
+                            byte[] input = Builtins.unBData(Builtins.headList(fields));
+                            byte[] expected = Builtins.unBData(Builtins.headList(Builtins.tailList(fields)));
+                            byte[] hex = ByteStringLib.toHex(input);
+                            return Builtins.equalsByteString(hex, expected);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.constr(0,
+                    PlutusData.bytes(new byte[]{(byte) 0xDE, (byte) 0xAD}),
+                    PlutusData.bytes("dead".getBytes()));
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(redeemer)));
+            assertTrue(result.isSuccess(), "toHex([0xDE,0xAD]) should produce 'dead'. Got: " + result);
+        }
+
+        @Test
+        void toHexZeroPadding() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            var fields = Builtins.constrFields(redeemer);
+                            byte[] input = Builtins.unBData(Builtins.headList(fields));
+                            byte[] expected = Builtins.unBData(Builtins.headList(Builtins.tailList(fields)));
+                            byte[] hex = ByteStringLib.toHex(input);
+                            return Builtins.equalsByteString(hex, expected);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.constr(0,
+                    PlutusData.bytes(new byte[]{0x00, (byte) 0xFF}),
+                    PlutusData.bytes("00ff".getBytes()));
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(redeemer)));
+            assertTrue(result.isSuccess(), "toHex([0x00,0xFF]) should produce '00ff'. Got: " + result);
+        }
+
+        @Test
+        void toHexEmptyInput() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] hex = ByteStringLib.toHex(Builtins.emptyByteString());
+                            return Builtins.lengthOfByteString(hex) == 0;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "toHex([]) should produce empty. Got: " + result);
+        }
+
+        @Test
+        void intToDecimalStringZero() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] result = ByteStringLib.intToDecimalString(BigInteger.ZERO);
+                            byte[] expected = Builtins.unBData(redeemer);
+                            return Builtins.equalsByteString(result, expected);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.bytes("0".getBytes());
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(redeemer)));
+            assertTrue(result.isSuccess(), "intToDecimalString(0) should produce '0'. Got: " + result);
+        }
+
+        @Test
+        void intToDecimalString42() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            var fields = Builtins.constrFields(redeemer);
+                            BigInteger n = Builtins.unIData(Builtins.headList(fields));
+                            byte[] expected = Builtins.unBData(Builtins.headList(Builtins.tailList(fields)));
+                            byte[] result = ByteStringLib.intToDecimalString(n);
+                            return Builtins.equalsByteString(result, expected);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.constr(0,
+                    PlutusData.integer(42),
+                    PlutusData.bytes("42".getBytes()));
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(redeemer)));
+            assertTrue(result.isSuccess(), "intToDecimalString(42) should produce '42'. Got: " + result);
+        }
+
+        @Test
+        void intToDecimalString12345() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            var fields = Builtins.constrFields(redeemer);
+                            BigInteger n = Builtins.unIData(Builtins.headList(fields));
+                            byte[] expected = Builtins.unBData(Builtins.headList(Builtins.tailList(fields)));
+                            byte[] result = ByteStringLib.intToDecimalString(n);
+                            return Builtins.equalsByteString(result, expected);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.constr(0,
+                    PlutusData.integer(12345),
+                    PlutusData.bytes("12345".getBytes()));
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(redeemer)));
+            assertTrue(result.isSuccess(), "intToDecimalString(12345) should produce '12345'. Got: " + result);
         }
     }
 }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/SwitchExhaustivenessTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/SwitchExhaustivenessTest.java
@@ -93,8 +93,8 @@ class SwitchExhaustivenessTest {
     }
 
     @Test
-    void testDefaultBranchProducesError() {
-        // Switch with default branch — should produce compiler error since default is not supported
+    void testDefaultBranchCompilesAndEvaluates() {
+        // Switch with default branch — should compile, default covers unmatched variants
         var source = """
             import java.math.BigInteger;
 
@@ -115,14 +115,28 @@ class SwitchExhaustivenessTest {
                 }
             }
             """;
-        var ex = assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
-        assertTrue(ex.getMessage().contains("default") && ex.getMessage().contains("not supported"),
-                "Should report default branch not supported. Got: " + ex.getMessage());
+        var result = new JulcCompiler().compile(source);
+        assertFalse(result.hasErrors(), "Default branch should compile. Got: " + result.diagnostics());
+
+        // Evaluate with Mint(10) → amt > 0 → true (explicit case)
+        var mintRedeemer = PlutusData.constr(0, PlutusData.integer(10));
+        var mintResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(mintRedeemer)));
+        assertTrue(mintResult.isSuccess(), "Mint(10) should pass via explicit case. Got: " + mintResult);
+
+        // Evaluate with Burn(5) → default → true (default branch)
+        var burnRedeemer = PlutusData.constr(1, PlutusData.integer(5));
+        var burnResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(burnRedeemer)));
+        assertTrue(burnResult.isSuccess(), "Burn(5) should pass via default branch. Got: " + burnResult);
+
+        // Evaluate with Transfer(3) → default → true (default branch)
+        var transferRedeemer = PlutusData.constr(2, PlutusData.integer(3));
+        var transferResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(transferRedeemer)));
+        assertTrue(transferResult.isSuccess(), "Transfer(3) should pass via default branch. Got: " + transferResult);
     }
 
     @Test
-    void testDefaultBranchWithAllCasesStillErrors() {
-        // Even with all cases + default, default branch should produce error
+    void testDefaultBranchWithAllCasesCompiles() {
+        // All cases + default — default is redundant but should still compile
         var source = """
             import java.math.BigInteger;
 
@@ -143,9 +157,18 @@ class SwitchExhaustivenessTest {
                 }
             }
             """;
-        var ex = assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
-        assertTrue(ex.getMessage().contains("default") && ex.getMessage().contains("not supported"),
-                "Should report default branch not supported even with all cases. Got: " + ex.getMessage());
+        var result = new JulcCompiler().compile(source);
+        assertFalse(result.hasErrors(), "All cases + default should compile. Got: " + result.diagnostics());
+
+        // Evaluate with Mint(10) → amt > 0 → true (explicit case takes priority)
+        var mintRedeemer = PlutusData.constr(0, PlutusData.integer(10));
+        var mintResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(mintRedeemer)));
+        assertTrue(mintResult.isSuccess(), "Mint(10) should pass. Got: " + mintResult);
+
+        // Evaluate with Burn(5) → amt > 0 → true (explicit case)
+        var burnRedeemer = PlutusData.constr(1, PlutusData.integer(5));
+        var burnResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(burnRedeemer)));
+        assertTrue(burnResult.isSuccess(), "Burn(5) should pass. Got: " + burnResult);
     }
 
     @Test

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/TypeMethodsTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/TypeMethodsTest.java
@@ -1573,4 +1573,131 @@ class TypeMethodsTest {
             assertTrue(result.isSuccess(), "unBData().value() == unBData().value() should compare ByteStrings. Got: " + result);
         }
     }
+
+    @Nested
+    class ChainedHashAccessor {
+        private PlutusData spendingCtx(PlutusData datum) {
+            var optDatum = PlutusData.constr(0, datum);
+            var txOutRef = PlutusData.constr(0, PlutusData.bytes(new byte[32]), PlutusData.integer(0));
+            var scriptInfo = PlutusData.constr(1, txOutRef, optDatum);
+            return buildScriptContext(buildTxInfo(new PlutusData[0], alwaysInterval()),
+                    PlutusData.integer(0), scriptInfo);
+        }
+
+        @Test
+        void sealedInterfaceHashDotHash() {
+            var source = """
+                    import java.math.BigInteger;
+
+                    @Validator
+                    class TestValidator {
+                        sealed interface Cred permits ScriptCred, PubKeyCred {}
+                        record ScriptCred(byte[] hash) implements Cred {}
+                        record PubKeyCred(byte[] hash) implements Cred {}
+
+                        record MyDatum(Cred cred, byte[] expected) {}
+
+                        @Entrypoint
+                        static boolean validate(MyDatum datum, PlutusData redeemer, ScriptContext ctx) {
+                            byte[] expected = datum.expected();
+                            return switch (datum.cred()) {
+                                case ScriptCred sc -> sc.hash().hash() == expected;
+                                case PubKeyCred pk -> false;
+                            };
+                        }
+                    }
+                    """;
+            var compiler = new JulcCompiler();
+            var program = compiler.compile(source).program();
+
+            // ScriptCred = Constr(0, [BData(hash)])
+            var cred = PlutusData.constr(0, PlutusData.bytes(new byte[]{1, 2, 3}));
+            // MyDatum = Constr(0, [cred, BData(expected)])
+            var datum = PlutusData.constr(0, cred, PlutusData.bytes(new byte[]{1, 2, 3}));
+            var ctx = spendingCtx(datum);
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "sc.hash().hash() should work without double UnBData. Got: " + result);
+        }
+
+        @Test
+        void helperMethodWithHashDotHash() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+
+                    @Validator
+                    class TestValidator {
+                        sealed interface Cred permits ScriptCred, PubKeyCred {}
+                        record ScriptCred(byte[] hash) implements Cred {}
+                        record PubKeyCred(byte[] hash) implements Cred {}
+
+                        static boolean isMatch(Cred cred, byte[] expected) {
+                            return switch (cred) {
+                                case ScriptCred sc -> sc.hash().hash() == expected;
+                                case PubKeyCred pk -> false;
+                            };
+                        }
+
+                        record MyDatum(Cred cred, byte[] expected) {}
+
+                        @Entrypoint
+                        static boolean validate(MyDatum datum, PlutusData redeemer, ScriptContext ctx) {
+                            return isMatch(datum.cred(), datum.expected());
+                        }
+                    }
+                    """;
+            var compiler = new JulcCompiler();
+            var program = compiler.compile(source).program();
+
+            var cred = PlutusData.constr(0, PlutusData.bytes(new byte[]{1, 2, 3}));
+            var datum = PlutusData.constr(0, cred, PlutusData.bytes(new byte[]{1, 2, 3}));
+            var ctx = spendingCtx(datum);
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "Helper method with sc.hash().hash() should work. Got: " + result);
+        }
+
+        @Test
+        void helperMethodInHofLambda() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+
+                    @Validator
+                    class TestValidator {
+                        sealed interface Cred permits ScriptCred, PubKeyCred {}
+                        record ScriptCred(byte[] hash) implements Cred {}
+                        record PubKeyCred(byte[] hash) implements Cred {}
+
+                        static boolean isMatch(Cred cred, byte[] expected) {
+                            return switch (cred) {
+                                case ScriptCred sc -> sc.hash().hash() == expected;
+                                case PubKeyCred pk -> false;
+                            };
+                        }
+
+                        record Item(Cred cred) {}
+                        record MyDatum(JulcList<Item> items, byte[] expected) {}
+
+                        @Entrypoint
+                        static boolean validate(MyDatum datum, PlutusData redeemer, ScriptContext ctx) {
+                            byte[] expected = datum.expected();
+                            return datum.items().any(item -> isMatch(item.cred(), expected));
+                        }
+                    }
+                    """;
+            var compiler = new JulcCompiler();
+            var program = compiler.compile(source).program();
+
+            // Item = Constr(0, [cred])  where cred = Constr(0, [BData(hash)])
+            var cred = PlutusData.constr(0, PlutusData.bytes(new byte[]{1, 2, 3}));
+            var item = PlutusData.constr(0, cred);
+            // MyDatum = Constr(0, [list_of_items, BData(expected)])
+            var datum = PlutusData.constr(0,
+                    PlutusData.list(item),
+                    PlutusData.bytes(new byte[]{1, 2, 3}));
+            var ctx = spendingCtx(datum);
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "Helper in HOF lambda with sc.hash().hash() should work. Got: " + result);
+        }
+    }
 }

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/AssetEntry.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/AssetEntry.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.julc.core.types;
+
+import java.math.BigInteger;
+
+/**
+ * A typed triple representing a single asset entry from a flattened Value.
+ * <p>
+ * On-chain: compiled to {@code ConstrData(0, [BData(policyId), BData(tokenName), IData(amount)])}.
+ * Field access auto-unwraps: {@code entry.policyId()} returns {@code byte[]} directly.
+ * <p>
+ * Returned by {@code ValuesLib.flatten()} for type-safe iteration over Value entries.
+ */
+public record AssetEntry(byte[] policyId, byte[] tokenName, BigInteger amount) {}

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/AddressLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/AddressLib.java
@@ -27,7 +27,7 @@ public class AddressLib {
     public static boolean isScriptAddress(Address address) {
         return switch (address.credential()) {
             case Credential.ScriptCredential sc -> true;
-            default -> false;
+            case Credential.PubKeyCredential pk -> false;
         };
     }
 
@@ -35,7 +35,7 @@ public class AddressLib {
     public static boolean isPubKeyAddress(Address address) {
         return switch (address.credential()) {
             case Credential.PubKeyCredential pk -> true;
-            default -> false;
+            case Credential.ScriptCredential sc -> false;
         };
     }
 

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLib.java
@@ -97,4 +97,55 @@ public class ByteStringLib {
     public static byte[] serialiseData(PlutusData d) {
         return Builtins.serialiseData(d);
     }
+
+    // --- Hex encoding ---
+
+    /** Map a nibble (0-15) to its lowercase ASCII hex char ('0'-'9', 'a'-'f'). */
+    public static long hexNibble(long n) {
+        if (n < 10) return 48 + n;   // '0' + n
+        return 87 + n;               // 'a' + (n - 10) = 87 + n
+    }
+
+    /**
+     * Convert a bytestring to its lowercase hex representation.
+     * Each byte becomes two hex characters (e.g. 0xDE → "de").
+     */
+    public static byte[] toHex(byte[] bs) {
+        long len = Builtins.lengthOfByteString(bs);
+        if (len == 0) return Builtins.emptyByteString();
+        return toHexStep(bs, len - 1, Builtins.emptyByteString());
+    }
+
+    /** Recursive helper: process bytes from index down to 0, prepending hex chars. */
+    public static byte[] toHexStep(byte[] bs, long idx, byte[] acc) {
+        long b = Builtins.indexByteString(bs, idx);
+        long hi = b / 16;
+        long lo = b % 16;
+        byte[] updated = Builtins.consByteString(hexNibble(hi),
+                Builtins.consByteString(hexNibble(lo), acc));
+        if (idx == 0) return updated;
+        return toHexStep(bs, idx - 1, updated);
+    }
+
+    // --- Integer to decimal string ---
+
+    /**
+     * Convert a non-negative integer to its decimal string representation as UTF-8 bytes.
+     * E.g. 42 → "42" (as byte[]{52, 50}).
+     */
+    public static byte[] intToDecimalString(BigInteger n) {
+        if (n.equals(BigInteger.ZERO)) {
+            return Builtins.consByteString(48, Builtins.emptyByteString()); // "0"
+        }
+        return intToDecimalStep(n, Builtins.emptyByteString());
+    }
+
+    /** Recursive helper: divmod by 10, prepend digit char. */
+    public static byte[] intToDecimalStep(BigInteger n, byte[] acc) {
+        if (n.equals(BigInteger.ZERO)) return acc;
+        BigInteger div = n.divide(BigInteger.TEN);
+        long digit = n.remainder(BigInteger.TEN).longValue();
+        byte[] updated = Builtins.consByteString(48 + digit, acc);
+        return intToDecimalStep(div, updated);
+    }
 }

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ContextsLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ContextsLib.java
@@ -135,7 +135,11 @@ public class ContextsLib {
                     yield Builtins.constrData(0, Builtins.mkNilData());
                 }
             }
-            default -> Builtins.constrData(0, Builtins.mkNilData());
+            case ScriptInfo.MintingScript ms -> Builtins.constrData(0, Builtins.mkNilData());
+            case ScriptInfo.RewardingScript rs -> Builtins.constrData(0, Builtins.mkNilData());
+            case ScriptInfo.CertifyingScript cs -> Builtins.constrData(0, Builtins.mkNilData());
+            case ScriptInfo.VotingScript vs -> Builtins.constrData(0, Builtins.mkNilData());
+            case ScriptInfo.ProposingScript ps -> Builtins.constrData(0, Builtins.mkNilData());
         };
     }
 
@@ -161,7 +165,11 @@ public class ContextsLib {
                 }
                 yield result;
             }
-            default -> Builtins.constrData(1, Builtins.mkNilData());
+            case ScriptInfo.MintingScript ms -> Builtins.constrData(1, Builtins.mkNilData());
+            case ScriptInfo.RewardingScript rs -> Builtins.constrData(1, Builtins.mkNilData());
+            case ScriptInfo.CertifyingScript cs -> Builtins.constrData(1, Builtins.mkNilData());
+            case ScriptInfo.VotingScript vs -> Builtins.constrData(1, Builtins.mkNilData());
+            case ScriptInfo.ProposingScript ps -> Builtins.constrData(1, Builtins.mkNilData());
         };
     }
 
@@ -231,27 +239,32 @@ public class ContextsLib {
         return result;
     }
 
+    /** Extracts the script credential hash from the own input's address. */
+    public static PlutusData.BytesData ownInputScriptHash(ScriptContext ctx) {
+        var ownInputOpt = findOwnInput(ctx);
+        var optFields = Builtins.constrFields(ownInputOpt);
+        var ownInput = Builtins.headList(optFields);
+        var ownInFields = Builtins.constrFields(ownInput);
+        var ownTxOut = Builtins.headList(Builtins.tailList(ownInFields));
+        var ownTxOutFields = Builtins.constrFields(ownTxOut);
+        var ownAddress = Builtins.headList(ownTxOutFields);
+        var addrFields = Builtins.constrFields(ownAddress);
+        var credential = Builtins.headList(addrFields);
+        var credFields = Builtins.constrFields(credential);
+        return (PlutusData.BytesData) Builtins.headList(credFields);
+    }
+
     /** Extracts the own script hash from the ScriptContext's ScriptInfo.
-     *  Minting (tag 0) -> policyId. Spending (tag 1) -> script credential hash. */
+     *  Minting (tag 0) -> policyId. Others -> script credential hash from own input. */
     public static PlutusData.BytesData ownHash(ScriptContext ctx) {
         return switch (ctx.scriptInfo()) {
             case ScriptInfo.MintingScript ms ->
                     (PlutusData.BytesData)(Object) ms.policyId();
-            default -> {
-                // For spending and other script types, find the own input and extract
-                // the script credential hash from its address
-                var ownInputOpt = findOwnInput(ctx);
-                var optFields = Builtins.constrFields(ownInputOpt);
-                var ownInput = Builtins.headList(optFields);
-                var ownInFields = Builtins.constrFields(ownInput);
-                var ownTxOut = Builtins.headList(Builtins.tailList(ownInFields));
-                var ownTxOutFields = Builtins.constrFields(ownTxOut);
-                var ownAddress = Builtins.headList(ownTxOutFields);
-                var addrFields = Builtins.constrFields(ownAddress);
-                var credential = Builtins.headList(addrFields);
-                var credFields = Builtins.constrFields(credential);
-                yield (PlutusData.BytesData) Builtins.headList(credFields);
-            }
+            case ScriptInfo.SpendingScript ss -> ownInputScriptHash(ctx);
+            case ScriptInfo.RewardingScript rs -> ownInputScriptHash(ctx);
+            case ScriptInfo.CertifyingScript cs -> ownInputScriptHash(ctx);
+            case ScriptInfo.VotingScript vs -> ownInputScriptHash(ctx);
+            case ScriptInfo.ProposingScript ps -> ownInputScriptHash(ctx);
         };
     }
 

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/OutputLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/OutputLib.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.julc.core.types.JulcList;
 import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
 import com.bloxbean.cardano.julc.ledger.Address;
 import com.bloxbean.cardano.julc.ledger.OutputDatum;
+import com.bloxbean.cardano.julc.ledger.TxInInfo;
 import com.bloxbean.cardano.julc.ledger.TxOut;
 import com.bloxbean.cardano.julc.ledger.Value;
 import com.bloxbean.cardano.julc.stdlib.Builtins;
@@ -134,7 +135,11 @@ public class OutputLib {
     public static PlutusData getInlineDatum(TxOut txOut) {
         return switch (txOut.datum()) {
             case OutputDatum.OutputDatumInline i -> i.datum();
-            default -> {
+            case OutputDatum.OutputDatumHash h -> {
+                Builtins.error();
+                yield (PlutusData)(Object) txOut.datum();
+            }
+            case OutputDatum.NoOutputDatum n -> {
                 Builtins.error();
                 yield (PlutusData)(Object) txOut.datum();
             }
@@ -155,10 +160,60 @@ public class OutputLib {
                     yield result;
                 }
             }
-            default -> {
+            case OutputDatum.NoOutputDatum n -> {
                 Builtins.error();
                 yield (PlutusData)(Object) txOut.datum();
             }
         };
+    }
+
+    // --- Multi-validator helpers: find outputs/inputs at script address with token ---
+
+    /**
+     * Find the first output at a script address (identified by scriptHash) containing
+     * the specified token with inline datum. Aborts if not found.
+     */
+    public static TxOut findOutputWithToken(JulcList<TxOut> outputs, byte[] scriptHash,
+                                            byte[] policyId, byte[] tokenName) {
+        TxOut result = outputs.head(); // placeholder — will be overwritten or abort
+        boolean found = false;
+        for (TxOut out : outputs) {
+            if (!found) {
+                byte[] sh = AddressLib.credentialHash(out.address());
+                if (Builtins.equalsByteString(sh, scriptHash)
+                        && ValuesLib.assetOf(out.value(), policyId, tokenName).compareTo(BigInteger.ZERO) > 0) {
+                    result = out;
+                    found = true;
+                }
+            }
+        }
+        if (!found) {
+            Builtins.error();
+        }
+        return result;
+    }
+
+    /**
+     * Find the first input at a script address containing the specified token with inline datum.
+     * Aborts if not found.
+     */
+    public static TxInInfo findInputWithToken(JulcList<TxInInfo> inputs, byte[] scriptHash,
+                                               byte[] policyId, byte[] tokenName) {
+        TxInInfo result = inputs.head(); // placeholder — will be overwritten or abort
+        boolean found = false;
+        for (TxInInfo inp : inputs) {
+            if (!found) {
+                byte[] sh = AddressLib.credentialHash(inp.resolved().address());
+                if (Builtins.equalsByteString(sh, scriptHash)
+                        && ValuesLib.assetOf(inp.resolved().value(), policyId, tokenName).compareTo(BigInteger.ZERO) > 0) {
+                    result = inp;
+                    found = true;
+                }
+            }
+        }
+        if (!found) {
+            Builtins.error();
+        }
+        return result;
     }
 }

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLib.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.julc.stdlib.lib;
 
 import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.types.AssetEntry;
+import com.bloxbean.cardano.julc.core.types.JulcList;
 import com.bloxbean.cardano.julc.core.types.JulcMap;
 import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
 import com.bloxbean.cardano.julc.ledger.Value;
@@ -235,19 +237,36 @@ public class ValuesLib {
         return Builtins.mapData(result);
     }
 
-    /** Flattens a Value into a list of (policy, token, amount) triples as ConstrData(0, [p, t, amt]). */
+    /**
+     * Flattens a Value into a list of (policy, token, amount) triples as ConstrData(0, [p, t, amt]).
+     * <p>
+     * Each element has the same layout as {@link AssetEntry}: {@code ConstrData(0, [BData, BData, IData])}.
+     * Cast the result for typed field access:
+     * <pre>{@code
+     * for (AssetEntry entry : (JulcList<AssetEntry>)(Object) ValuesLib.flatten(txInfo.mint())) {
+     *     byte[] policy = entry.policyId();
+     *     byte[] name = entry.tokenName();
+     *     BigInteger qty = entry.amount();
+     * }
+     * }</pre>
+     *
+     * Note: Split into separate step methods to avoid nested while loops
+     * (compiler limitation — while-loop calling a function with a while-loop).
+     */
     public static PlutusData.ListData flatten(Value value) {
-        PlutusData.ListData result = Builtins.mkNilData();
-        var outerPairs = Builtins.unMapData(value);
-        PlutusData current = outerPairs;
-        while (!Builtins.nullList(current)) {
-            var outerPair = Builtins.headList(current);
-            var policyData = Builtins.fstPair(outerPair);
-            PlutusData.MapData innerMap = (PlutusData.MapData) Builtins.sndPair(outerPair);
-            result = flattenPolicy(policyData, innerMap, result);
-            current = Builtins.tailList(current);
+        return flattenStep(Builtins.unMapData(value), Builtins.mkNilData());
+    }
+
+    /** Process one policy from the outer map, then recurse on the rest. */
+    public static PlutusData.ListData flattenStep(PlutusData outerPairs, PlutusData.ListData acc) {
+        if (Builtins.nullList(outerPairs)) {
+            return ListsLib.reverse(acc);
         }
-        return ListsLib.reverse(result);
+        var outerPair = Builtins.headList(outerPairs);
+        var policyData = Builtins.fstPair(outerPair);
+        PlutusData.MapData innerMap = (PlutusData.MapData) Builtins.sndPair(outerPair);
+        PlutusData.ListData updated = flattenPolicy(policyData, innerMap, acc);
+        return flattenStep(Builtins.tailList(outerPairs), updated);
     }
 
     /** Flatten a single policy's token entries into the accumulator list. */
@@ -363,5 +382,93 @@ public class ValuesLib {
     /** Subtracts value b from value a: add(a, negate(b)). */
     public static Value subtract(Value a, Value b) {
         return add(a, negate(b));
+    }
+
+    // =========================================================================
+    // Mint helpers — common patterns for validating minting/burning transactions
+    // =========================================================================
+
+    /**
+     * Count tokens with a specific quantity under a specific policy in a Value/mint.
+     * E.g., count how many tokens were minted with qty=1 under a given policy.
+     */
+    public static BigInteger countTokensWithQty(Value mint, byte[] policyId, BigInteger expectedQty) {
+        return _countTokensWithQty(mint, Builtins.bData(policyId), expectedQty);
+    }
+
+    /** Internal implementation: count tokens matching expectedQty under a policy. */
+    public static BigInteger _countTokensWithQty(Value mint, PlutusData policyData, BigInteger expectedQty) {
+        var outerPairs = Builtins.unMapData(mint);
+        BigInteger count = BigInteger.ZERO;
+        PlutusData current = outerPairs;
+        while (!Builtins.nullList(current)) {
+            var outerPair = Builtins.headList(current);
+            if (Builtins.equalsData(Builtins.fstPair(outerPair), policyData)) {
+                count = count.add(_countInnerTokensWithQty(
+                        (PlutusData.MapData) Builtins.sndPair(outerPair), expectedQty));
+                current = Builtins.mkNilPairData();
+            } else {
+                current = Builtins.tailList(current);
+            }
+        }
+        return count;
+    }
+
+    /** Count tokens matching expectedQty in an inner token map (single policy). */
+    public static BigInteger _countInnerTokensWithQty(PlutusData.MapData innerPairs, BigInteger expectedQty) {
+        BigInteger count = BigInteger.ZERO;
+        PlutusData current = Builtins.unMapData(innerPairs);
+        while (!Builtins.nullList(current)) {
+            var pair = Builtins.headList(current);
+            var qty = Builtins.unIData(Builtins.sndPair(pair));
+            if (qty.equals(expectedQty)) {
+                count = count.add(BigInteger.ONE);
+            }
+            current = Builtins.tailList(current);
+        }
+        return count;
+    }
+
+    /**
+     * Find the first token name with a specific quantity under a specific policy.
+     * Returns empty bytestring if not found.
+     */
+    public static byte[] findTokenName(Value mint, byte[] policyId, BigInteger expectedQty) {
+        return _findTokenName(mint, Builtins.bData(policyId), expectedQty);
+    }
+
+    /** Internal implementation: find first token name matching expectedQty under a policy. */
+    public static byte[] _findTokenName(Value mint, PlutusData policyData, BigInteger expectedQty) {
+        var outerPairs = Builtins.unMapData(mint);
+        byte[] result = Builtins.emptyByteString();
+        PlutusData current = outerPairs;
+        while (!Builtins.nullList(current)) {
+            var outerPair = Builtins.headList(current);
+            if (Builtins.equalsData(Builtins.fstPair(outerPair), policyData)) {
+                result = _findInnerTokenName(
+                        (PlutusData.MapData) Builtins.sndPair(outerPair), expectedQty);
+                current = Builtins.mkNilPairData();
+            } else {
+                current = Builtins.tailList(current);
+            }
+        }
+        return result;
+    }
+
+    /** Find first token name matching expectedQty in an inner token map. Returns empty bytestring if not found. */
+    public static byte[] _findInnerTokenName(PlutusData.MapData innerPairs, BigInteger expectedQty) {
+        byte[] result = Builtins.emptyByteString();
+        boolean found = false;
+        PlutusData current = Builtins.unMapData(innerPairs);
+        while (!Builtins.nullList(current) && !found) {
+            var pair = Builtins.headList(current);
+            var qty = Builtins.unIData(Builtins.sndPair(pair));
+            if (qty.equals(expectedQty)) {
+                result = (byte[]) (Object) Builtins.unBData(Builtins.fstPair(pair));
+                found = true;
+            }
+            current = Builtins.tailList(current);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
**Compiler:**
  - Implement switch default branch compilation: default body now covers unmatched SumType variants instead of producing a compiler error
  - Add CastExpr type resolution in resolveExpressionType for  (RecordType)(Object) patterns enabling field access after cast
  - Add identity constructor for ledger hash types (ScriptHash, PubKeyHash etc.) that resolve to ByteStringType
  - Register AssetEntry as a 3-field RecordType in TypeResolver

  **Stdlib:**
  - Add ByteStringLib.toHex() and intToDecimalString() for on-chain string formatting
  - Add ValuesLib mint helpers: countTokensWithQty, findTokenName with  inner-map decomposition to avoid nested while loops
  - Refactor ValuesLib.flatten() from while loop to recursive flattenStep() to avoid nested loop limitation
  - Add OutputLib.findOutputWithToken/findInputWithToken for multi-validator patterns
  - Add ContextsLib.ownInputScriptHash() helper, refactor ownHash() to use explicit cases
  - Replace default branches with explicit cases in AddressLib, ContextsLib, OutputLib to match new compiler support