### PR TITLE
Improve compiler error quality and fix cross-method type inference

### DIFF
--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
@@ -183,7 +183,7 @@ public class JulcCompiler {
         var allCus = new ArrayList<CompilationUnit>();
         allCus.addAll(libraryCus);
         allCus.add(validatorCu);
-        new TypeRegistrar().registerAll(allCus, typeResolver);
+        registerTypesWithDiagnostics(allCus, typeResolver, diagnostics);
         options.logf("Registered types from %d compilation unit(s)", allCus.size());
 
         // 5c. Build knownFqcns for ImportResolver (types + library classes + stdlib classes)
@@ -580,7 +580,7 @@ public class JulcCompiler {
         var allCus = new ArrayList<CompilationUnit>();
         allCus.addAll(libraryCus);
         allCus.add(cu);
-        new TypeRegistrar().registerAll(allCus, typeResolver);
+        registerTypesWithDiagnostics(allCus, typeResolver, diagnostics);
 
         // 6. Build knownFqcns and import resolver
         var knownFqcns = new LinkedHashSet<String>();
@@ -1256,6 +1256,23 @@ public class JulcCompiler {
             methodType = new PirType.FunType(paramTypes.get(i), methodType);
         }
         return methodType;
+    }
+
+    /** Register types with error collection instead of immediate failure. */
+    private void registerTypesWithDiagnostics(List<CompilationUnit> allCus, TypeResolver typeResolver,
+                                              List<CompilerDiagnostic> diagnostics) {
+        try {
+            new TypeRegistrar().registerAll(allCus, typeResolver);
+        } catch (CompilerException e) {
+            diagnostics.addAll(e.diagnostics());
+            if (e.diagnostics().isEmpty()) {
+                diagnostics.add(new CompilerDiagnostic(
+                        CompilerDiagnostic.Level.ERROR, e.getMessage(), "<source>", 0, 0));
+            }
+            if (hasErrors(diagnostics)) {
+                throw new CompilerException(diagnostics);
+            }
+        }
     }
 
     private boolean hasErrors(List<CompilerDiagnostic> diagnostics) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollector.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollector.java
@@ -1,0 +1,193 @@
+package com.bloxbean.cardano.julc.compiler.error;
+
+import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.github.javaparser.ast.Node;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Collects compiler diagnostics (errors, warnings, info) during compilation,
+ * enabling multi-error reporting instead of fail-fast behavior.
+ * <p>
+ * This is the standard pattern for error collection across all compiler phases.
+ * Errors can be accumulated and thrown together at the end of a phase.
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * var collector = new DiagnosticCollector("MyValidator.java");
+ *
+ * // Collect errors during processing
+ * collector.error(node, "Undefined variable 'x'", "Check spelling or ensure 'x' is declared before use");
+ * collector.warning(node, "Unreachable code");
+ *
+ * // At the end, throw if there were errors
+ * collector.throwIfErrors();
+ * }</pre>
+ */
+public class DiagnosticCollector {
+
+    private final List<CompilerDiagnostic> diagnostics = new ArrayList<>();
+    private String fileName;
+
+    public DiagnosticCollector() {
+        this.fileName = "<source>";
+    }
+
+    public DiagnosticCollector(String fileName) {
+        this.fileName = fileName;
+    }
+
+    /**
+     * Set the current file name for diagnostics.
+     */
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    /**
+     * Record an error with source position from an AST node.
+     */
+    public void error(Node node, String message) {
+        error(node, message, null);
+    }
+
+    /**
+     * Record an error with source position and a suggestion.
+     */
+    public void error(Node node, String message, String suggestion) {
+        int line = 0, col = 0;
+        if (node != null) {
+            var begin = node.getBegin();
+            if (begin.isPresent()) {
+                line = begin.get().line;
+                col = begin.get().column;
+            }
+        }
+        diagnostics.add(new CompilerDiagnostic(
+                CompilerDiagnostic.Level.ERROR, message, fileName, line, col, suggestion));
+    }
+
+    /**
+     * Record an error without a source node (structural errors).
+     */
+    public void error(String message) {
+        error(message, (String) null);
+    }
+
+    /**
+     * Record an error without a source node but with a suggestion.
+     */
+    public void error(String message, String suggestion) {
+        diagnostics.add(new CompilerDiagnostic(
+                CompilerDiagnostic.Level.ERROR, message, fileName, 0, 0, suggestion));
+    }
+
+    /**
+     * Record a warning with source position.
+     */
+    public void warning(Node node, String message) {
+        warning(node, message, null);
+    }
+
+    /**
+     * Record a warning with source position and a suggestion.
+     */
+    public void warning(Node node, String message, String suggestion) {
+        int line = 0, col = 0;
+        if (node != null) {
+            var begin = node.getBegin();
+            if (begin.isPresent()) {
+                line = begin.get().line;
+                col = begin.get().column;
+            }
+        }
+        diagnostics.add(new CompilerDiagnostic(
+                CompilerDiagnostic.Level.WARNING, message, fileName, line, col, suggestion));
+    }
+
+    /**
+     * Record a warning without a source node.
+     */
+    public void warning(String message) {
+        diagnostics.add(new CompilerDiagnostic(
+                CompilerDiagnostic.Level.WARNING, message, fileName, 0, 0));
+    }
+
+    /**
+     * Check if any errors have been collected.
+     */
+    public boolean hasErrors() {
+        return diagnostics.stream().anyMatch(CompilerDiagnostic::isError);
+    }
+
+    /**
+     * Get all collected diagnostics.
+     */
+    public List<CompilerDiagnostic> getDiagnostics() {
+        return Collections.unmodifiableList(diagnostics);
+    }
+
+    /**
+     * Get only error-level diagnostics.
+     */
+    public List<CompilerDiagnostic> getErrors() {
+        return diagnostics.stream()
+                .filter(CompilerDiagnostic::isError)
+                .toList();
+    }
+
+    /**
+     * Get only warning-level diagnostics.
+     */
+    public List<CompilerDiagnostic> getWarnings() {
+        return diagnostics.stream()
+                .filter(d -> d.level() == CompilerDiagnostic.Level.WARNING)
+                .toList();
+    }
+
+    /**
+     * Throw a CompilerException if any errors have been collected.
+     */
+    public void throwIfErrors() {
+        if (hasErrors()) {
+            throw new CompilerException(diagnostics);
+        }
+    }
+
+    /**
+     * Add all diagnostics from another collector.
+     */
+    public void addAll(DiagnosticCollector other) {
+        diagnostics.addAll(other.diagnostics);
+    }
+
+    /**
+     * Add all diagnostics from a list.
+     */
+    public void addAll(List<CompilerDiagnostic> otherDiagnostics) {
+        diagnostics.addAll(otherDiagnostics);
+    }
+
+    /**
+     * Clear all collected diagnostics.
+     */
+    public void clear() {
+        diagnostics.clear();
+    }
+
+    /**
+     * Number of diagnostics collected.
+     */
+    public int size() {
+        return diagnostics.size();
+    }
+
+    /**
+     * Check if no diagnostics have been collected.
+     */
+    public boolean isEmpty() {
+        return diagnostics.isEmpty();
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -15,6 +15,7 @@ import com.github.javaparser.ast.stmt.*;
 
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
 import com.bloxbean.cardano.julc.compiler.resolve.LibraryMethodRegistry;
+import com.bloxbean.cardano.julc.compiler.util.StringUtils;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -564,7 +565,7 @@ public class PirGenerator {
                 if (castTargetType instanceof PirType.MapType) {
                     return new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnMapData), inner);
                 }
-            } catch (IllegalArgumentException _) {
+            } catch (IllegalArgumentException | CompilerException _) {
                 // Unknown cast target type (e.g., Object) — treat as no-op
             }
             return inner;
@@ -603,6 +604,12 @@ public class PirGenerator {
         // Infer operand type for type-aware dispatching
         var leftType = resolveExpressionType(be.getLeft());
         if (leftType instanceof PirType.DataType) leftType = inferPirType(left);
+        // If left is still DataType, try the right operand for better type inference
+        if (leftType instanceof PirType.DataType) {
+            var rightType = resolveExpressionType(be.getRight());
+            if (rightType instanceof PirType.DataType) rightType = inferPirType(right);
+            if (!(rightType instanceof PirType.DataType)) leftType = rightType;
+        }
 
         return switch (be.getOperator()) {
             case PLUS -> {
@@ -969,13 +976,18 @@ public class PirGenerator {
                 return extractReturnType(methodType.get());
             }
         }
+        // Handle literal expressions for type inference
+        if (expr instanceof IntegerLiteralExpr || expr instanceof LongLiteralExpr)
+            return new PirType.IntegerType();
+        if (expr instanceof StringLiteralExpr) return new PirType.StringType();
+        if (expr instanceof BooleanLiteralExpr) return new PirType.BoolType();
         // Handle cast expressions: (RecordType)(Object) data → resolve the target type
         // This enables `var sd = (StateDatum)(Object) rawDatum;` to infer RecordType
         if (expr instanceof CastExpr ce) {
             try {
                 var castType = typeResolver.resolve(ce.getType());
                 if (!(castType instanceof PirType.DataType)) return castType;
-            } catch (IllegalArgumentException _) {
+            } catch (IllegalArgumentException | CompilerException _) {
                 // Unknown target (e.g., Object) — fall through
             }
             return resolveExpressionType(ce.getExpression());
@@ -1165,7 +1177,7 @@ public class PirGenerator {
             if (resolvedType instanceof PirType.ByteStringType && oce.getArguments().size() == 1) {
                 return generateExpression(oce.getArguments().get(0));
             }
-        } catch (IllegalArgumentException _) {
+        } catch (IllegalArgumentException | CompilerException _) {
             // Not a known type — continue to other checks
         }
 
@@ -3073,26 +3085,6 @@ public class PirGenerator {
     }
 
     /**
-     * Compute the edit distance between two strings (Levenshtein distance).
-     * Used for fuzzy matching in error suggestions.
-     */
-    private static int editDistance(String a, String b) {
-        int m = a.length(), n = b.length();
-        int[] prev = new int[n + 1];
-        int[] curr = new int[n + 1];
-        for (int j = 0; j <= n; j++) prev[j] = j;
-        for (int i = 1; i <= m; i++) {
-            curr[0] = i;
-            for (int j = 1; j <= n; j++) {
-                int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
-                curr[j] = Math.min(Math.min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
-            }
-            var tmp = prev; prev = curr; curr = tmp;
-        }
-        return prev[n];
-    }
-
-    /**
      * Find the closest method name from available stdlib methods.
      * Returns a suggestion string like "Did you mean 'ListsLib.contains()'?" or empty if no close match.
      */
@@ -3131,7 +3123,7 @@ public class PirGenerator {
 
         for (String qualified : knownMethods) {
             String simpleName = qualified.substring(qualified.indexOf('.') + 1);
-            int dist = editDistance(methodName.toLowerCase(), simpleName.toLowerCase());
+            int dist = StringUtils.levenshtein(methodName.toLowerCase(), simpleName.toLowerCase());
             if (dist < bestDist && dist <= Math.max(2, methodName.length() / 3)) {
                 bestDist = dist;
                 bestMatch = qualified;

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
@@ -330,7 +330,7 @@ public final class TypeMethodRegistry {
         // get(index): LetRec-based nth element access (O(n) linked list traversal)
         reg.register("ListType", "get",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("get() requires an index argument");
+                    if (args.isEmpty()) throw new CompilerException("get() requires an index argument. Usage: list.get(0)");
                     // LetRec pattern: go(lst, idx) = if idx == 0 then HeadList(lst) else go(TailList(lst), idx-1)
                     var lstVar = new PirTerm.Var("lst_get", new PirType.ListType(new PirType.DataType()));
                     var idxVar = new PirTerm.Var("idx_get", new PirType.IntegerType());
@@ -369,7 +369,7 @@ public final class TypeMethodRegistry {
         // contains: recursive search with typed equality
         reg.register("ListType", "contains",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("contains() requires one argument");
+                    if (args.isEmpty()) throw new CompilerException("contains() requires one argument. Usage: list.contains(element)");
                     var lt = (PirType.ListType) scopeType;
                     var targetType = argTypes.get(0);
                     return PirHelpers.generateListContains(scope, args.get(0), lt.elemType(), targetType);
@@ -406,7 +406,7 @@ public final class TypeMethodRegistry {
         // go(reversed, other) = if null(reversed) then other else go(tail(reversed), mkCons(head(reversed), other))
         reg.register("ListType", "concat",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("concat() requires one argument");
+                    if (args.isEmpty()) throw new CompilerException("concat() requires one argument. Usage: list.concat(otherList)");
                     // First reverse the source list
                     var revLstVar = new PirTerm.Var("lst_crev", new PirType.ListType(new PirType.DataType()));
                     var revAccVar = new PirTerm.Var("acc_crev", new PirType.ListType(new PirType.DataType()));
@@ -436,7 +436,7 @@ public final class TypeMethodRegistry {
         // take(n): LetRec go(lst, n) = if n<=0 || null(lst) then nil else mkCons(head(lst), go(tail(lst), n-1))
         reg.register("ListType", "take",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("take() requires a count argument");
+                    if (args.isEmpty()) throw new CompilerException("take() requires a count argument. Usage: list.take(n)");
                     var lstVar = new PirTerm.Var("lst_take", new PirType.ListType(new PirType.DataType()));
                     var nVar = new PirTerm.Var("n_take", new PirType.IntegerType());
                     var goVar = new PirTerm.Var("go_take", new PirType.FunType(
@@ -472,7 +472,7 @@ public final class TypeMethodRegistry {
         // drop(n): LetRec go(lst, n) = if n<=0 || null(lst) then lst else go(tail(lst), n-1)
         reg.register("ListType", "drop",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("drop() requires a count argument");
+                    if (args.isEmpty()) throw new CompilerException("drop() requires a count argument. Usage: list.drop(n)");
                     var lstVar = new PirTerm.Var("lst_drop", new PirType.ListType(new PirType.DataType()));
                     var nVar = new PirTerm.Var("n_drop", new PirType.IntegerType());
                     var goVar = new PirTerm.Var("go_drop", new PirType.FunType(
@@ -505,7 +505,7 @@ public final class TypeMethodRegistry {
         // map(fn): apply fn to each element, return new list
         reg.register("ListType", "map",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("list.map() requires a function argument");
+                    if (args.isEmpty()) throw new CompilerException("list.map() requires a function argument. Usage: list.map(x -> x + 1)");
                     return PirHofBuilders.map(scope, args.get(0));
                 },
                 scopeType -> new PirType.ListType(new PirType.DataType()));
@@ -513,7 +513,7 @@ public final class TypeMethodRegistry {
         // filter(pred): keep elements where pred returns true
         reg.register("ListType", "filter",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("list.filter() requires a predicate argument");
+                    if (args.isEmpty()) throw new CompilerException("list.filter() requires a predicate argument. Usage: list.filter(x -> x > 0)");
                     return PirHofBuilders.filter(scope, args.get(0));
                 },
                 scopeType -> scopeType);
@@ -521,7 +521,7 @@ public final class TypeMethodRegistry {
         // any(pred): return true if any element satisfies pred
         reg.register("ListType", "any",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("list.any() requires a predicate argument");
+                    if (args.isEmpty()) throw new CompilerException("list.any() requires a predicate argument. Usage: list.any(x -> x > 0)");
                     return PirHofBuilders.any(scope, args.get(0));
                 },
                 scopeType -> new PirType.BoolType());
@@ -529,7 +529,7 @@ public final class TypeMethodRegistry {
         // all(pred): return true if all elements satisfy pred
         reg.register("ListType", "all",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("list.all() requires a predicate argument");
+                    if (args.isEmpty()) throw new CompilerException("list.all() requires a predicate argument. Usage: list.all(x -> x > 0)");
                     return PirHofBuilders.all(scope, args.get(0));
                 },
                 scopeType -> new PirType.BoolType());
@@ -537,7 +537,7 @@ public final class TypeMethodRegistry {
         // find(pred): return first element matching pred as Optional
         reg.register("ListType", "find",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("list.find() requires a predicate argument");
+                    if (args.isEmpty()) throw new CompilerException("list.find() requires a predicate argument. Usage: list.find(x -> x == target)");
                     return PirHofBuilders.find(scope, args.get(0));
                 },
                 scopeType -> new PirType.OptionalType(new PirType.DataType()));
@@ -584,7 +584,7 @@ public final class TypeMethodRegistry {
         // get(key): search pair list, return value directly (crash on miss)
         reg.register("MapType", "get",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("map.get() requires a key argument");
+                    if (args.isEmpty()) throw new CompilerException("map.get() requires a key argument. Usage: map.get(key). Note: crashes on missing key; use map.lookup(key) for Optional result");
                     var mt = (PirType.MapType) scopeType;
                     var keyArg = PirHelpers.wrapEncode(args.get(0),
                             argTypes.isEmpty() ? new PirType.DataType() : argTypes.get(0));
@@ -606,7 +606,7 @@ public final class TypeMethodRegistry {
         // lookup(key): search pair list, return Optional(value) on match
         reg.register("MapType", "lookup",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("map.lookup() requires a key argument");
+                    if (args.isEmpty()) throw new CompilerException("map.lookup() requires a key argument. Usage: map.lookup(key). Returns Optional<V>");
                     var keyArg = PirHelpers.wrapEncode(args.get(0),
                             argTypes.isEmpty() ? new PirType.DataType() : argTypes.get(0));
                     return PirHelpers.pairListSearch("lk", scope, keyArg, PirHelpers.mkNone(),
@@ -622,7 +622,7 @@ public final class TypeMethodRegistry {
         // containsKey(key): search pair list, return true on match
         reg.register("MapType", "containsKey",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("map.containsKey() requires a key argument");
+                    if (args.isEmpty()) throw new CompilerException("map.containsKey() requires a key argument. Usage: map.containsKey(key)");
                     var keyArg = PirHelpers.wrapEncode(args.get(0),
                             argTypes.isEmpty() ? new PirType.DataType() : argTypes.get(0));
                     return PirHelpers.pairListSearch("ck", scope, keyArg,
@@ -702,7 +702,7 @@ public final class TypeMethodRegistry {
         // insert(key, value): MkCons(MkPairData(key, value), pairList) — returns pair list
         reg.register("MapType", "insert",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.size() < 2) throw new CompilerException("map.insert() requires key and value arguments");
+                    if (args.size() < 2) throw new CompilerException("map.insert() requires key and value arguments. Usage: map.insert(key, value)");
                     var mt = (PirType.MapType) scopeType;
                     var keyArg = PirHelpers.wrapEncode(args.get(0), argTypes.size() >= 1 ? argTypes.get(0) : new PirType.DataType());
                     var valArg = PirHelpers.wrapEncode(args.get(1), argTypes.size() >= 2 ? argTypes.get(1) : new PirType.DataType());
@@ -715,7 +715,7 @@ public final class TypeMethodRegistry {
         // delete(key): filter out matching key from pair list
         reg.register("MapType", "delete",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("map.delete() requires a key argument");
+                    if (args.isEmpty()) throw new CompilerException("map.delete() requires a key argument. Usage: map.delete(key)");
                     var keyArg = PirHelpers.wrapEncode(args.get(0),
                             argTypes.isEmpty() ? new PirType.DataType() : argTypes.get(0));
                     return PirHelpers.pairListSearch("del", scope, keyArg, PirHelpers.mkNilPairData(),
@@ -780,7 +780,7 @@ public final class TypeMethodRegistry {
         // containsPolicy(policyId): check if policy exists in Value's outer map
         reg.register("Value", "containsPolicy",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.isEmpty()) throw new CompilerException("value.containsPolicy() requires a policyId argument");
+                    if (args.isEmpty()) throw new CompilerException("value.containsPolicy() requires a policyId argument. Usage: value.containsPolicy(policyId)");
                     var pairList = new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnMapData), scope);
                     var keyArg = PirHelpers.wrapEncode(args.get(0),
                             argTypes.isEmpty() ? new PirType.DataType() : argTypes.get(0));
@@ -798,7 +798,7 @@ public final class TypeMethodRegistry {
         // assetOf(policyId, tokenName): LetRec search in nested maps
         reg.register("Value", "assetOf",
                 (scope, args, scopeType, argTypes) -> {
-                    if (args.size() < 2) throw new CompilerException("value.assetOf() requires policyId and tokenName arguments");
+                    if (args.size() < 2) throw new CompilerException("value.assetOf() requires policyId and tokenName arguments. Usage: value.assetOf(policyId, tokenName)");
                     var policyArg = PirHelpers.wrapEncode(args.get(0), argTypes.size() >= 1 ? argTypes.get(0) : new PirType.DataType());
                     var tokenArg = PirHelpers.wrapEncode(args.get(1), argTypes.size() >= 2 ? argTypes.get(1) : new PirType.DataType());
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeRegistrar.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeRegistrar.java
@@ -1,9 +1,11 @@
 package com.bloxbean.cardano.julc.compiler.resolve;
 
 import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
@@ -49,7 +51,7 @@ public class TypeRegistrar {
                 var fqcn = rd.getFullyQualifiedName().orElse(simpleName);
 
                 if (allRecords.containsKey(fqcn)) {
-                    throw new CompilerException("Duplicate record type '" + fqcn + "' found across compilation units");
+                    throw errorAt(rd, "Duplicate record type '" + fqcn + "' found across compilation units");
                 }
                 allRecords.put(fqcn, rd);
                 typeToCu.put(fqcn, cu);
@@ -65,7 +67,7 @@ public class TypeRegistrar {
                     var fqcn = cd.getFullyQualifiedName().orElse(simpleName);
 
                     if (allSealed.containsKey(fqcn)) {
-                        throw new CompilerException("Duplicate sealed interface '" + fqcn + "' found across compilation units");
+                        throw errorAt(cd, "Duplicate sealed interface '" + fqcn + "' found across compilation units");
                     }
                     allSealed.put(fqcn, cd);
                     typeToCu.put(fqcn, cu);
@@ -216,12 +218,12 @@ public class TypeRegistrar {
     private void validateNewType(RecordDeclaration rd) {
         var params = rd.getParameters();
         if (params.size() != 1) {
-            throw new CompilerException("@NewType record '" + rd.getNameAsString()
+            throw errorAt(rd, "@NewType record '" + rd.getNameAsString()
                     + "' must have exactly 1 field, got " + params.size());
         }
         var fieldType = params.get(0).getType().asString();
         if (!isSupportedNewTypeField(fieldType)) {
-            throw new CompilerException("@NewType record '" + rd.getNameAsString()
+            throw errorAt(rd, "@NewType record '" + rd.getNameAsString()
                     + "' field type '" + fieldType + "' is not supported. "
                     + "Supported types: byte[], BigInteger, String, boolean");
         }
@@ -235,7 +237,8 @@ public class TypeRegistrar {
             case "BigInteger" -> new PirType.IntegerType();
             case "String" -> new PirType.StringType();
             case "boolean" -> new PirType.BoolType();
-            default -> throw new CompilerException("Unsupported @NewType field type: " + fieldType);
+            default -> throw new CompilerException("Unsupported @NewType field type: " + fieldType
+                    + ". Supported types: byte[], BigInteger, String, boolean");
         };
     }
 
@@ -374,5 +377,24 @@ public class TypeRegistrar {
         }
 
         return result;
+    }
+
+    /** Create a CompilerException with source position from a JavaParser node. */
+    private CompilerException errorAt(Node node, String message) {
+        int line = 0, col = 0;
+        String fileName = "<source>";
+        if (node != null) {
+            var range = node.getRange();
+            if (range.isPresent()) {
+                line = range.get().begin.line;
+                col = range.get().begin.column;
+            }
+            var cu = node.findCompilationUnit();
+            if (cu.isPresent() && cu.get().getStorage().isPresent()) {
+                fileName = cu.get().getStorage().get().getFileName();
+            }
+        }
+        var diag = new CompilerDiagnostic(CompilerDiagnostic.Level.ERROR, message, fileName, line, col);
+        return new CompilerException(List.of(diag));
     }
 }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolver.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.julc.compiler.resolve;
 
+import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
+import com.bloxbean.cardano.julc.compiler.util.StringUtils;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -62,7 +64,7 @@ public class TypeResolver {
     public void registerRecord(RecordDeclaration rd, String fqcn) {
         var name = rd.getNameAsString();
         if (recordTypes.containsKey(fqcn)) {
-            throw new IllegalArgumentException("Duplicate record type: '" + fqcn + "'. "
+            throw new CompilerException("Duplicate record type: '" + fqcn + "'. "
                     + "A record with this name is already registered.");
         }
         var fields = new ArrayList<PirType.Field>();
@@ -116,7 +118,7 @@ public class TypeResolver {
     public void registerSealedInterface(ClassOrInterfaceDeclaration decl, String fqcn) {
         var interfaceName = decl.getNameAsString();
         if (sumTypes.containsKey(fqcn)) {
-            throw new IllegalArgumentException("Duplicate sealed interface: '" + fqcn + "'. "
+            throw new CompilerException("Duplicate sealed interface: '" + fqcn + "'. "
                     + "A sealed interface with this name is already registered.");
         }
         var constructors = new ArrayList<PirType.Constructor>();
@@ -161,7 +163,7 @@ public class TypeResolver {
                                                      List<String> variantFqcns) {
         var interfaceName = decl.getNameAsString();
         if (sumTypes.containsKey(fqcn)) {
-            throw new IllegalArgumentException("Duplicate sealed interface: '" + fqcn + "'. "
+            throw new CompilerException("Duplicate sealed interface: '" + fqcn + "'. "
                     + "A sealed interface with this name is already registered.");
         }
         var constructors = new ArrayList<PirType.Constructor>();
@@ -246,7 +248,8 @@ public class TypeResolver {
             return switch (pt.getType()) {
                 case BOOLEAN -> new PirType.BoolType();
                 case INT, LONG -> new PirType.IntegerType();
-                default -> throw new IllegalArgumentException("Unsupported primitive type: " + pt);
+                default -> throw new CompilerException("Unsupported primitive type: " + pt
+                        + ". Supported types: boolean, int, long");
             };
         }
         if (type instanceof VoidType) {
@@ -265,12 +268,13 @@ public class TypeResolver {
                     pt.getType() == PrimitiveType.Primitive.BYTE) {
                 return new PirType.ByteStringType();
             }
-            throw new IllegalArgumentException("Arrays are not supported; use List. Got: " + at);
+            throw new CompilerException("Arrays are not supported except byte[]. Use List<T> instead. Got: " + at);
         }
         if (type instanceof com.github.javaparser.ast.type.UnknownType) {
             return new PirType.DataType(); // default fallback for untyped lambda params
         }
-        throw new IllegalArgumentException("Cannot resolve type: " + type);
+        throw new CompilerException("Cannot resolve type: " + type
+                + ". Supported types: BigInteger, String, boolean, byte[], List<T>, Map<K,V>, records, sealed interfaces");
     }
 
     private PirType resolveClassType(ClassOrInterfaceType ct) {
@@ -362,8 +366,11 @@ public class TypeResolver {
                         }
                     }
                 }
-                throw new IllegalArgumentException("Unknown type: " + name
-                        + (fqcn.equals(name) ? "" : " (resolved to " + fqcn + ")"));
+                // Suggest similar registered types
+                var suggestion = findSimilarType(name);
+                throw new CompilerException("Unknown type: " + name
+                        + (fqcn.equals(name) ? "" : " (resolved to " + fqcn + ")")
+                        + (suggestion != null ? ". Did you mean: " + suggestion + "?" : ""));
             }
         };
     }
@@ -413,7 +420,7 @@ public class TypeResolver {
         var fqcns = simpleNameIndex.get(simpleName);
         if (fqcns != null && fqcns.size() == 1) return fqcns.iterator().next();
         if (fqcns != null && fqcns.size() > 1) {
-            throw new IllegalArgumentException("Ambiguous type '" + simpleName
+            throw new CompilerException("Ambiguous type '" + simpleName
                     + "'. Could be: " + String.join(", ", fqcns)
                     + ". Use an explicit import to disambiguate.");
         }
@@ -460,5 +467,35 @@ public class TypeResolver {
         all.addAll(variantToSumType.keySet());
         all.addAll(newTypes.keySet());
         return all;
+    }
+
+    private static final List<String> BUILTIN_TYPE_NAMES = List.of(
+            "BigInteger", "String", "Boolean", "PlutusData",
+            "List", "Map", "Optional", "Tuple2", "Tuple3");
+
+    /**
+     * Find a registered type with a similar name (for "did you mean?" suggestions).
+     * Uses case-insensitive Levenshtein distance.
+     */
+    private String findSimilarType(String name) {
+        String best = null;
+        int bestDist = Integer.MAX_VALUE;
+        String lowerName = name.toLowerCase();
+
+        for (String registered : simpleNameIndex.keySet()) {
+            int dist = StringUtils.levenshtein(lowerName, registered.toLowerCase());
+            if (dist < bestDist && dist <= 3) {
+                bestDist = dist;
+                best = registered;
+            }
+        }
+        for (String builtin : BUILTIN_TYPE_NAMES) {
+            int dist = StringUtils.levenshtein(lowerName, builtin.toLowerCase());
+            if (dist < bestDist && dist <= 3) {
+                bestDist = dist;
+                best = builtin;
+            }
+        }
+        return best;
     }
 }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/util/StringUtils.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/util/StringUtils.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.julc.compiler.util;
+
+/**
+ * Shared string utilities for the compiler.
+ */
+public final class StringUtils {
+
+    private StringUtils() {}
+
+    /**
+     * Compute the Levenshtein (edit) distance between two strings.
+     * Uses a space-optimized two-row DP approach.
+     */
+    public static int levenshtein(String a, String b) {
+        int m = a.length(), n = b.length();
+        int[] prev = new int[n + 1];
+        int[] curr = new int[n + 1];
+        for (int j = 0; j <= n; j++) prev[j] = j;
+        for (int i = 1; i <= m; i++) {
+            curr[0] = i;
+            for (int j = 1; j <= n; j++) {
+                int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+                curr[j] = Math.min(Math.min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+            }
+            var tmp = prev; prev = curr; curr = tmp;
+        }
+        return prev[n];
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CrossMethodTypeInferenceTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CrossMethodTypeInferenceTest.java
@@ -1,0 +1,267 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for P0-3: Cross-Method Type Inference Hardening.
+ * Verifies that cross-method calls use correct UPLC builtins for comparisons
+ * (EqualsInteger instead of EqualsData for integer comparisons, etc.)
+ */
+class CrossMethodTypeInferenceTest {
+
+    /**
+     * Helper with long param + == comparison should use EqualsInteger.
+     */
+    @Test
+    void helperWithLongParamUsesEqualsInteger() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    static boolean isEqual(long a, long b) {
+                        return a == b;
+                    }
+
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return isEqual(5, 10);
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsInteger"),
+                "Helper with long params should use equalsInteger, PIR: " + pir);
+        assertFalse(pir.contains("equalsData"),
+                "Helper with long params should NOT use equalsData, PIR: " + pir);
+    }
+
+    /**
+     * Helper with BigInteger param + == comparison should use EqualsInteger.
+     */
+    @Test
+    void helperWithBigIntegerParamUsesEqualsInteger() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    static boolean isEqual(BigInteger a, BigInteger b) {
+                        return a == b;
+                    }
+
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return isEqual(redeemer, ctx);
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsInteger"),
+                "Helper with BigInteger params should use equalsInteger, PIR: " + pir);
+    }
+
+    /**
+     * Helper with byte[] param + == comparison should use EqualsByteString.
+     */
+    @Test
+    void helperWithByteArrayParamUsesEqualsByteString() {
+        var source = """
+                @Validator
+                class MyValidator {
+                    record BsHolder(byte[] a, byte[] b) {}
+
+                    static boolean matches(byte[] a, byte[] b) {
+                        return a == b;
+                    }
+
+                    @Entrypoint
+                    static boolean validate(BsHolder redeemer, ScriptContext ctx) {
+                        return matches(redeemer.a(), redeemer.b());
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsByteString"),
+                "Helper with byte[] params should use equalsByteString, PIR: " + pir);
+    }
+
+    /**
+     * Var-inferred return from helper used in comparison should maintain type.
+     */
+    @Test
+    void varInferredHelperReturnUsesEqualsInteger() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    static BigInteger doubleIt(BigInteger x) {
+                        return x + x;
+                    }
+
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        var result = doubleIt(redeemer);
+                        return result == 10;
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsInteger"),
+                "Var-inferred helper return should use equalsInteger, PIR: " + pir);
+    }
+
+    /**
+     * Chained helpers: A→B→C with type narrowing should preserve types.
+     */
+    @Test
+    void chainedHelpersPreserveType() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    static BigInteger addOne(BigInteger x) {
+                        return x + 1;
+                    }
+
+                    static BigInteger doubleAndAdd(BigInteger x) {
+                        return addOne(x + x);
+                    }
+
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return doubleAndAdd(redeemer) == 21;
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsInteger"),
+                "Chained helpers should use equalsInteger, PIR: " + pir);
+    }
+
+    /**
+     * Integer literal on right-hand side of == with DataType left should still
+     * use EqualsInteger when the right side is recognizably an integer literal.
+     */
+    @Test
+    void literalComparisonUsesEqualsInteger() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return redeemer == 42;
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsInteger"),
+                "Literal comparison should use equalsInteger, PIR: " + pir);
+    }
+
+    /**
+     * Helper comparing result of arithmetic (which produces IntegerType PIR)
+     * against a literal should use EqualsInteger.
+     */
+    @Test
+    void helperWithArithmeticResultUsesEqualsInteger() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    static BigInteger compute(BigInteger x) {
+                        return x * 2 + 1;
+                    }
+
+                    static boolean checkComputed(BigInteger x) {
+                        var result = compute(x);
+                        return result == 43;
+                    }
+
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return checkComputed(redeemer);
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsInteger"),
+                "Arithmetic result comparison should use equalsInteger, PIR: " + pir);
+    }
+
+    /**
+     * Comparison where left is entrypoint param (typed as BigInteger = IntegerType).
+     * This should already work since BigInteger maps to IntegerType in symbol table.
+     */
+    @Test
+    void entrypointParamComparisonUsesEqualsInteger() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return redeemer == ctx;
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+    }
+
+    /**
+     * String helper comparison should use EqualsString.
+     */
+    @Test
+    void helperWithStringParamUsesEqualsString() {
+        var source = """
+                @Validator
+                class MyValidator {
+                    static boolean matches(String a, String b) {
+                        return a == b;
+                    }
+
+                    @Entrypoint
+                    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                        return matches("hello", "world");
+                    }
+                }
+                """;
+        var result = new JulcCompiler().compileWithDetails(source);
+        assertNotNull(result.program());
+        assertFalse(result.hasErrors());
+        var pir = result.pirFormatted();
+        assertTrue(pir.contains("equalsString"),
+                "Helper with String params should use equalsString, PIR: " + pir);
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollectorTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollectorTest.java
@@ -1,0 +1,94 @@
+package com.bloxbean.cardano.julc.compiler.error;
+
+import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DiagnosticCollectorTest {
+
+    @Test
+    void collectsErrorsWithPosition() {
+        var collector = new DiagnosticCollector("test.java");
+
+        // Use a parsed expression to get a real Node with position
+        var cu = StaticJavaParser.parse("class A { void m() { int x = 42; } }");
+        var literal = cu.findFirst(IntegerLiteralExpr.class).orElseThrow();
+
+        collector.error(literal, "Test error", "Fix suggestion");
+
+        assertTrue(collector.hasErrors());
+        assertEquals(1, collector.size());
+        var diag = collector.getDiagnostics().get(0);
+        assertTrue(diag.isError());
+        assertEquals("Test error", diag.message());
+        assertEquals("Fix suggestion", diag.suggestion());
+        assertEquals("test.java", diag.fileName());
+        assertTrue(diag.line() > 0);
+    }
+
+    @Test
+    void collectsWarnings() {
+        var collector = new DiagnosticCollector("test.java");
+        collector.warning(null, "Test warning");
+
+        assertFalse(collector.hasErrors());
+        assertEquals(1, collector.size());
+        assertEquals(CompilerDiagnostic.Level.WARNING, collector.getDiagnostics().get(0).level());
+    }
+
+    @Test
+    void throwIfErrorsDoesNothingWhenNoErrors() {
+        var collector = new DiagnosticCollector();
+        collector.warning(null, "Just a warning");
+        assertDoesNotThrow(collector::throwIfErrors);
+    }
+
+    @Test
+    void throwIfErrorsThrowsCompilerException() {
+        var collector = new DiagnosticCollector();
+        collector.error("Test error");
+
+        var ex = assertThrows(CompilerException.class, collector::throwIfErrors);
+        assertFalse(ex.diagnostics().isEmpty());
+        assertEquals("Test error", ex.diagnostics().get(0).message());
+    }
+
+    @Test
+    void addAllMergesCollectors() {
+        var collector1 = new DiagnosticCollector("file1.java");
+        collector1.error("Error 1");
+
+        var collector2 = new DiagnosticCollector("file2.java");
+        collector2.error("Error 2");
+        collector2.warning(null, "Warning 1");
+
+        collector1.addAll(collector2);
+        assertEquals(3, collector1.size());
+        assertEquals(2, collector1.getErrors().size());
+        assertEquals(1, collector1.getWarnings().size());
+    }
+
+    @Test
+    void clearRemovesAllDiagnostics() {
+        var collector = new DiagnosticCollector();
+        collector.error("Error 1");
+        collector.warning(null, "Warning 1");
+        collector.clear();
+
+        assertTrue(collector.isEmpty());
+        assertFalse(collector.hasErrors());
+    }
+
+    @Test
+    void errorsWithoutNodeUseZeroPosition() {
+        var collector = new DiagnosticCollector("test.java");
+        collector.error("Structural error");
+
+        var diag = collector.getDiagnostics().get(0);
+        assertEquals(0, diag.line());
+        assertEquals(0, diag.column());
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/ErrorQualityTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/ErrorQualityTest.java
@@ -1,0 +1,173 @@
+package com.bloxbean.cardano.julc.compiler.error;
+
+import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for P0-2: Compiler Error Quality & Multi-Error Recovery.
+ * Verifies that error messages include source positions, suggestions,
+ * and "did you mean?" hints.
+ */
+class ErrorQualityTest {
+
+    @Test
+    void unknownTypeIncludesDidYouMean() {
+        var source = """
+                @Validator
+                class MyValidator {
+                    record MyDatum(Strng name) {}
+
+                    @Entrypoint
+                    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                        return true;
+                    }
+                }
+                """;
+        var ex = assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
+        assertTrue(ex.getMessage().contains("Did you mean"),
+                "Error should suggest similar type. Got: " + ex.getMessage());
+    }
+
+    @Test
+    void unsupportedPrimitiveIncludesSupportedTypes() {
+        var source = """
+                @Validator
+                class MyValidator {
+                    record BadRecord(float value) {}
+
+                    @Entrypoint
+                    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                        return true;
+                    }
+                }
+                """;
+        var ex = assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
+        // SubsetValidator should catch float before TypeResolver
+        assertTrue(ex.getMessage().toLowerCase().contains("float")
+                || ex.getMessage().toLowerCase().contains("supported"),
+                "Error should mention unsupported float type. Got: " + ex.getMessage());
+    }
+
+    @Test
+    void typeMethodRegistryErrorMessagesIncludeUsageHints() {
+        // Verify that TypeMethodRegistry error messages contain usage hints
+        // This is a unit-level check of the error message format
+        try {
+            // Create a scope (empty list) and call get() with no args
+            var registry = com.bloxbean.cardano.julc.compiler.pir.TypeMethodRegistry.defaultRegistry();
+            var scope = new com.bloxbean.cardano.julc.compiler.pir.PirTerm.Const(
+                    new com.bloxbean.cardano.julc.core.Constant.UnitConst());
+            var scopeType = new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(
+                    new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType());
+            registry.dispatch(scope, "get", java.util.List.of(), scopeType, java.util.List.of());
+            fail("Should have thrown CompilerException");
+        } catch (CompilerException e) {
+            assertTrue(e.getMessage().contains("Usage"),
+                    "Error should include usage hint. Got: " + e.getMessage());
+            assertTrue(e.getMessage().contains("list.get(0)"),
+                    "Error should include example. Got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void multipleSubsetErrorsReportedTogether() {
+        // Source with multiple unsupported constructs
+        var source = """
+                @Validator
+                class MyValidator {
+                    @Entrypoint
+                    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                        try {
+                            return true;
+                        } catch (Exception e) {
+                            return false;
+                        }
+                    }
+                }
+                """;
+        var ex = assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
+        // SubsetValidator should report the try-catch error
+        assertTrue(ex.diagnostics().size() >= 1, "Should report at least 1 error");
+        // Check that diagnostics have file/line info
+        var diag = ex.diagnostics().get(0);
+        assertTrue(diag.line() > 0, "Error should have line number");
+    }
+
+    @Test
+    void typeResolverErrorUsesCompilerException() {
+        var source = """
+                @Validator
+                class MyValidator {
+                    record BadRecord(UnknownTypeName field) {}
+
+                    @Entrypoint
+                    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                        return true;
+                    }
+                }
+                """;
+        // Should throw CompilerException (not IllegalArgumentException)
+        assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
+    }
+
+    @Test
+    void undefinedVariableErrorHasSuggestion() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return unknownVar == 42;
+                    }
+                }
+                """;
+        var ex = assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
+        assertTrue(ex.getMessage().contains("Undefined variable") || ex.getMessage().contains("Unknown method"),
+                "Error should mention undefined variable. Got: " + ex.getMessage());
+    }
+
+    @Test
+    void unsupportedStatementErrorHasSuggestion() {
+        var source = """
+                import java.math.BigInteger;
+
+                @Validator
+                class MyValidator {
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        for (int i = 0; i < 10; i++) {
+                            // do nothing
+                        }
+                        return true;
+                    }
+                }
+                """;
+        var ex = assertThrows(CompilerException.class, () -> new JulcCompiler().compile(source));
+        // Should be caught by SubsetValidator
+        assertTrue(ex.getMessage().contains("for") || ex.getMessage().contains("C-style"),
+                "Error should mention unsupported for loop. Got: " + ex.getMessage());
+    }
+
+    @Test
+    void diagnosticToStringIncludesAllFields() {
+        var diag = new CompilerDiagnostic(
+                CompilerDiagnostic.Level.ERROR,
+                "Test error message",
+                "MyValidator.java",
+                42, 10,
+                "Try using XYZ instead");
+
+        String str = diag.toString();
+        assertTrue(str.contains("ERROR"));
+        assertTrue(str.contains("MyValidator.java"));
+        assertTrue(str.contains("42"));
+        assertTrue(str.contains("10"));
+        assertTrue(str.contains("Test error message"));
+        assertTrue(str.contains("Try using XYZ instead"));
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolverTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolverTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.julc.compiler.resolve;
 
+import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
@@ -155,12 +156,12 @@ class TypeResolverTest {
     }
 
     @Test void resolveUnknownTypeThrows() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(CompilerException.class,
                 () -> resolver.resolve(StaticJavaParser.parseClassOrInterfaceType("UnknownType")));
     }
 
     @Test void resolveFloatThrows() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(CompilerException.class,
                 () -> resolver.resolve(PrimitiveType.floatType()));
     }
 

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -41,7 +40,7 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
 
         Path metaInfDir = outDir.toPath().resolve("META-INF/plutus-sources");
 
-        List<File> javaFiles = findJavaFiles(srcDir);
+        List<File> javaFiles = SourceScanner.findJavaFiles(srcDir);
         int bundled = 0;
 
         for (File javaFile : javaFiles) {
@@ -67,22 +66,4 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
         }
     }
 
-    private List<File> findJavaFiles(File dir) {
-        List<File> files = new ArrayList<>();
-        if (!dir.exists()) return files;
-        collectJavaFiles(dir, files);
-        return files;
-    }
-
-    private void collectJavaFiles(File dir, List<File> result) {
-        File[] children = dir.listFiles();
-        if (children == null) return;
-        for (File child : children) {
-            if (child.isDirectory()) {
-                collectJavaFiles(child, result);
-            } else if (child.getName().endsWith(".java")) {
-                result.add(child);
-            }
-        }
-    }
 }

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/SourceScanner.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/SourceScanner.java
@@ -1,0 +1,46 @@
+package com.bloxbean.cardano.julc.gradle;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared utilities for scanning validator and library source files.
+ */
+final class SourceScanner {
+
+    private SourceScanner() {}
+
+    /** Recursively find all .java files under a directory. */
+    static List<File> findJavaFiles(File dir) {
+        List<File> files = new ArrayList<>();
+        if (!dir.exists()) return files;
+        collectJavaFiles(dir, files);
+        return files;
+    }
+
+    private static void collectJavaFiles(File dir, List<File> result) {
+        File[] children = dir.listFiles();
+        if (children == null) return;
+        for (File child : children) {
+            if (child.isDirectory()) {
+                collectJavaFiles(child, result);
+            } else if (child.getName().endsWith(".java")) {
+                result.add(child);
+            }
+        }
+    }
+
+    /** Check if source contains a validator annotation. */
+    static boolean isValidatorSource(String source) {
+        return source.contains("@Validator") || source.contains("@MintingPolicy")
+                || source.contains("@SpendingValidator") || source.contains("@MintingValidator")
+                || source.contains("@WithdrawValidator") || source.contains("@CertifyingValidator")
+                || source.contains("@VotingValidator") || source.contains("@ProposingValidator");
+    }
+
+    /** Check if source is an on-chain library (should be compiled alongside validators). */
+    static boolean isLibrarySource(String source) {
+        return source.contains("@OnchainLibrary");
+    }
+}


### PR DESCRIPTION
  - Fix cross-method type inference: right-operand fallback in binary expressions now correctly infers types from literals (e.g., helper(x) == 42)
  - Replace IllegalArgumentException with CompilerException throughout TypeResolver for consistent error handling
  - Add "Did you mean?" suggestions for unknown types and methods
  - Add source file/line/column to TypeRegistrar errors via errorAt()
  - Improve TypeMethodRegistry error messages with usage examples
  - Extract editDistance to StringUtils.levenshtein() (shared utility)
  - Add DiagnosticCollector for structured error collection
  - Refactor BundleJulcSourcesTask to use shared SourceScanner
  - Remove BenchmarkJulcTask and benchmark testkit (low priority)
  - Revert CompileJulcTask to remove redundant LibrarySourceResolver integration