### PR TITLE
 Add byte constant support, new stdlib methods, and fix Value ADA-first ordering   

### DIFF
--- a/docs/advanced-guide.md
+++ b/docs/advanced-guide.md
@@ -26,6 +26,7 @@ stdlib usage) as covered in the getting-started guide.
 15. [Tuple2/Tuple3 Generic Support](#15-tuple2tuple3-generic-support)
 16. [Nested Loops](#16-nested-loops)
 17. [Higher-Order Functions (HOFs)](#17-higher-order-functions-hofs)
+18. [Byte Array Constants](#18-byte-array-constants)
 
 ---
 
@@ -1508,3 +1509,43 @@ Variable capture is supported. Block body lambdas and chaining (`list.filter(...
 Note: `map()` wraps lambda results to Data — the returned list has `DataType` elements. Use `Builtins.unIData()` etc. when extracting values from mapped results.
 
 For the full HOF reference, see [Standard Library Guide — HOFs](stdlib-guide.md).
+
+---
+
+## 18. Byte Array Constants
+
+JuLC supports `byte[]` constants in on-chain code using two syntaxes:
+
+### String.getBytes()
+
+```java
+static final byte[] FACTORY_MARKER = "FACTORY_MARKER".getBytes();
+static final byte[] LOTTERY_TOKEN = "LOTTERY_TOKEN".getBytes();
+```
+
+Compiles to `EncodeUtf8("FACTORY_MARKER")` — produces the UTF-8 encoded bytes at UPLC level.
+
+### Literal byte[] Initializers
+
+```java
+static final byte[] TOKEN_PREFIX = new byte[]{0x46, 0x41, 0x43, 0x54};
+```
+
+Compiles to a `ByteString` constant. All array elements must be integer literals (no variables or expressions).
+
+### Usage in Validators
+
+```java
+@MintingValidator
+class FactoryPolicy {
+    static final byte[] FACTORY_MARKER = "FACTORY_MARKER".getBytes();
+
+    @Entrypoint
+    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+        TxInfo txInfo = ctx.txInfo();
+        byte[] ownPolicy = (byte[])(Object) ContextsLib.ownHash(ctx);
+        BigInteger qty = ValuesLib.assetOf(txInfo.mint(), ownPolicy, FACTORY_MARKER);
+        return qty.equals(BigInteger.ONE);
+    }
+}
+```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -489,6 +489,7 @@ Import from `com.bloxbean.cardano.julc.stdlib.lib.*` in validators. See [Standar
 | `singleton(policy, token, amount)` | BS, BS, Integer | Create single-token value |
 | `negate(value)` | Value | Negate all amounts |
 | `flatten(value)` | Value | Flatten to list of triples |
+| `flattenTyped(value)` | Value | Flatten to typed `JulcList<AssetEntry>` |
 | `add(a, b)` | Value, Value | Add two values |
 | `subtract(a, b)` | Value, Value | Subtract values |
 | `countTokensWithQty(mint, policy, qty)` | Value, BS, Integer | Count tokens with exact quantity under policy |
@@ -584,6 +585,7 @@ Note: `sha2_256`, `sha3_256`, `blake2b_256`, `blake2b_224`, `keccak_256`, and `v
 | `hexNibble(n)` | Integer | Convert nibble (0-15) to hex ASCII code |
 | `toHex(bs)` | BS | Convert bytestring to hex-encoded bytestring |
 | `intToDecimalString(n)` | Integer | Convert integer to decimal digit bytestring |
+| `utf8ToInteger(bs)` | BS | Parse UTF-8 decimal string to integer |
 
 ### BitwiseLib
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -879,13 +879,13 @@ when your validator references them.
 |---|---|
 | `ContextsLib` | ScriptContext/TxInfo field accessors, `signedBy`, `findOwnInput`, `getContinuingOutputs`, `findDatum`, `ownHash`, `trace` |
 | `ListsLib` | `empty`, `prepend`, `length`, `isEmpty`, `head`, `tail`, `reverse`, `concat`, `nth`, `take`, `drop`, `contains`, `containsInt`, `containsBytes`, `hasDuplicateInts`, `hasDuplicateBytes` + PIR HOFs (`any`, `all`, `find`, `foldl`, `map`, `filter`, `zip`) |
-| `ValuesLib` | `lovelaceOf`, `assetOf`, `containsPolicy`, `geq`, `geqMultiAsset`, `leq`, `eq`, `isZero`, `singleton`, `negate`, `flatten`, `add`, `subtract`, `countTokensWithQty`, `findTokenName` |
+| `ValuesLib` | `lovelaceOf`, `assetOf`, `containsPolicy`, `geq`, `geqMultiAsset`, `leq`, `eq`, `isZero`, `singleton`, `negate`, `flatten`, `flattenTyped`, `add`, `subtract`, `countTokensWithQty`, `findTokenName` |
 | `MapLib` | `lookup`, `member`, `insert`, `delete`, `keys`, `values`, `toList`, `fromList`, `size` |
 | `OutputLib` | `txOutAddress`, `txOutValue`, `txOutDatum`, `outputsAt`, `countOutputsAt`, `uniqueOutputAt`, `outputsWithToken`, `valueHasToken`, `lovelacePaidTo`, `paidAtLeast`, `getInlineDatum`, `resolveDatum`, `findOutputWithToken`, `findInputWithToken` |
 | `MathLib` | `abs`, `max`, `min`, `divMod`, `quotRem`, `pow`, `sign`, `expMod` |
 | `IntervalLib` | `contains`, `always`, `after`, `before`, `between`, `never`, `isEmpty`, `finiteUpperBound`, `finiteLowerBound` |
 | `CryptoLib` | `sha2_256`, `blake2b_256`, `sha3_256`, `blake2b_224`, `keccak_256`, `verifyEd25519Signature`, `verifyEcdsaSecp256k1`, `verifySchnorrSecp256k1`, `ripemd_160` (all hash functions also available via `Builtins.*`) |
-| `ByteStringLib` | `at`, `cons`, `slice`, `length`, `drop`, `take`, `append`, `empty`, `zeros`, `equals`, `lessThan`, `lessThanEquals`, `integerToByteString`, `byteStringToInteger`, `encodeUtf8`, `decodeUtf8`, `serialiseData`, `hexNibble`, `toHex`, `intToDecimalString` |
+| `ByteStringLib` | `at`, `cons`, `slice`, `length`, `drop`, `take`, `append`, `empty`, `zeros`, `equals`, `lessThan`, `lessThanEquals`, `integerToByteString`, `byteStringToInteger`, `encodeUtf8`, `decodeUtf8`, `serialiseData`, `hexNibble`, `toHex`, `intToDecimalString`, `utf8ToInteger` |
 | `BitwiseLib` | `andByteString`, `orByteString`, `xorByteString`, `complementByteString`, `readBit`, `writeBits`, `shiftByteString`, `rotateByteString`, `countSetBits`, `findFirstSetBit` |
 | `AddressLib` | `credentialHash`, `isScriptAddress`, `isPubKeyAddress`, `paymentCredential` |
 
@@ -1393,7 +1393,7 @@ following limitations apply:
   `PlutusData`, records, sealed interfaces, `List<T>`, `Map<K,V>`, `Optional<T>`,
   `Tuple2<A,B>`, `Tuple3<A,B,C>`.
 - **No float/double**: Floating-point types do not exist on-chain.
-- **No arrays** (except `byte[]`): Use `List<T>` for collections.
+- **No arrays** (except `byte[]`): Use `List<T>` for collections. `byte[]` literal arrays (`new byte[]{0x48, 0x45}`) and `"TOKEN".getBytes()` are supported as compile-time constants.
 - **No class inheritance**: Only records and sealed interfaces are supported for
   data types.
 

--- a/docs/stdlib-guide.md
+++ b/docs/stdlib-guide.md
@@ -112,6 +112,7 @@ The JuLC standard library provides 11 on-chain libraries in the `com.bloxbean.ca
 | `singleton(policy, token, amount)` | Create single-asset Value |
 | `negate(value)` | Negate all amounts |
 | `flatten(value)` | Flatten to list of (policy, token, amount) triples |
+| `flattenTyped(value)` | Flatten to typed `JulcList<AssetEntry>` with `.policyId()`, `.tokenName()`, `.amount()` |
 | `add(a, b)` | Add two Values |
 | `subtract(a, b)` | Subtract value b from value a |
 | `countTokensWithQty(mint, policy, qty)` | Count tokens with exact quantity under policy |
@@ -215,6 +216,7 @@ The JuLC standard library provides 11 on-chain libraries in the `com.bloxbean.ca
 | `hexNibble(n)` | Convert nibble (0-15) to hex ASCII code |
 | `toHex(bs)` | Convert bytestring to hex-encoded bytestring |
 | `intToDecimalString(n)` | Convert integer to decimal digit bytestring |
+| `utf8ToInteger(bs)` | Parse UTF-8 decimal string to integer (inverse of `intToDecimalString`) |
 
 ### BitwiseLib
 
@@ -562,6 +564,32 @@ class ValueArithmeticExample {
     }
 }
 ```
+
+### Typed Asset Iteration
+
+`ValuesLib.flattenTyped()` returns a `JulcList<AssetEntry>` for type-safe iteration over all assets in a Value. Each `AssetEntry` provides `.policyId()`, `.tokenName()`, and `.amount()` field access without manual destructuring.
+
+```java
+@SpendingValidator
+class TokenLeakCheck {
+    @Entrypoint
+    static boolean validate(PlutusData datum, PlutusData redeemer, ScriptContext ctx) {
+        TxOut output = ctx.txInfo().outputs().head();
+        long nonAdaCount = 0;
+        for (AssetEntry asset : ValuesLib.flattenTyped(output.value())) {
+            byte[] policy = asset.policyId();
+            byte[] name = asset.tokenName();
+            BigInteger amount = asset.amount();
+            if (Builtins.lengthOfByteString(policy) > 0) {
+                nonAdaCount = nonAdaCount + 1;
+            }
+        }
+        return nonAdaCount == 1;
+    }
+}
+```
+
+> **Tip:** Use `flattenTyped()` instead of `flatten()` whenever you need to inspect individual assets. The raw `flatten()` returns `PlutusData.ListData` requiring manual `Builtins.constrFields()` + `headList`/`tailList` destructuring.
 
 ---
 
@@ -1028,6 +1056,19 @@ class ByteStringCompareExample {
 }
 ```
 
+### UTF-8 Decimal Parsing
+
+`ByteStringLib.utf8ToInteger()` parses a UTF-8-encoded decimal string into an integer. This is the inverse of `intToDecimalString()`.
+
+```java
+// Parse "42" bytes → integer 42
+byte[] bs = "42".getBytes();
+BigInteger n = ByteStringLib.utf8ToInteger(bs);  // 42
+
+// Roundtrip property:
+// ByteStringLib.utf8ToInteger(ByteStringLib.intToDecimalString(n)) == n
+```
+
 ---
 
 ## BitwiseLib -- Bitwise Operations
@@ -1188,6 +1229,31 @@ BigInteger amount = ValuesLib.assetOf(value, policyId, tokenName);
 
 // The library internally wraps with bData for the UPLC comparison
 ```
+
+### ownHash + containsPolicy Pattern
+
+When checking if a minting policy's own token exists in a value (common in minting validators), use the `(byte[])(Object)` cast on `ContextsLib.ownHash()`:
+
+```java
+@MintingValidator
+class MyTokenPolicy {
+    @Entrypoint
+    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+        TxInfo txInfo = ctx.txInfo();
+        byte[] ownPolicy = (byte[])(Object) ContextsLib.ownHash(ctx);
+
+        // Check if minted value contains our policy
+        boolean hasMint = ValuesLib.containsPolicy(txInfo.mint(), ownPolicy);
+
+        // Or get a specific token amount
+        BigInteger qty = ValuesLib.assetOf(txInfo.mint(), ownPolicy, "TOKEN".getBytes());
+
+        return hasMint && qty.equals(BigInteger.ONE);
+    }
+}
+```
+
+The `(byte[])(Object)` cast is required because `ownHash()` returns a `ValidatorHash` (which is `ByteStringType` at UPLC level but a different Java type at source level). The cast is a no-op at UPLC level.
 
 ### MapLib.lookup Returns Optional Encoding
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -569,6 +569,15 @@ public class PirGenerator {
             }
             return inner;
         }
+        if (expr instanceof ArrayCreationExpr ace) {
+            // byte[] literal initializer → ByteString constant
+            var values = ace.getInitializer().get().getValues();
+            byte[] bytes = new byte[values.size()];
+            for (int i = 0; i < values.size(); i++) {
+                bytes[i] = (byte) values.get(i).asIntegerLiteralExpr().asNumber().intValue();
+            }
+            return new PirTerm.Const(Constant.byteString(bytes));
+        }
         if (expr instanceof AssignExpr ae && ae.getTarget() instanceof NameExpr ne) {
             var name = ne.getNameAsString();
             if ((forEachAccumulatorVar != null && name.equals(forEachAccumulatorVar))

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
@@ -273,6 +273,12 @@ public final class TypeMethodRegistry {
                 (scope, args, scopeType, argTypes) ->
                         PirHelpers.builtinApp2(DefaultFun.EqualsString, scope, args.get(0)),
                 scopeType -> new PirType.BoolType());
+
+        // getBytes: EncodeUtf8(s) — convert String to byte[]
+        reg.register("StringType", "getBytes",
+                (scope, args, scopeType, argTypes) ->
+                        new PirTerm.App(new PirTerm.Builtin(DefaultFun.EncodeUtf8), scope),
+                scopeType -> new PirType.ByteStringType());
     }
 
     // --- Data/Record/SumType .equals() (3 registrations, same handler) ---

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/validate/SubsetValidator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/validate/SubsetValidator.java
@@ -195,8 +195,19 @@ public class SubsetValidator extends VoidVisitorAdapter<Void> {
 
     @Override
     public void visit(ArrayCreationExpr n, Void arg) {
+        // Allow: new byte[]{0x46, 0x41, ...} — compiles to ByteString constant
+        if (n.getElementType().isPrimitiveType()
+                && n.getElementType().asPrimitiveType().getType() == PrimitiveType.Primitive.BYTE
+                && n.getInitializer().isPresent()) {
+            boolean allLiterals = n.getInitializer().get().getValues().stream()
+                    .allMatch(v -> v.isIntegerLiteralExpr());
+            if (allLiterals) {
+                super.visit(n, arg);
+                return;
+            }
+        }
         error(n, "arrays are not supported on-chain",
-                "Use List<T> instead of arrays");
+                "Use List<T> instead of arrays, or byte[] with literal initializers");
         super.visit(n, arg);
     }
 

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
@@ -6002,4 +6002,349 @@ class StdlibCompileEvalTest {
             assertTrue(result.isSuccess(), "findDatum should return empty for non-matching hash. Got: " + result);
         }
     }
+
+    // =========================================================================
+    // 22. StringGetBytes — String.getBytes() → EncodeUtf8
+    // =========================================================================
+
+    @Nested
+    class StringGetBytes {
+
+        @Test
+        void getBytesProducesCorrectBytes() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] name = "hello".getBytes();
+                            return Builtins.equalsByteString(name, Builtins.encodeUtf8("hello"));
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "\"hello\".getBytes() should equal encodeUtf8(\"hello\"). Got: " + result);
+        }
+
+        @Test
+        void emptyStringGetBytes() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] empty = "".getBytes();
+                            return Builtins.lengthOfByteString(empty) == 0;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "\"\".getBytes() should be empty. Got: " + result);
+        }
+
+        @Test
+        void staticFinalByteConstant() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        static final byte[] TOKEN_NAME = "TOKEN".getBytes();
+
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            return Builtins.lengthOfByteString(TOKEN_NAME) == 5;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "static final byte[] from .getBytes() should work. Got: " + result);
+        }
+    }
+
+    // =========================================================================
+    // 23. ByteArrayLiteral — new byte[]{0x48, 0x45} → ByteString constant
+    // =========================================================================
+
+    @Nested
+    class ByteArrayLiteral {
+
+        @Test
+        void byteArrayLiteralCompiles() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] marker = new byte[]{0x48, 0x45, 0x4C};
+                            return Builtins.lengthOfByteString(marker) == 3;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "new byte[]{0x48, 0x45, 0x4C} should compile and have length 3. Got: " + result);
+        }
+
+        @Test
+        void emptyByteArrayLiteral() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] empty = new byte[]{};
+                            return Builtins.lengthOfByteString(empty) == 0;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "new byte[]{} should compile to empty ByteString. Got: " + result);
+        }
+
+        @Test
+        void staticFinalByteArrayLiteral() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        static final byte[] MARKER = new byte[]{0x46, 0x41, 0x43};
+
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            return Builtins.equalsByteString(MARKER, new byte[]{0x46, 0x41, 0x43});
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "static final byte[] literal should equal inline literal. Got: " + result);
+        }
+
+        @Test
+        void byteArrayLiteralEqualsGetBytes() {
+            var source = """
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] fromLiteral = new byte[]{72, 69, 76};
+                            byte[] fromString = "HEL".getBytes();
+                            return Builtins.equalsByteString(fromLiteral, fromString);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "byte[] literal should equal String.getBytes() for same chars. Got: " + result);
+        }
+    }
+
+    // =========================================================================
+    // 24. Utf8ToIntegerEval — ByteStringLib.utf8ToInteger() compile + eval
+    // =========================================================================
+
+    @Nested
+    class Utf8ToIntegerEval {
+
+        @Test
+        void parsesSimpleNumber() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.lib.ByteStringLib;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            byte[] bs = "42".getBytes();
+                            BigInteger n = ByteStringLib.utf8ToInteger(bs);
+                            return n.equals(BigInteger.valueOf(42));
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "utf8ToInteger(\"42\".getBytes()) should equal 42. Got: " + result);
+        }
+
+        @Test
+        void roundtripWithIntToDecimalString() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.lib.ByteStringLib;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            BigInteger original = BigInteger.valueOf(12345);
+                            byte[] encoded = ByteStringLib.intToDecimalString(original);
+                            BigInteger decoded = ByteStringLib.utf8ToInteger(encoded);
+                            return decoded.equals(original);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "utf8ToInteger(intToDecimalString(12345)) should roundtrip. Got: " + result);
+        }
+    }
+
+    // =========================================================================
+    // 25. FlattenTypedEval — ValuesLib.flattenTyped() compile + eval
+    // =========================================================================
+
+    @Nested
+    class FlattenTypedEval {
+
+        @Test
+        void flattenTypedReturnsAssetEntries() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.core.types.AssetEntry;
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            JulcList<AssetEntry> entries = ValuesLib.flattenTyped(redeemer);
+                            boolean found = false;
+                            for (AssetEntry entry : entries) {
+                                if (entry.amount().compareTo(BigInteger.valueOf(100)) == 0) {
+                                    found = true;
+                                }
+                            }
+                            return found;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var value = PlutusData.map(
+                    new PlutusData.Pair(
+                            PlutusData.bytes(new byte[]{1, 2, 3}),
+                            PlutusData.map(
+                                    new PlutusData.Pair(PlutusData.bytes(new byte[]{4, 5, 6}), PlutusData.integer(100))
+                            )
+                    )
+            );
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(value)));
+            assertTrue(result.isSuccess(), "flattenTyped should return typed AssetEntry list. Got: " + result);
+        }
+    }
+
+    // =========================================================================
+    // 26. OwnHashContainsPolicyCompat — ownHash + containsPolicy cross-library
+    // =========================================================================
+
+    @Nested
+    class OwnHashContainsPolicyCompat {
+
+        @Test
+        void ownHashWithContainsPolicyMinting() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+                    import com.bloxbean.cardano.julc.ledger.*;
+
+                    @MintingPolicy
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                            TxInfo txInfo = ContextsLib.getTxInfo(ctx);
+                            byte[] ownPolicy = (byte[])(Object) ContextsLib.ownHash(ctx);
+                            Value mint = txInfo.mint();
+                            return ValuesLib.containsPolicy(mint, ownPolicy);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+
+            var policyId = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+            var mintValue = PlutusData.map(
+                    new PlutusData.Pair(PlutusData.bytes(policyId),
+                            PlutusData.map(new PlutusData.Pair(PlutusData.bytes("token".getBytes()), PlutusData.integer(1)))));
+
+            var txInfo = buildTxInfoWithMint(mintValue);
+            var mintingInfo = PlutusData.constr(0, PlutusData.bytes(policyId)); // MintingScript(policyId)
+            var ctx = PlutusData.constr(0, txInfo, PlutusData.integer(0), mintingInfo);
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "ownHash + containsPolicy should work for minting. Got: " + result);
+        }
+
+        @Test
+        void ownHashWithAssetOfMinting() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+                    import com.bloxbean.cardano.julc.ledger.*;
+
+                    @MintingPolicy
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                            TxInfo txInfo = ContextsLib.getTxInfo(ctx);
+                            byte[] ownPolicy = (byte[])(Object) ContextsLib.ownHash(ctx);
+                            Value mint = txInfo.mint();
+                            BigInteger qty = ValuesLib.assetOf(mint, ownPolicy, "token".getBytes());
+                            return qty.equals(BigInteger.ONE);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+
+            var policyId = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+            var mintValue = PlutusData.map(
+                    new PlutusData.Pair(PlutusData.bytes(policyId),
+                            PlutusData.map(new PlutusData.Pair(PlutusData.bytes("token".getBytes()), PlutusData.integer(1)))));
+
+            var txInfo = buildTxInfoWithMint(mintValue);
+            var mintingInfo = PlutusData.constr(0, PlutusData.bytes(policyId));
+            var ctx = PlutusData.constr(0, txInfo, PlutusData.integer(0), mintingInfo);
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+            assertTrue(result.isSuccess(), "ownHash + assetOf should work for minting. Got: " + result);
+        }
+
+        /** Build a TxInfo with custom mint at field 4. */
+        static PlutusData buildTxInfoWithMint(PlutusData mint) {
+            return PlutusData.constr(0,
+                    PlutusData.list(),                                     // 0: inputs
+                    PlutusData.list(),                                     // 1: referenceInputs
+                    PlutusData.list(),                                     // 2: outputs
+                    PlutusData.integer(2000000),                           // 3: fee
+                    mint,                                                  // 4: mint
+                    PlutusData.list(),                                     // 5: certificates
+                    PlutusData.map(),                                      // 6: withdrawals
+                    alwaysInterval(),                                      // 7: validRange
+                    PlutusData.list(),                                     // 8: signatories
+                    PlutusData.map(),                                      // 9: redeemers
+                    PlutusData.map(),                                      // 10: datums
+                    PlutusData.bytes(new byte[32]),                        // 11: txId
+                    PlutusData.map(),                                      // 12: votes
+                    PlutusData.list(),                                     // 13: proposalProcedures
+                    PlutusData.constr(1),                                  // 14: currentTreasuryAmount (None)
+                    PlutusData.constr(1)                                   // 15: treasuryDonation (None)
+            );
+        }
+    }
 }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
@@ -6347,4 +6347,36 @@ class StdlibCompileEvalTest {
             );
         }
     }
+
+    // =========================================================================
+    // 28. MergedValueLovelaceOf — ValuesLib.lovelaceOf() on multi-asset values
+    // =========================================================================
+
+    @Nested
+    class MergedValueLovelaceOf {
+
+        @Test
+        void lovelaceOfMultiAssetValue() {
+            // On-chain test: pass a multi-asset value (ADA first) and verify lovelaceOf extracts ADA amount
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @Validator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            long lovelace = ValuesLib.lovelaceOf(redeemer);
+                            return lovelace == 5000000;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            // Build a multi-asset value with ADA first (as the Cardano ledger serializes)
+            var policy = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28};
+            var value = multiAssetValue(5000000, policy, new byte[]{0x01}, 42);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(value)));
+            assertTrue(result.isSuccess(), "lovelaceOf on multi-asset value should extract 5000000. Got: " + result);
+        }
+    }
 }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/validate/SubsetValidatorTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/validate/SubsetValidatorTest.java
@@ -63,6 +63,10 @@ class SubsetValidatorTest {
     @Test void rejectsThis() { assertRejects("class X { void f() { Object x = this; } }", "this"); }
     @Test void rejectsSuper() { assertRejects("class X extends Y { void f() { super.f(); } }", "super"); }
     @Test void rejectsArrayCreation() { assertRejects("class X { void f() { int[] a = new int[5]; } }", "arrays"); }
+    @Test void acceptsByteArrayLiteral() { assertAccepts("class X { void f() { byte[] b = new byte[]{0x48, 0x45}; } }"); }
+    @Test void acceptsEmptyByteArrayLiteral() { assertAccepts("class X { void f() { byte[] b = new byte[]{}; } }"); }
+    @Test void rejectsIntArrayLiteral() { assertRejects("class X { void f() { int[] a = new int[]{1, 2}; } }", "arrays"); }
+    @Test void rejectsByteArrayWithVarElement() { assertRejects("class X { void f(int v) { byte[] b = new byte[]{(byte)v}; } }", "arrays"); }
     @Test void rejectsArrayAccess() { assertRejects("class X { void f(int[] a) { int x = a[0]; } }", "array access"); }
     @Test void rejectsFloat() { assertRejects("class X { void f(float x) { } }", "floating point"); }
     @Test void rejectsDouble() { assertRejects("class X { void f(double x) { } }", "floating point"); }

--- a/julc-ledger-api/src/main/java/com/bloxbean/cardano/julc/ledger/Value.java
+++ b/julc-ledger-api/src/main/java/com/bloxbean/cardano/julc/ledger/Value.java
@@ -81,6 +81,8 @@ public record Value(JulcMap<PolicyId, JulcMap<TokenName, BigInteger>> inner) imp
     @Override
     public PlutusData.MapData toPlutusData() {
         List<PlutusData.Pair> outerEntries = new ArrayList<>();
+        PlutusData.Pair adaEntry = null;
+
         for (PolicyId policyId : inner.keys()) {
             JulcMap<TokenName, BigInteger> tokens = inner.get(policyId);
             List<PlutusData.Pair> innerEntries = new ArrayList<>();
@@ -89,9 +91,19 @@ public record Value(JulcMap<PolicyId, JulcMap<TokenName, BigInteger>> inner) imp
                         tokenName.toPlutusData(),
                         new PlutusData.IntData(tokens.get(tokenName))));
             }
-            outerEntries.add(new PlutusData.Pair(
+            var pair = new PlutusData.Pair(
                     policyId.toPlutusData(),
-                    new PlutusData.MapData(innerEntries)));
+                    new PlutusData.MapData(innerEntries));
+            if (policyId.equals(PolicyId.ADA)) {
+                adaEntry = pair;
+            } else {
+                outerEntries.add(pair);
+            }
+        }
+
+        // Ensure ADA entry is first, matching Cardano ledger invariant
+        if (adaEntry != null) {
+            outerEntries.addFirst(adaEntry);
         }
         return new PlutusData.MapData(outerEntries);
     }

--- a/julc-ledger-api/src/test/java/com/bloxbean/cardano/julc/ledger/LedgerTypesTest.java
+++ b/julc-ledger-api/src/test/java/com/bloxbean/cardano/julc/ledger/LedgerTypesTest.java
@@ -169,7 +169,12 @@ class LedgerTypesTest {
         void roundTrip() {
             var v = Value.lovelace(BigInteger.valueOf(1_500_000))
                     .merge(Value.singleton(pid(), tn(), BigInteger.valueOf(42)));
-            assertEquals(v, Value.fromPlutusData(v.toPlutusData()));
+            // toPlutusData() normalizes to ADA-first; fromPlutusData preserves that order.
+            // Verify the normalized form is idempotent and preserves all values.
+            var restored = Value.fromPlutusData(v.toPlutusData());
+            assertEquals(BigInteger.valueOf(1_500_000), restored.lovelaceOf());
+            assertEquals(BigInteger.valueOf(42), restored.assetOf(pid(), tn()));
+            assertEquals(restored, Value.fromPlutusData(restored.toPlutusData()));
         }
 
         @Test
@@ -182,6 +187,51 @@ class LedgerTypesTest {
         void encodingIsMap() {
             var data = Value.lovelace(BigInteger.ONE).toPlutusData();
             assertInstanceOf(PlutusData.MapData.class, data);
+        }
+
+        @Test
+        void mergePreservesADAFirst() {
+            var merged = Value.lovelace(BigInteger.valueOf(5_000_000))
+                    .merge(Value.singleton(pid(), tn(), BigInteger.ONE));
+            var mapData = merged.toPlutusData();
+            // ADA (empty bytestring) must be the first entry
+            var firstKey = mapData.entries().getFirst().key();
+            assertInstanceOf(PlutusData.BytesData.class, firstKey);
+            assertArrayEquals(new byte[0], ((PlutusData.BytesData) firstKey).value());
+        }
+
+        @Test
+        void mergeThenLovelaceOfReturnsCorrectAmount() {
+            var merged = Value.lovelace(BigInteger.valueOf(5_000_000))
+                    .merge(Value.singleton(pid(), tn(), BigInteger.valueOf(42)));
+            // Round-trip through PlutusData and check lovelaceOf
+            var restored = Value.fromPlutusData(merged.toPlutusData());
+            assertEquals(BigInteger.valueOf(5_000_000), restored.lovelaceOf());
+        }
+
+        @Test
+        void mergeMultiplePoliciesKeepsADAFirst() {
+            var policyA = new PolicyId(bytes28());
+            var policyB = new PolicyId(bytes28b());
+            var merged = Value.lovelace(BigInteger.valueOf(2_000_000))
+                    .merge(Value.singleton(policyA, tn(), BigInteger.ONE))
+                    .merge(Value.singleton(policyB, tn(), BigInteger.TWO));
+            var mapData = merged.toPlutusData();
+            var firstKey = mapData.entries().getFirst().key();
+            assertInstanceOf(PlutusData.BytesData.class, firstKey);
+            assertArrayEquals(new byte[0], ((PlutusData.BytesData) firstKey).value());
+            assertEquals(3, mapData.entries().size());
+        }
+
+        @Test
+        void mergeWithoutADAStillWorks() {
+            var policyA = new PolicyId(bytes28());
+            var policyB = new PolicyId(bytes28b());
+            var merged = Value.singleton(policyA, tn(), BigInteger.ONE)
+                    .merge(Value.singleton(policyB, tn(), BigInteger.TWO));
+            var mapData = merged.toPlutusData();
+            assertEquals(2, mapData.entries().size());
+            assertEquals(BigInteger.ZERO, merged.lovelaceOf());
         }
     }
 

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLib.java
@@ -148,4 +148,28 @@ public class ByteStringLib {
         byte[] updated = Builtins.consByteString(48 + digit, acc);
         return intToDecimalStep(div, updated);
     }
+
+    // --- Decimal string (UTF-8) to integer ---
+
+    /**
+     * Parse a UTF-8 decimal string (e.g. bytes of "42") to an integer.
+     * Inverse of {@link #intToDecimalString(BigInteger)}.
+     * Assumes all bytes are ASCII digits ('0'-'9'). No sign handling.
+     */
+    public static BigInteger utf8ToInteger(byte[] bs) {
+        long len = Builtins.lengthOfByteString(bs);
+        if (len == 0) {
+            return BigInteger.ZERO;
+        }
+        return utf8ToIntegerStep(bs, 0L, len, BigInteger.ZERO);
+    }
+
+    /** Recursive helper: accumulate decimal value left-to-right. */
+    public static BigInteger utf8ToIntegerStep(byte[] bs, long idx, long len, BigInteger acc) {
+        if (idx >= len) return acc;
+        long digitByte = Builtins.indexByteString(bs, idx);
+        BigInteger digit = BigInteger.valueOf(digitByte - 48);
+        BigInteger newAcc = acc.multiply(BigInteger.TEN).add(digit);
+        return utf8ToIntegerStep(bs, idx + 1, len, newAcc);
+    }
 }

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLib.java
@@ -251,6 +251,7 @@ public class ValuesLib {
      *     BigInteger qty = entry.amount();
      * }
      * }</pre>
+     * Or use {@link #flattenTyped(Value)} for a typed alternative.
      *
      * Note: Split into separate step methods to avoid nested while loops
      * (compiler limitation — while-loop calling a function with a while-loop).
@@ -258,6 +259,16 @@ public class ValuesLib {
     @SuppressWarnings("unchecked")
     public static JulcList<PlutusData> flatten(Value value) {
         return flattenStep(Builtins.unMapData(value), JulcList.empty());
+    }
+
+    /**
+     * Typed variant of {@link #flatten(Value)} that returns {@code JulcList<AssetEntry>}.
+     * Each element provides typed field access: {@code entry.policyId()}, {@code entry.tokenName()},
+     * {@code entry.amount()}.
+     */
+    @SuppressWarnings("unchecked")
+    public static JulcList<AssetEntry> flattenTyped(Value value) {
+        return (JulcList<AssetEntry>)(Object) flatten(value);
     }
 
     /** Process one policy from the outer map, then recurse on the rest. */

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLibTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLibTest.java
@@ -239,4 +239,44 @@ class ByteStringLibTest {
             assertArrayEquals(new byte[]{52, 50}, result); // '4'=52, '2'=50
         }
     }
+
+    @Nested
+    class Utf8ToInteger {
+
+        @Test
+        void emptyReturnsZero() {
+            assertEquals(BigInteger.ZERO, eval.call("utf8ToInteger", new byte[]{}).asInteger());
+        }
+
+        @Test
+        void singleDigit() {
+            // "7" = byte 55
+            assertEquals(BigInteger.valueOf(7), eval.call("utf8ToInteger", new byte[]{55}).asInteger());
+        }
+
+        @Test
+        void twoDigits() {
+            // "42" = bytes {52, 50}
+            assertEquals(BigInteger.valueOf(42), eval.call("utf8ToInteger", new byte[]{52, 50}).asInteger());
+        }
+
+        @Test
+        void largeNumber() {
+            // "12345" = bytes {49, 50, 51, 52, 53}
+            assertEquals(BigInteger.valueOf(12345), eval.call("utf8ToInteger", new byte[]{49, 50, 51, 52, 53}).asInteger());
+        }
+
+        @Test
+        void zero() {
+            // "0" = byte 48
+            assertEquals(BigInteger.ZERO, eval.call("utf8ToInteger", new byte[]{48}).asInteger());
+        }
+
+        @Test
+        void roundtripWithIntToDecimalString() {
+            // intToDecimalString(42) → bytes, utf8ToInteger(bytes) → 42
+            byte[] encoded = eval.call("intToDecimalString", BigInteger.valueOf(42)).asByteString();
+            assertEquals(BigInteger.valueOf(42), eval.call("utf8ToInteger", encoded).asInteger());
+        }
+    }
 }

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLibTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLibTest.java
@@ -253,6 +253,18 @@ class ValuesLibTest {
         }
     }
 
+    @Nested
+    class FlattenTyped {
+
+        @Test
+        void flattenTypedReturnsSameAsFlatten() {
+            var v = multiAssetValue(2_000_000, POLICY_A, TOKEN_X, 42);
+            var flatResult = eval.call("flatten", v).asList();
+            var typedResult = eval.call("flattenTyped", v).asList();
+            assertEquals(flatResult.size(), typedResult.size());
+        }
+    }
+
     // =========================================================================
     // add, subtract
     // =========================================================================


### PR DESCRIPTION
 ## Summary

  - **Byte array constants**: `static final byte[] NAME = "TOKEN".getBytes()` and `new byte[]{0x48, 0x45, ...}` literal arrays now compile to on-chain ByteString constants
  - **`ByteStringLib.utf8ToInteger(byte[])`**: Parse UTF-8 decimal strings to integers (inverse of `intToDecimalString`)
  - **`ValuesLib.flattenTyped(Value)`**: Returns `JulcList<AssetEntry>` with typed `.policyId()`, `.tokenName()`, `.amount()` field access — replaces manual Builtins destructuring
  - **`ownHash` + `containsPolicy` pattern**: Confirmed working for minting validators with `(byte[])(Object)` cast; documented the pattern
  - **Fix `Value.toPlutusData()` ADA-first ordering**: `Value.merge()` could place the ADA entry after native tokens, breaking `lovelaceOf()`. Now ensures ADA is always first, matching the Cardano ledger invariant.

  ## Changes

  ### Compiler
  - Register `String.getBytes()` as `EncodeUtf8` builtin in TypeMethodRegistry
  - Allow `new byte[]{...}` literal arrays in SubsetValidator and compile to ByteString constants in PirGenerator

  ### Stdlib
  - Add `ByteStringLib.utf8ToInteger()` with recursive digit parsing helper
  - Add `ValuesLib.flattenTyped()` returning typed `JulcList<AssetEntry>`

  ### Ledger API
  - Fix `Value.toPlutusData()` to always place ADA (empty PolicyId) entry first

  ### Documentation
  - Add `flattenTyped` and `utf8ToInteger` to all reference tables (stdlib-guide, api-reference, getting-started)
  - Add "Typed Asset Iteration", "UTF-8 Decimal Parsing", and "ownHash + containsPolicy Pattern" sections to stdlib-guide
  - Add section 18 "Byte Array Constants" to advanced-guide
  - Update getting-started limitations to note byte[] constant support