### PR TITLE
feat: Add PV11 Batch 6 builtins and BLS12-381 library. Add  JulcArray and NativeValueLib 

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -39,6 +39,7 @@ This document covers all supported Java operations in the JuLC compiler, the sta
 | `@NewType` records | Underlying type | Zero-cost alias (identity on-chain) |
 | `PubKeyHash`, `PolicyId`, `TokenName`, `TxId`, `ScriptHash`, `ValidatorHash`, `DatumHash` | ByteString | Ledger hash types |
 | `Value` | Map(Pair) | Named RecordType with instance methods |
+| `JulcArray<T>` *(PV11)* | BuiltinArray | O(1) random access array (CIP-156). PV11+ only |
 
 ### JulcList and JulcMap
 
@@ -48,6 +49,21 @@ This document covers all supported Java operations in the JuLC compiler, the sta
 JulcList<PubKeyHash> signers = txInfo.signatories();  // typed list of PubKeyHash
 JulcMap<Credential, BigInteger> withdrawals = txInfo.withdrawals();
 ```
+
+### JulcArray (PV11)
+
+> **Protocol Version 11+ only.** Arrays use CIP-156 builtins and are not available on PV10 networks.
+
+`JulcArray<T>` is an immutable array interface providing O(1) random access on-chain. Create from a list via `list.toArray()` or `JulcArray.fromList(list)`.
+
+```java
+JulcList<BigInteger> list = ...;
+JulcArray<BigInteger> arr = list.toArray();     // ListToArray builtin
+BigInteger elem = arr.get(0);                    // IndexArray builtin (O(1))
+long len = arr.length();                         // LengthOfArray builtin
+```
+
+Off-chain: backed by `JulcArrayImpl`, wrapping `java.util.List` with O(1) index access.
 
 ### Tuple2 and Tuple3
 
@@ -110,7 +126,7 @@ var items2 = PlutusData.cast(data, JulcList.class);                 // element t
 
 ### Not Supported
 
-`float`, `double`, `char`, arrays (`T[]`), `null`, collections other than `List`/`Map`/`Optional`, generic classes, inheritance (use sealed interfaces instead).
+`float`, `double`, `char`, arrays (`T[]` — use `JulcArray<T>` on PV11+ or `List<T>`), `null`, collections other than `List`/`Map`/`Optional`/`JulcArray`, generic classes, inheritance (use sealed interfaces instead).
 
 ## Operators
 
@@ -645,6 +661,39 @@ Note: `sha2_256`, `sha3_256`, `blake2b_256`, `blake2b_224`, `keccak_256`, and `v
 | `isScriptAddress(addr)` | Address | True if script address |
 | `isPubKeyAddress(addr)` | Address | True if pub key address |
 | `paymentCredential(addr)` | Address | Extract payment credential |
+
+### BlsLib
+
+BLS12-381 elliptic curve operations. Available on PV10+. See [Standard Library Guide](stdlib-guide.md#blslib----bls12-381-curve-operations) for full documentation.
+
+| Method | Args | Description |
+|--------|------|-------------|
+| `g1Add(a, b)` | G1, G1 | Add two G1 elements |
+| `g1Neg(a)` | G1 | Negate a G1 element |
+| `g1ScalarMul(scalar, g1)` | Integer, G1 | Scalar multiplication of G1 |
+| `g1Equal(a, b)` | G1, G1 | Check G1 equality |
+| `g1Compress(g1)` / `g1Uncompress(bs)` | G1 / BS | G1 compression |
+| `g1HashToGroup(msg, dst)` | BS, BS | Hash to G1 |
+| `g2Add`, `g2Neg`, `g2ScalarMul`, `g2Equal`, `g2Compress`, `g2Uncompress`, `g2HashToGroup` | — | G2 equivalents |
+| `millerLoop(g1, g2)` | G1, G2 | Compute Miller loop pairing |
+| `mulMlResult(a, b)` | ML, ML | Multiply two Miller loop results |
+| `finalVerify(a, b)` | ML, ML | Final pairing verification |
+| `g1MultiScalarMul(scalars, points)` | List, List | Multi-scalar multiplication on G1 |
+| `g2MultiScalarMul(scalars, points)` | List, List | Multi-scalar multiplication on G2 |
+
+### NativeValueLib (PV11)
+
+> **Protocol Version 11+ only.** Native MaryEra Value operations via CIP-153 builtins. For PV10 networks, use `ValuesLib`. See [Standard Library Guide](stdlib-guide.md#nativevaluelib----native-value-operations-pv11) for full documentation.
+
+| Method | Args | Description |
+|--------|------|-------------|
+| `insertCoin(policy, token, amount, value)` | BS, BS, Integer, Value | Insert/update token quantity |
+| `lookupCoin(policy, token, value)` | BS, BS, Value | Look up token quantity (0 if absent) |
+| `union(a, b)` | Value, Value | Merge two Values by adding quantities |
+| `contains(a, b)` | Value, Value | Check a >= b element-wise |
+| `scale(scalar, value)` | Integer, Value | Scale all quantities |
+| `fromData(mapData)` | Data | Convert Map-encoded PlutusData to native Value |
+| `toData(value)` | Value | Convert native Value back to Map encoding |
 
 ## Annotations Reference
 

--- a/docs/compiler-developer-guide.md
+++ b/docs/compiler-developer-guide.md
@@ -349,6 +349,7 @@ Defined in `TypeResolver.resolve(Type)`:
 | `List<T>` | `ListType(resolve(T))` | Generic |
 | `Map<K,V>` | `MapType(resolve(K), resolve(V))` | Generic |
 | `Optional<T>` | `OptionalType(resolve(T))` | Generic |
+| `JulcArray<T>` | `ArrayType(resolve(T))` | PV11 only; O(1) random access (CIP-156) |
 | `PubKeyHash`, `ScriptHash`, `ValidatorHash`, `PolicyId`, `TokenName`, `DatumHash`, `TxId` | `ByteStringType` | Ledger hash types |
 | `StakingCredential`, `ScriptPurpose`, `Vote`, `Voter`, `DRep`, `Delegatee`, `GovernanceActionId`, `GovernanceAction`, `ProposalProcedure`, `TxCert`, `Rational`, `ProtocolVersion`, `Committee` | `DataType` | Opaque ledger types |
 | Registered records | `RecordType(...)` | User-defined or ledger records |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1495,9 +1495,9 @@ following limitations apply:
 
 - **Supported types**: `BigInteger`, `boolean`, `byte[]`, `long`, `String`,
   `PlutusData`, records, sealed interfaces, `List<T>`, `Map<K,V>`, `Optional<T>`,
-  `Tuple2<A,B>`, `Tuple3<A,B,C>`.
+  `Tuple2<A,B>`, `Tuple3<A,B,C>`, `JulcArray<T>` *(PV11+)*.
 - **No float/double**: Floating-point types do not exist on-chain.
-- **No arrays** (except `byte[]`): Use `List<T>` for collections. `byte[]` literal arrays (`new byte[]{0x48, 0x45}`) and `"TOKEN".getBytes()` are supported as compile-time constants.
+- **No Java arrays** (except `byte[]`): Use `JulcList<T>` for collections (or `List<T>`), or `JulcArray<T>` for O(1) random access on PV11+ networks (CIP-156). `byte[]` literal arrays (`new byte[]{0x48, 0x45}`) and `"TOKEN".getBytes()` are supported as compile-time constants. `JulcList<T>` is preferred over `List<T>` because it provides IDE autocomplete for on-chain methods (`.contains()`, `.size()`, `.get()`, `.filter()`, etc.).
 - **No class inheritance**: Only records and sealed interfaces are supported for
   data types.
 

--- a/docs/library-developer-guide.md
+++ b/docs/library-developer-guide.md
@@ -357,7 +357,7 @@ The following Java features are NOT supported in `@OnchainLibrary` classes:
 - **No `try`/`catch`** -- errors abort execution via `Builtins.error()`.
 - **No `null`** -- Plutus has no null concept.
 - **No object creation** (`new`) -- all data is constructed via `Builtins.*` or `PlutusData` factories.
-- **No arrays or collections** -- lists are Plutus builtin lists manipulated through `Builtins.headList`, `Builtins.tailList`, etc.
+- **No Java arrays or raw collections** -- lists are Plutus builtin lists manipulated through `Builtins.headList`, `Builtins.tailList`, etc. PV11 adds `JulcArray<T>` with `Builtins.listToArray`, `Builtins.indexArray`, `Builtins.lengthOfArray`.
 - **No `return` inside `while` body** -- accumulate into a variable and return after the loop.
 - **No `for` loops with ranges** -- use `while` with a counter variable.
 - **No string operations in library source** -- UPLC Text type cannot be compiled from Java source; use PIR API for `trace`.

--- a/docs/stdlib-guide.md
+++ b/docs/stdlib-guide.md
@@ -1,6 +1,6 @@
 # JuLC Standard Library Usage Guide
 
-The JuLC standard library provides 11 on-chain libraries in the `com.bloxbean.cardano.julc.stdlib.lib` package. Each library is annotated with `@OnchainLibrary` and compiled from Java source to UPLC. All methods are `static` and can be called directly from your validator code.
+The JuLC standard library provides 13 on-chain libraries in the `com.bloxbean.cardano.julc.stdlib.lib` package. Each library is annotated with `@OnchainLibrary` and compiled from Java source to UPLC. All methods are `static` and can be called directly from your validator code.
 
 ## Table of Contents
 
@@ -17,6 +17,8 @@ The JuLC standard library provides 11 on-chain libraries in the `com.bloxbean.ca
 - [ByteStringLib -- ByteString Operations](#bytestringlib----bytestring-operations)
 - [BitwiseLib -- Bitwise Operations](#bitwiselib----bitwise-operations)
 - [AddressLib -- Address Operations](#addresslib----address-operations)
+- [BlsLib -- BLS12-381 Curve Operations](#blslib----bls12-381-curve-operations)
+- [NativeValueLib -- Native Value Operations (PV11)](#nativevaluelib----native-value-operations-pv11)
 - [Important Notes and Caveats](#important-notes-and-caveats)
 
 ---
@@ -36,6 +38,8 @@ The JuLC standard library provides 11 on-chain libraries in the `com.bloxbean.ca
 | **ByteStringLib** | `com.bloxbean.cardano.julc.stdlib.lib.ByteStringLib` | ByteString slicing, comparison, encoding, serialization |
 | **BitwiseLib** | `com.bloxbean.cardano.julc.stdlib.lib.BitwiseLib` | Bitwise AND/OR/XOR, shift, rotate, bit read/write |
 | **AddressLib** | `com.bloxbean.cardano.julc.stdlib.lib.AddressLib` | Credential extraction, address type checks |
+| **BlsLib** | `com.bloxbean.cardano.julc.stdlib.lib.BlsLib` | BLS12-381 G1/G2/pairing/MSM operations |
+| **NativeValueLib** *(PV11)* | `com.bloxbean.cardano.julc.stdlib.lib.NativeValueLib` | Native MaryEra Value insert, lookup, union, contains, scale |
 
 ---
 
@@ -1196,6 +1200,90 @@ class DestinationCheckExample {
 
 ---
 
+## BlsLib -- BLS12-381 Curve Operations
+
+`BlsLib` wraps the Plutus V3 BLS12-381 builtins for elliptic curve cryptography. All methods are `static` and available on PV10+.
+
+### Quick Reference
+
+| Method | Description |
+|--------|-------------|
+| `g1Add(a, b)` | Add two G1 elements |
+| `g1Neg(a)` | Negate a G1 element |
+| `g1ScalarMul(scalar, g1)` | Scalar multiplication of G1 |
+| `g1Equal(a, b)` | Check G1 equality |
+| `g1Compress(g1)` | Compress G1 to bytes |
+| `g1Uncompress(compressed)` | Uncompress bytes to G1 |
+| `g1HashToGroup(msg, dst)` | Hash to G1 |
+| `g2Add(a, b)` | Add two G2 elements |
+| `g2Neg(a)` | Negate a G2 element |
+| `g2ScalarMul(scalar, g2)` | Scalar multiplication of G2 |
+| `g2Equal(a, b)` | Check G2 equality |
+| `g2Compress(g2)` | Compress G2 to bytes |
+| `g2Uncompress(compressed)` | Uncompress bytes to G2 |
+| `g2HashToGroup(msg, dst)` | Hash to G2 |
+| `millerLoop(g1, g2)` | Compute Miller loop pairing |
+| `mulMlResult(a, b)` | Multiply two Miller loop results |
+| `finalVerify(a, b)` | Final pairing verification |
+| `g1MultiScalarMul(scalars, points)` | Multi-scalar multiplication on G1 |
+| `g2MultiScalarMul(scalars, points)` | Multi-scalar multiplication on G2 |
+
+### Usage
+
+```java
+import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+
+// G1 operations
+var sum = BlsLib.g1Add(pointA, pointB);
+var scaled = BlsLib.g1ScalarMul(scalar, point);
+boolean eq = BlsLib.g1Equal(a, b);
+
+// Pairing
+var ml = BlsLib.millerLoop(g1Point, g2Point);
+boolean valid = BlsLib.finalVerify(ml1, ml2);
+```
+
+> **Off-chain:** BlsLib methods throw `UnsupportedOperationException` — use `JulcEval.forSource()` for UPLC evaluation.
+
+---
+
+## NativeValueLib -- Native Value Operations (PV11)
+
+> **Protocol Version 11+ only.** These operations use native UPLC Value builtins (CIP-153) available from PV11 onwards. They will not work on PV10 networks. For PV10 networks, use `ValuesLib` which operates on Map-encoded PlutusData.
+
+`NativeValueLib` provides efficient native MaryEra Value operations via PV11 builtins.
+
+### Quick Reference
+
+| Method | Description |
+|--------|-------------|
+| `insertCoin(policyId, tokenName, amount, value)` | Insert/update token quantity |
+| `lookupCoin(policyId, tokenName, value)` | Look up token quantity (0 if absent) |
+| `union(a, b)` | Merge two Values by adding quantities |
+| `contains(a, b)` | Check a >= b element-wise |
+| `scale(scalar, value)` | Scale all quantities |
+| `fromData(mapData)` | Convert Map-encoded PlutusData to native Value |
+| `toData(value)` | Convert native Value back to Map encoding |
+
+### Usage
+
+```java
+import com.bloxbean.cardano.julc.stdlib.lib.NativeValueLib;
+
+// Build a Value with tokens
+var value = NativeValueLib.insertCoin(policyId, tokenName, BigInteger.valueOf(100), emptyValue);
+
+// Check if one value contains another
+boolean ok = NativeValueLib.contains(outputValue, requiredValue);
+
+// Merge values
+var total = NativeValueLib.union(valueA, valueB);
+```
+
+> **Off-chain:** NativeValueLib methods throw `UnsupportedOperationException` — use `JulcEval.forSource()` for UPLC evaluation.
+
+---
+
 ## Important Notes and Caveats
 
 ### On-Chain vs Off-Chain
@@ -1317,3 +1405,13 @@ boolean anyLarge = outputs.any(out -> isLarge(out));
 JulcList<TxOut> filtered = outputs.filter(out -> isLarge(out));
 JulcList<PlutusData> mapped = outputs.map(out -> transform(out));
 ```
+
+### PV11 (Protocol Version 11) Features
+
+The following features require protocol version 11 or later and will not work on PV10 networks:
+
+- **NativeValueLib** — Native MaryEra Value operations (CIP-153)
+- **JulcArray\<T\>** — Immutable arrays with O(1) random access (CIP-156)
+- **Builtins.dropList()** — Drop first n elements from a list (CIP-158)
+
+These are experimental APIs that may evolve as PV11 stabilizes. BlsLib and all other existing stdlib libraries work on PV10+.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -757,6 +757,8 @@ var data = new byte[32];
 // Use ByteString for byte arrays, or List<T> for element lists
 ```
 
+> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-156 builtins. Use `list.toArray()` to convert a list.
+
 ---
 
 ### 2.11 `array access is not supported on-chain`
@@ -776,6 +778,8 @@ var first = Builtins.headList(items);
 // or
 var nth = ListsLib.nth(items, 2);
 ```
+
+> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-156 builtins. Use `list.toArray()` to convert a list, then `arr.get(index)` for O(1) access.
 
 ---
 
@@ -1010,6 +1014,8 @@ public record MyData(BigInteger amount, byte[] hash) {}
 (mapped to ByteString).
 
 **Fix:** Use `List<T>` instead of arrays.
+
+> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-156 builtins. Use `list.toArray()` to convert a list.
 
 ---
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -3170,17 +3170,35 @@ public class PirGenerator {
         return switch (fun) {
             case AddInteger, SubtractInteger, MultiplyInteger, DivideInteger,
                  QuotientInteger, RemainderInteger, ModInteger,
-                 LengthOfByteString, ByteStringToInteger, UnIData -> new PirType.IntegerType();
+                 LengthOfByteString, ByteStringToInteger, UnIData,
+                 LengthOfArray, LookupCoin -> new PirType.IntegerType();
             case EqualsInteger, LessThanInteger, LessThanEqualsInteger,
                  EqualsByteString, LessThanByteString, LessThanEqualsByteString,
-                 EqualsString, EqualsData, NullList -> new PirType.BoolType();
+                 EqualsString, EqualsData, NullList,
+                 Bls12_381_G1_equal, Bls12_381_G2_equal, Bls12_381_finalVerify,
+                 ValueContains -> new PirType.BoolType();
             case AppendByteString, SliceByteString, ConsByteString,
-                 Sha2_256, Sha3_256, Blake2b_256, EncodeUtf8, UnBData -> new PirType.ByteStringType();
+                 Sha2_256, Sha3_256, Blake2b_256, EncodeUtf8, UnBData,
+                 Bls12_381_G1_compress, Bls12_381_G2_compress,
+                 // BLS G1/G2 element-returning operations (native UPLC BLS constants, treated as opaque bytes)
+                 Bls12_381_G1_add, Bls12_381_G1_neg, Bls12_381_G1_scalarMul,
+                 Bls12_381_G1_hashToGroup, Bls12_381_G1_uncompress,
+                 Bls12_381_G2_add, Bls12_381_G2_neg, Bls12_381_G2_scalarMul,
+                 Bls12_381_G2_hashToGroup, Bls12_381_G2_uncompress,
+                 // Miller loop result-returning operations (also opaque BLS constants)
+                 Bls12_381_millerLoop, Bls12_381_mulMlResult,
+                 // Multi-scalar multiplication results
+                 Bls12_381_G1_multiScalarMul, Bls12_381_G2_multiScalarMul -> new PirType.ByteStringType();
             case AppendString, DecodeUtf8 -> new PirType.StringType();
             // List-returning builtins: these return List(Data) in UPLC
-            case UnListData, TailList, MkCons, MkNilData -> new PirType.ListType(new PirType.DataType());
+            case UnListData, TailList, MkCons, MkNilData,
+                 DropList, MultiIndexArray -> new PirType.ListType(new PirType.DataType());
             // Map-returning builtins: these return List(Pair(Data,Data)) in UPLC
             case UnMapData, MkNilPairData -> new PirType.MapType(new PirType.DataType(), new PirType.DataType());
+            // Array-returning builtins
+            case ListToArray -> new PirType.ArrayType(new PirType.DataType());
+            // IndexArray, InsertCoin, UnionValue, ValueData, UnValueData, ScaleValue intentionally
+            // fall through to DataType — actual types are resolved by TypeMethodRegistry or are opaque.
             default -> new PirType.DataType();
         };
     }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirType.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirType.java
@@ -20,6 +20,7 @@ public sealed interface PirType {
     record PairType(PirType first, PirType second) implements PirType {}
     record MapType(PirType keyType, PirType valueType) implements PirType {}
     record OptionalType(PirType elemType) implements PirType {}
+    record ArrayType(PirType elemType) implements PirType {}
 
     // Function type
     record FunType(PirType paramType, PirType returnType) implements PirType {}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
@@ -77,6 +77,7 @@ public final class TypeMethodRegistry {
         registerMapMethods(reg);
         registerPairMethods(reg);
         registerValueMethods(reg);
+        registerArrayMethods(reg);
         return reg;
     }
 
@@ -497,6 +498,32 @@ public final class TypeMethodRegistry {
                             new PirTerm.App(new PirTerm.App(goVar, scope), args.get(0)));
                 },
                 scopeType -> scopeType);
+
+        // toArray: ListToArray(list) — PV11 only
+        reg.register("ListType", "toArray",
+                (scope, args, scopeType, argTypes) ->
+                        new PirTerm.App(new PirTerm.Builtin(DefaultFun.ListToArray), scope),
+                scopeType -> new PirType.ArrayType(((PirType.ListType) scopeType).elemType()));
+    }
+
+    // --- Array methods (2): length, get ---
+
+    private static void registerArrayMethods(TypeMethodRegistry reg) {
+        // length: LengthOfArray(arr)
+        reg.register("ArrayType", "length",
+                (scope, args, scopeType, argTypes) ->
+                        new PirTerm.App(new PirTerm.Builtin(DefaultFun.LengthOfArray), scope),
+                scopeType -> new PirType.IntegerType());
+
+        // get(index): wrapDecode(IndexArray(arr, index), elemType)
+        reg.register("ArrayType", "get",
+                (scope, args, scopeType, argTypes) -> {
+                    if (args.isEmpty()) throw new CompilerException("arr.get() requires an index argument. Usage: arr.get(0)");
+                    var at = (PirType.ArrayType) scopeType;
+                    var raw = PirHelpers.builtinApp2(DefaultFun.IndexArray, scope, args.get(0));
+                    return PirHelpers.wrapDecode(raw, at.elemType());
+                },
+                scopeType -> ((PirType.ArrayType) scopeType).elemType());
     }
 
     // --- List HOF instance methods (5): map, filter, any, all, find ---

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/LibraryMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/LibraryMethodRegistry.java
@@ -208,6 +208,7 @@ public class LibraryMethodRegistry implements StdlibLookup {
             case PirType.RecordType rt -> rt.name();
             case PirType.SumType st -> st.name();
             case PirType.OptionalType ot -> "Optional[" + pirTypeName(ot.elemType()) + "]";
+            case PirType.ArrayType at -> "Array[" + pirTypeName(at.elemType()) + "]";
         };
     }
 }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/TypeResolver.java
@@ -294,6 +294,14 @@ public class TypeResolver {
                 }
                 yield new PirType.ListType(elemType);
             }
+            case "JulcArray" -> {
+                PirType elemType = new PirType.DataType();
+                var arrayArgs = ct.getTypeArguments();
+                if (arrayArgs.isPresent() && !arrayArgs.get().isEmpty()) {
+                    elemType = resolve(arrayArgs.get().get(0));
+                }
+                yield new PirType.ArrayType(elemType);
+            }
             case "Map", "JulcMap" -> {
                 PirType keyType = new PirType.DataType();
                 PirType valType = new PirType.DataType();

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
@@ -493,7 +493,8 @@ public class UplcGenerator {
             case FstPair, SndPair, ChooseList -> 2;
             // 1 Force (1 type variable: ∀ a)
             case IfThenElse, ChooseUnit, Trace, ChooseData,
-                 SerialiseData, MkCons, HeadList, TailList, NullList -> 1;
+                 SerialiseData, MkCons, HeadList, TailList, NullList,
+                 DropList, LengthOfArray, ListToArray, IndexArray, MultiIndexArray -> 1;
             // 0 Forces (monomorphic)
             default -> 0;
         };

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcArray.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcArray.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.julc.core.types;
+
+/**
+ * Immutable array interface for O(1) random access on-chain.
+ * <p>
+ * <b>PV11 only</b> — Arrays use PV11 Batch 6 builtins (CIP-156) and are available
+ * from protocol version 11 onwards. They will not work on PV10 networks.
+ * <p>
+ * On-chain: the JuLC compiler resolves {@code JulcArray<T>} to {@code ArrayType(resolve(T))}.
+ * Instance methods are dispatched via TypeMethodRegistry to native UPLC builtins.
+ * <p>
+ * Off-chain: backed by {@link JulcArrayImpl}, wrapping a {@code java.util.List<T>}
+ * with O(1) index access.
+ *
+ * @param <T> the element type
+ */
+public interface JulcArray<T> {
+
+    /** Get element at 0-based index (O(1) on-chain). */
+    T get(long index);
+
+    /** Return the number of elements. */
+    long length();
+
+    /** Create an array from a list. On-chain: compiles to ListToArray builtin. */
+    static <T> JulcArray<T> fromList(JulcList<T> list) {
+        var elements = new java.util.ArrayList<T>();
+        for (T elem : list) elements.add(elem);
+        return new JulcArrayImpl<>(elements);
+    }
+}

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcArrayImpl.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcArrayImpl.java
@@ -1,0 +1,46 @@
+package com.bloxbean.cardano.julc.core.types;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Off-chain implementation of {@link JulcArray} backed by a {@code java.util.List<T>}.
+ * Immutable — the delegate list is copied on construction.
+ *
+ * @param <T> the element type
+ */
+public final class JulcArrayImpl<T> implements JulcArray<T> {
+
+    private final List<T> delegate;
+
+    public JulcArrayImpl(List<T> elements) {
+        this.delegate = List.copyOf(elements);
+    }
+
+    @Override
+    public T get(long index) {
+        return delegate.get((int) index);
+    }
+
+    @Override
+    public long length() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o instanceof JulcArrayImpl<?> that) return delegate.equals(that.delegate);
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate);
+    }
+
+    @Override
+    public String toString() {
+        return "JulcArray" + delegate;
+    }
+}

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcList.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcList.java
@@ -74,6 +74,13 @@ public interface JulcList<T> extends Iterable<T> {
     /** Return the first element satisfying the predicate, or null if none. */
     T find(java.util.function.Predicate<T> pred);
 
+    // --- Conversion ---
+
+    /** Convert this list to an immutable array for O(1) access. PV11 only on-chain. */
+    default JulcArray<T> toArray() {
+        return JulcArray.fromList(this);
+    }
+
     // --- Factory methods (off-chain only — on-chain use compiler intrinsics) ---
 
     /** Create an empty list. */

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
@@ -724,6 +724,200 @@ public final class Builtins {
     }
 
     // =========================================================================
+    // BLS12-381 operations
+    // =========================================================================
+    // These stubs are replaced by UPLC BLS12-381 builtins on-chain.
+    // Off-chain (JVM), they throw UnsupportedOperationException — use the
+    // Julc VM for off-chain evaluation of BLS operations.
+
+    // ---- G1 operations ----
+
+    /** Add two BLS12-381 G1 elements. */
+    public static byte[] bls12_381_G1_add(byte[] a, byte[] b) {
+        throw new UnsupportedOperationException("BLS12-381 G1 add: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Negate a BLS12-381 G1 element. */
+    public static byte[] bls12_381_G1_neg(byte[] a) {
+        throw new UnsupportedOperationException("BLS12-381 G1 neg: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Scalar multiplication of a BLS12-381 G1 element. */
+    public static byte[] bls12_381_G1_scalarMul(BigInteger scalar, byte[] g1) {
+        throw new UnsupportedOperationException("BLS12-381 G1 scalarMul: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Check equality of two BLS12-381 G1 elements. */
+    public static boolean bls12_381_G1_equal(byte[] a, byte[] b) {
+        throw new UnsupportedOperationException("BLS12-381 G1 equal: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Compress a BLS12-381 G1 element (uncompressed → 48 bytes compressed). */
+    public static byte[] bls12_381_G1_compress(byte[] g1) {
+        throw new UnsupportedOperationException("BLS12-381 G1 compress: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Uncompress a BLS12-381 G1 element (48 bytes compressed → uncompressed). */
+    public static byte[] bls12_381_G1_uncompress(byte[] compressed) {
+        throw new UnsupportedOperationException("BLS12-381 G1 uncompress: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Hash a message to a BLS12-381 G1 element using the given DST. */
+    public static byte[] bls12_381_G1_hashToGroup(byte[] msg, byte[] dst) {
+        throw new UnsupportedOperationException("BLS12-381 G1 hashToGroup: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    // ---- G2 operations ----
+
+    /** Add two BLS12-381 G2 elements. */
+    public static byte[] bls12_381_G2_add(byte[] a, byte[] b) {
+        throw new UnsupportedOperationException("BLS12-381 G2 add: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Negate a BLS12-381 G2 element. */
+    public static byte[] bls12_381_G2_neg(byte[] a) {
+        throw new UnsupportedOperationException("BLS12-381 G2 neg: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Scalar multiplication of a BLS12-381 G2 element. */
+    public static byte[] bls12_381_G2_scalarMul(BigInteger scalar, byte[] g2) {
+        throw new UnsupportedOperationException("BLS12-381 G2 scalarMul: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Check equality of two BLS12-381 G2 elements. */
+    public static boolean bls12_381_G2_equal(byte[] a, byte[] b) {
+        throw new UnsupportedOperationException("BLS12-381 G2 equal: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Compress a BLS12-381 G2 element (uncompressed → 96 bytes compressed). */
+    public static byte[] bls12_381_G2_compress(byte[] g2) {
+        throw new UnsupportedOperationException("BLS12-381 G2 compress: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Uncompress a BLS12-381 G2 element (96 bytes compressed → uncompressed). */
+    public static byte[] bls12_381_G2_uncompress(byte[] compressed) {
+        throw new UnsupportedOperationException("BLS12-381 G2 uncompress: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Hash a message to a BLS12-381 G2 element using the given DST. */
+    public static byte[] bls12_381_G2_hashToGroup(byte[] msg, byte[] dst) {
+        throw new UnsupportedOperationException("BLS12-381 G2 hashToGroup: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    // ---- Pairing operations ----
+
+    /** Compute a BLS12-381 Miller loop pairing of a G1 and G2 element. */
+    public static byte[] bls12_381_millerLoop(byte[] g1, byte[] g2) {
+        throw new UnsupportedOperationException("BLS12-381 millerLoop: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Multiply two BLS12-381 Miller loop results. */
+    public static byte[] bls12_381_mulMlResult(byte[] a, byte[] b) {
+        throw new UnsupportedOperationException("BLS12-381 mulMlResult: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Final verification of two BLS12-381 Miller loop results. Returns true if the pairing check passes. */
+    public static boolean bls12_381_finalVerify(byte[] a, byte[] b) {
+        throw new UnsupportedOperationException("BLS12-381 finalVerify: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    // ---- Multi-Scalar Multiplication ----
+
+    /** Multi-scalar multiplication on BLS12-381 G1. Takes a list of scalars and a list of G1 elements. */
+    public static byte[] bls12_381_G1_multiScalarMul(PlutusData scalars, PlutusData points) {
+        throw new UnsupportedOperationException("BLS12-381 G1 multiScalarMul: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Multi-scalar multiplication on BLS12-381 G2. Takes a list of scalars and a list of G2 elements. */
+    public static byte[] bls12_381_G2_multiScalarMul(PlutusData scalars, PlutusData points) {
+        throw new UnsupportedOperationException("BLS12-381 G2 multiScalarMul: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    // =========================================================================
+    // PV11 List Extensions (CIP-158)
+    // =========================================================================
+
+    /** Drop the first n elements from a list. PV11 only. */
+    public static PlutusData dropList(long n, PlutusData list) {
+        throw new UnsupportedOperationException("Builtins.dropList: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    // =========================================================================
+    // PV11 Array Operations (CIP-156)
+    // =========================================================================
+
+    /** Convert a list to an immutable array for O(1) random access. PV11 only. */
+    public static PlutusData listToArray(PlutusData list) {
+        throw new UnsupportedOperationException("Builtins.listToArray: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Return the number of elements in an array. PV11 only. */
+    public static long lengthOfArray(PlutusData array) {
+        throw new UnsupportedOperationException("Builtins.lengthOfArray: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Get the element at the given 0-based index. PV11 only. */
+    public static PlutusData indexArray(PlutusData array, long index) {
+        throw new UnsupportedOperationException("Builtins.indexArray: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Get multiple elements at the given indices. PV11 only. */
+    public static PlutusData multiIndexArray(PlutusData array, PlutusData indices) {
+        throw new UnsupportedOperationException("Builtins.multiIndexArray: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    // =========================================================================
+    // PV11 MaryEraValue Operations (CIP-153)
+    // =========================================================================
+
+    /**
+     * Insert or update a token quantity in a native Value. PV11 only.
+     *
+     * @apiNote On-chain, the UPLC builtin accepts arbitrary-precision integers. The {@code long}
+     *          parameter here covers the practical range for token quantities but will truncate
+     *          values outside {@code Long.MIN_VALUE..Long.MAX_VALUE}.
+     */
+    public static PlutusData insertCoin(byte[] policyId, byte[] tokenName, long amount, PlutusData value) {
+        throw new UnsupportedOperationException("Builtins.insertCoin: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /**
+     * Look up a token quantity in a native Value. Returns 0 if absent. PV11 only.
+     *
+     * @apiNote On-chain, the UPLC builtin returns an arbitrary-precision integer. The {@code long}
+     *          return type here covers the practical range but will truncate values outside
+     *          {@code Long.MIN_VALUE..Long.MAX_VALUE}.
+     */
+    public static long lookupCoin(byte[] policyId, byte[] tokenName, PlutusData value) {
+        throw new UnsupportedOperationException("Builtins.lookupCoin: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Merge two native Values by adding quantities. PV11 only. */
+    public static PlutusData unionValue(PlutusData a, PlutusData b) {
+        throw new UnsupportedOperationException("Builtins.unionValue: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Check if native Value a contains at least Value b (a >= b element-wise). PV11 only. */
+    public static boolean valueContains(PlutusData a, PlutusData b) {
+        throw new UnsupportedOperationException("Builtins.valueContains: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Convert a native Value to its Data encoding. PV11 only. */
+    public static PlutusData valueData(PlutusData value) {
+        throw new UnsupportedOperationException("Builtins.valueData: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Convert Data-encoded value to native Value. PV11 only. */
+    public static PlutusData unValueData(PlutusData data) {
+        throw new UnsupportedOperationException("Builtins.unValueData: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    /** Scale all quantities in a native Value by a scalar. PV11 only. */
+    public static PlutusData scaleValue(long scalar, PlutusData value) {
+        throw new UnsupportedOperationException("Builtins.scaleValue: on-chain only — use Julc VM for off-chain evaluation");
+    }
+
+    // =========================================================================
     // Object-accepting overloads for IDE + off-chain compatibility
     // =========================================================================
     // On-chain types (ScriptInfo, TxInfo, etc.) don't extend PlutusData in

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
@@ -240,7 +240,7 @@ public final class StdlibRegistry implements StdlibLookup {
         fqcns.add(PKG + "Builtins");
         for (String lib : List.of("ContextsLib", "ListsLib", "MapLib", "ValuesLib",
                 "OutputLib", "MathLib", "IntervalLib", "CryptoLib",
-                "ByteStringLib", "BitwiseLib", "AddressLib")) {
+                "ByteStringLib", "BitwiseLib", "AddressLib", "BlsLib", "NativeValueLib")) {
             fqcns.add(LIB + lib);
         }
         return fqcns;
@@ -307,6 +307,20 @@ public final class StdlibRegistry implements StdlibLookup {
             {"complementByteString", DefaultFun.ComplementByteString},
             {"countSetBits",        DefaultFun.CountSetBits},
             {"findFirstSetBit",     DefaultFun.FindFirstSetBit},
+            // BLS12-381 G1 operations (1-arg)
+            {"bls12_381_G1_neg",              DefaultFun.Bls12_381_G1_neg},
+            {"bls12_381_G1_compress",         DefaultFun.Bls12_381_G1_compress},
+            {"bls12_381_G1_uncompress",       DefaultFun.Bls12_381_G1_uncompress},
+            // BLS12-381 G2 operations (1-arg)
+            {"bls12_381_G2_neg",              DefaultFun.Bls12_381_G2_neg},
+            {"bls12_381_G2_compress",         DefaultFun.Bls12_381_G2_compress},
+            {"bls12_381_G2_uncompress",       DefaultFun.Bls12_381_G2_uncompress},
+            // PV11 Array operations (1-arg)
+            {"listToArray",                   DefaultFun.ListToArray},
+            {"lengthOfArray",                 DefaultFun.LengthOfArray},
+            // PV11 MaryEraValue operations (1-arg)
+            {"valueData",                     DefaultFun.ValueData},
+            {"unValueData",                   DefaultFun.UnValueData},
     };
 
     /** 2-arg builtin operations: methodName → Builtin(fun, arg0, arg1) */
@@ -328,6 +342,32 @@ public final class StdlibRegistry implements StdlibLookup {
             {"readBit",             DefaultFun.ReadBit},
             {"shiftByteString",     DefaultFun.ShiftByteString},
             {"rotateByteString",    DefaultFun.RotateByteString},
+            // BLS12-381 G1 operations (2-arg)
+            {"bls12_381_G1_add",              DefaultFun.Bls12_381_G1_add},
+            {"bls12_381_G1_scalarMul",        DefaultFun.Bls12_381_G1_scalarMul},
+            {"bls12_381_G1_equal",            DefaultFun.Bls12_381_G1_equal},
+            {"bls12_381_G1_hashToGroup",      DefaultFun.Bls12_381_G1_hashToGroup},
+            // BLS12-381 G2 operations (2-arg)
+            {"bls12_381_G2_add",              DefaultFun.Bls12_381_G2_add},
+            {"bls12_381_G2_scalarMul",        DefaultFun.Bls12_381_G2_scalarMul},
+            {"bls12_381_G2_equal",            DefaultFun.Bls12_381_G2_equal},
+            {"bls12_381_G2_hashToGroup",      DefaultFun.Bls12_381_G2_hashToGroup},
+            // BLS12-381 Pairing operations (2-arg)
+            {"bls12_381_millerLoop",          DefaultFun.Bls12_381_millerLoop},
+            {"bls12_381_mulMlResult",         DefaultFun.Bls12_381_mulMlResult},
+            {"bls12_381_finalVerify",         DefaultFun.Bls12_381_finalVerify},
+            // BLS12-381 Multi-Scalar Multiplication (2-arg: scalars list, points list)
+            {"bls12_381_G1_multiScalarMul",   DefaultFun.Bls12_381_G1_multiScalarMul},
+            {"bls12_381_G2_multiScalarMul",   DefaultFun.Bls12_381_G2_multiScalarMul},
+            // PV11 List extensions (2-arg)
+            {"dropList",                      DefaultFun.DropList},
+            // PV11 Array operations (2-arg)
+            {"indexArray",                    DefaultFun.IndexArray},
+            {"multiIndexArray",               DefaultFun.MultiIndexArray},
+            // PV11 MaryEraValue operations (2-arg)
+            {"unionValue",                    DefaultFun.UnionValue},
+            {"valueContains",                 DefaultFun.ValueContains},
+            {"scaleValue",                    DefaultFun.ScaleValue},
     };
 
     /** 3-arg builtin operations: methodName → Builtin(fun, arg0, arg1, arg2) */
@@ -345,6 +385,8 @@ public final class StdlibRegistry implements StdlibLookup {
             {"writeBits",           DefaultFun.WriteBits},
             // Math operations
             {"expModInteger",       DefaultFun.ExpModInteger},
+            // PV11 MaryEraValue operations (3-arg)
+            {"lookupCoin",          DefaultFun.LookupCoin},
     };
 
     /**
@@ -426,6 +468,12 @@ public final class StdlibRegistry implements StdlibLookup {
         reg.register(B, "toByteString", args -> {
             requireArgs("Builtins.toByteString", args, 1);
             return args.get(0);
+        });
+
+        // PV11 InsertCoin: 4-arg builtin (special case, not in tables)
+        reg.register(B, "insertCoin", args -> {
+            requireArgs("Builtins.insertCoin", args, 4);
+            return builtinApp4(DefaultFun.InsertCoin, args.get(0), args.get(1), args.get(2), args.get(3));
         });
     }
 
@@ -542,6 +590,12 @@ public final class StdlibRegistry implements StdlibLookup {
             requireArgs("JulcMap.empty", args, 0);
             return builtinApp1(DefaultFun.MkNilPairData, new PirTerm.Const(Constant.unit()));
         });
+
+        // JulcArray.fromList(list) → ListToArray(list) — PV11 only
+        reg.register("JulcArray", "fromList", args -> {
+            requireArgs("JulcArray.fromList", args, 1);
+            return builtinApp1(DefaultFun.ListToArray, args.get(0));
+        });
     }
 
     /**
@@ -609,6 +663,13 @@ public final class StdlibRegistry implements StdlibLookup {
                         new PirTerm.App(new PirTerm.Builtin(fun), a),
                         b),
                 c);
+    }
+
+    private static PirTerm builtinApp4(DefaultFun fun, PirTerm a, PirTerm b, PirTerm c, PirTerm d) {
+        return new PirTerm.App(
+                new PirTerm.App(
+                        new PirTerm.App(
+                                new PirTerm.App(new PirTerm.Builtin(fun), a), b), c), d);
     }
 
     // ---- Value factory methods ----

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/BlsLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/BlsLib.java
@@ -1,0 +1,127 @@
+package com.bloxbean.cardano.julc.stdlib.lib;
+
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+import java.math.BigInteger;
+
+/**
+ * BLS12-381 elliptic curve operations compiled from Java source to UPLC.
+ * <p>
+ * Provides ergonomic wrappers around the raw {@link Builtins} BLS12-381 stubs.
+ * On-chain, calls compile to the corresponding UPLC BLS12-381 builtins.
+ * <p>
+ * <b>Off-chain testing:</b> These methods throw {@link UnsupportedOperationException} when
+ * called directly on the JVM. To test code that uses this library:
+ * <ul>
+ *   <li>Use {@code JulcEval.forSource(...)} to compile and evaluate through the UPLC VM</li>
+ *   <li>Or mock these calls using a test framework such as Mockito</li>
+ * </ul>
+ */
+@OnchainLibrary
+public class BlsLib {
+
+    // ---- G1 operations ----
+
+    /** Add two G1 elements. */
+    public static byte[] g1Add(byte[] a, byte[] b) {
+        return Builtins.bls12_381_G1_add(a, b);
+    }
+
+    /** Negate a G1 element. */
+    public static byte[] g1Neg(byte[] a) {
+        return Builtins.bls12_381_G1_neg(a);
+    }
+
+    /** Scalar multiplication of a G1 element. */
+    public static byte[] g1ScalarMul(BigInteger scalar, byte[] g1) {
+        return Builtins.bls12_381_G1_scalarMul(scalar, g1);
+    }
+
+    /** Check equality of two G1 elements. */
+    public static boolean g1Equal(byte[] a, byte[] b) {
+        return Builtins.bls12_381_G1_equal(a, b);
+    }
+
+    /** Compress a G1 element to 48 bytes. */
+    public static byte[] g1Compress(byte[] g1) {
+        return Builtins.bls12_381_G1_compress(g1);
+    }
+
+    /** Uncompress a 48-byte compressed G1 element. */
+    public static byte[] g1Uncompress(byte[] compressed) {
+        return Builtins.bls12_381_G1_uncompress(compressed);
+    }
+
+    /** Hash a message to a G1 element using the given domain separation tag. */
+    public static byte[] g1HashToGroup(byte[] msg, byte[] dst) {
+        return Builtins.bls12_381_G1_hashToGroup(msg, dst);
+    }
+
+    // ---- G2 operations ----
+
+    /** Add two G2 elements. */
+    public static byte[] g2Add(byte[] a, byte[] b) {
+        return Builtins.bls12_381_G2_add(a, b);
+    }
+
+    /** Negate a G2 element. */
+    public static byte[] g2Neg(byte[] a) {
+        return Builtins.bls12_381_G2_neg(a);
+    }
+
+    /** Scalar multiplication of a G2 element. */
+    public static byte[] g2ScalarMul(BigInteger scalar, byte[] g2) {
+        return Builtins.bls12_381_G2_scalarMul(scalar, g2);
+    }
+
+    /** Check equality of two G2 elements. */
+    public static boolean g2Equal(byte[] a, byte[] b) {
+        return Builtins.bls12_381_G2_equal(a, b);
+    }
+
+    /** Compress a G2 element to 96 bytes. */
+    public static byte[] g2Compress(byte[] g2) {
+        return Builtins.bls12_381_G2_compress(g2);
+    }
+
+    /** Uncompress a 96-byte compressed G2 element. */
+    public static byte[] g2Uncompress(byte[] compressed) {
+        return Builtins.bls12_381_G2_uncompress(compressed);
+    }
+
+    /** Hash a message to a G2 element using the given domain separation tag. */
+    public static byte[] g2HashToGroup(byte[] msg, byte[] dst) {
+        return Builtins.bls12_381_G2_hashToGroup(msg, dst);
+    }
+
+    // ---- Pairing operations ----
+
+    /** Compute the Miller loop pairing of a G1 and G2 element. */
+    public static byte[] millerLoop(byte[] g1, byte[] g2) {
+        return Builtins.bls12_381_millerLoop(g1, g2);
+    }
+
+    /** Multiply two Miller loop results. */
+    public static byte[] mulMlResult(byte[] a, byte[] b) {
+        return Builtins.bls12_381_mulMlResult(a, b);
+    }
+
+    /** Final verification of two Miller loop results. Returns true if the pairing check passes. */
+    public static boolean finalVerify(byte[] a, byte[] b) {
+        return Builtins.bls12_381_finalVerify(a, b);
+    }
+
+    // ---- Multi-Scalar Multiplication ----
+
+    /** Multi-scalar multiplication on G1. Takes a list of scalars and a list of G1 elements. */
+    public static byte[] g1MultiScalarMul(PlutusData scalars, PlutusData points) {
+        return Builtins.bls12_381_G1_multiScalarMul(scalars, points);
+    }
+
+    /** Multi-scalar multiplication on G2. Takes a list of scalars and a list of G2 elements. */
+    public static byte[] g2MultiScalarMul(PlutusData scalars, PlutusData points) {
+        return Builtins.bls12_381_G2_multiScalarMul(scalars, points);
+    }
+}

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/NativeValueLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/NativeValueLib.java
@@ -1,0 +1,65 @@
+package com.bloxbean.cardano.julc.stdlib.lib;
+
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+/**
+ * Native MaryEra Value operations using PV11 builtins (CIP-153).
+ * <p>
+ * <b>Experimental PV11 API</b> — These operations use the native UPLC Value type
+ * introduced in protocol version 11. They will be merged into {@link ValuesLib}
+ * once the PV11 hard fork is complete. Until then, use these for PV11 testing
+ * and be prepared to migrate imports in a future release.
+ * <p>
+ * Unlike {@link ValuesLib} which operates on Map-encoded PlutusData, these methods
+ * operate on the native Value UPLC constant type. Use {@link #fromData(PlutusData)}
+ * to convert from Map encoding and {@link #toData(PlutusData)} to convert back.
+ * <p>
+ * <b>Off-chain testing:</b> These methods throw {@link UnsupportedOperationException} when
+ * called directly on the JVM. To test code that uses this library:
+ * <ul>
+ *   <li>Use {@code JulcEval.forSource(...)} to compile and evaluate through the UPLC VM</li>
+ *   <li>Or mock these calls using a test framework such as Mockito</li>
+ * </ul>
+ *
+ * @see ValuesLib
+ */
+@OnchainLibrary
+public class NativeValueLib {
+
+    /** Convert Map-encoded PlutusData to native Value. */
+    public static PlutusData fromData(PlutusData mapData) {
+        return Builtins.unValueData(mapData);
+    }
+
+    /** Convert native Value back to Map-encoded PlutusData. */
+    public static PlutusData toData(PlutusData value) {
+        return Builtins.valueData(value);
+    }
+
+    /** Insert or update a token quantity in a Value. */
+    public static PlutusData insertCoin(byte[] policyId, byte[] tokenName, long amount, PlutusData value) {
+        return Builtins.insertCoin(policyId, tokenName, amount, value);
+    }
+
+    /** Look up a token quantity. Returns 0 if absent. */
+    public static long lookupCoin(byte[] policyId, byte[] tokenName, PlutusData value) {
+        return Builtins.lookupCoin(policyId, tokenName, value);
+    }
+
+    /** Merge two Values by adding quantities. */
+    public static PlutusData union(PlutusData a, PlutusData b) {
+        return Builtins.unionValue(a, b);
+    }
+
+    /** Check if Value a contains at least Value b (a >= b element-wise). */
+    public static boolean contains(PlutusData a, PlutusData b) {
+        return Builtins.valueContains(a, b);
+    }
+
+    /** Scale all quantities by a scalar. */
+    public static PlutusData scale(long scalar, PlutusData value) {
+        return Builtins.scaleValue(scalar, value);
+    }
+}

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/BlsLibTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/BlsLibTest.java
@@ -1,0 +1,552 @@
+package com.bloxbean.cardano.julc.stdlib.lib;
+
+import com.bloxbean.cardano.julc.testkit.JulcEval;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link BlsLib} BLS12-381 operations.
+ * <p>
+ * BLS operations require proper UPLC element types (bls12_381_G1_element, etc.),
+ * not raw bytestrings. So we use inline Java source that chains operations:
+ * hashToGroup/uncompress to create elements, then test the target operation.
+ */
+class BlsLibTest {
+
+    // -- Shared source fragments --
+
+    private static final String IMPORTS = """
+            import com.bloxbean.cardano.julc.stdlib.Builtins;
+            import java.math.BigInteger;
+            """;
+
+    // ====== G1 Operations ======
+
+    @Nested
+    class G1Operations {
+
+        @Test
+        void g1HashToGroupProducesElement() {
+            // hashToGroup(msg, dst) → G1 element → compress → 48-byte bytestring
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test(byte[] msg, byte[] dst) {
+                            return Builtins.bls12_381_G1_compress(
+                                       Builtins.bls12_381_G1_hashToGroup(msg, dst));
+                        }
+                    }
+                    """);
+            byte[] result = eval.call("test", new byte[]{1, 2, 3}, new byte[]{}).asByteString();
+            assertEquals(48, result.length);
+        }
+
+        @Test
+        void g1AddCommutative() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(m1, dst);
+                            var b = Builtins.bls12_381_G1_hashToGroup(m2, dst);
+                            var ab = Builtins.bls12_381_G1_add(a, b);
+                            var ba = Builtins.bls12_381_G1_add(b, a);
+                            return Builtins.bls12_381_G1_equal(ab, ba);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{2}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g1NegInverse() {
+            // a + neg(a) == identity; compress(a + neg(a)) should equal compress(uncompress(identity))
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var negA = Builtins.bls12_381_G1_neg(a);
+                            var sum = Builtins.bls12_381_G1_add(a, negA);
+                            var negSum = Builtins.bls12_381_G1_neg(sum);
+                            var doubleNeg = Builtins.bls12_381_G1_add(sum, negSum);
+                            return Builtins.bls12_381_G1_equal(sum, doubleNeg);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g1EqualSameElement() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            return Builtins.bls12_381_G1_equal(a, a);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{42}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g1EqualDifferentElements() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(m1, dst);
+                            var b = Builtins.bls12_381_G1_hashToGroup(m2, dst);
+                            return Builtins.bls12_381_G1_equal(a, b);
+                        }
+                    }
+                    """);
+            assertFalse(eval.call("test", new byte[]{1}, new byte[]{2}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g1CompressUncompressRoundtrip() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var g1 = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var compressed = Builtins.bls12_381_G1_compress(g1);
+                            var uncompressed = Builtins.bls12_381_G1_uncompress(compressed);
+                            return Builtins.bls12_381_G1_equal(g1, uncompressed);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1, 2, 3}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g1CompressProduces48Bytes() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static BigInteger test(byte[] msg, byte[] dst) {
+                            var g1 = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var compressed = Builtins.bls12_381_G1_compress(g1);
+                            return BigInteger.valueOf(Builtins.lengthOfByteString(compressed));
+                        }
+                    }
+                    """);
+            assertEquals(48, eval.call("test", new byte[]{5}, new byte[]{}).asLong());
+        }
+
+        @Test
+        void g1ScalarMulByOne() {
+            // 1 * a == a
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var scaled = Builtins.bls12_381_G1_scalarMul(BigInteger.valueOf(1), a);
+                            return Builtins.bls12_381_G1_equal(a, scaled);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{7}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g1ScalarMulByTwo() {
+            // 2 * a == a + a
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var doubled = Builtins.bls12_381_G1_scalarMul(BigInteger.valueOf(2), a);
+                            var added = Builtins.bls12_381_G1_add(a, a);
+                            return Builtins.bls12_381_G1_equal(doubled, added);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{7}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g1DoubleNegIsIdentity() {
+            // neg(neg(a)) == a
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var nn = Builtins.bls12_381_G1_neg(Builtins.bls12_381_G1_neg(a));
+                            return Builtins.bls12_381_G1_equal(a, nn);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{3}, new byte[]{}).asBoolean());
+        }
+    }
+
+    // ====== G2 Operations ======
+
+    @Nested
+    class G2Operations {
+
+        @Test
+        void g2HashToGroupProducesElement() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test(byte[] msg, byte[] dst) {
+                            return Builtins.bls12_381_G2_compress(
+                                       Builtins.bls12_381_G2_hashToGroup(msg, dst));
+                        }
+                    }
+                    """);
+            byte[] result = eval.call("test", new byte[]{1, 2, 3}, new byte[]{}).asByteString();
+            assertEquals(96, result.length);
+        }
+
+        @Test
+        void g2AddCommutative() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] dst) {
+                            var a = Builtins.bls12_381_G2_hashToGroup(m1, dst);
+                            var b = Builtins.bls12_381_G2_hashToGroup(m2, dst);
+                            var ab = Builtins.bls12_381_G2_add(a, b);
+                            var ba = Builtins.bls12_381_G2_add(b, a);
+                            return Builtins.bls12_381_G2_equal(ab, ba);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{2}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g2EqualSameElement() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            return Builtins.bls12_381_G2_equal(a, a);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{42}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g2EqualDifferentElements() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] dst) {
+                            var a = Builtins.bls12_381_G2_hashToGroup(m1, dst);
+                            var b = Builtins.bls12_381_G2_hashToGroup(m2, dst);
+                            return Builtins.bls12_381_G2_equal(a, b);
+                        }
+                    }
+                    """);
+            assertFalse(eval.call("test", new byte[]{1}, new byte[]{2}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g2CompressUncompressRoundtrip() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var g2 = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            var compressed = Builtins.bls12_381_G2_compress(g2);
+                            var uncompressed = Builtins.bls12_381_G2_uncompress(compressed);
+                            return Builtins.bls12_381_G2_equal(g2, uncompressed);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1, 2, 3}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g2ScalarMulByOne() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            var scaled = Builtins.bls12_381_G2_scalarMul(BigInteger.valueOf(1), a);
+                            return Builtins.bls12_381_G2_equal(a, scaled);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{7}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g2ScalarMulByTwo() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            var doubled = Builtins.bls12_381_G2_scalarMul(BigInteger.valueOf(2), a);
+                            var added = Builtins.bls12_381_G2_add(a, a);
+                            return Builtins.bls12_381_G2_equal(doubled, added);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{7}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void g2DoubleNegIsIdentity() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            var nn = Builtins.bls12_381_G2_neg(Builtins.bls12_381_G2_neg(a));
+                            return Builtins.bls12_381_G2_equal(a, nn);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{3}, new byte[]{}).asBoolean());
+        }
+    }
+
+    // ====== Pairing Operations ======
+
+    @Nested
+    class PairingOperations {
+
+        @Test
+        void millerLoopProducesResult() {
+            // millerLoop(g1, g2) should produce a result that can be used in finalVerify
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] dst) {
+                            var g1 = Builtins.bls12_381_G1_hashToGroup(m1, dst);
+                            var g2 = Builtins.bls12_381_G2_hashToGroup(m2, dst);
+                            var ml = Builtins.bls12_381_millerLoop(g1, g2);
+                            return Builtins.bls12_381_finalVerify(ml, ml);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{2}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void mulMlResultAssociative() {
+            // mulMlResult(a, mulMlResult(b, c)) == mulMlResult(mulMlResult(a, b), c)
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] m3, byte[] dst) {
+                            var g1a = Builtins.bls12_381_G1_hashToGroup(m1, dst);
+                            var g2a = Builtins.bls12_381_G2_hashToGroup(m1, dst);
+                            var g1b = Builtins.bls12_381_G1_hashToGroup(m2, dst);
+                            var g2b = Builtins.bls12_381_G2_hashToGroup(m2, dst);
+                            var g1c = Builtins.bls12_381_G1_hashToGroup(m3, dst);
+                            var g2c = Builtins.bls12_381_G2_hashToGroup(m3, dst);
+                            var mlA = Builtins.bls12_381_millerLoop(g1a, g2a);
+                            var mlB = Builtins.bls12_381_millerLoop(g1b, g2b);
+                            var mlC = Builtins.bls12_381_millerLoop(g1c, g2c);
+                            var left = Builtins.bls12_381_mulMlResult(mlA,
+                                           Builtins.bls12_381_mulMlResult(mlB, mlC));
+                            var right = Builtins.bls12_381_mulMlResult(
+                                            Builtins.bls12_381_mulMlResult(mlA, mlB), mlC);
+                            return Builtins.bls12_381_finalVerify(left, right);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test",
+                    new byte[]{1}, new byte[]{2}, new byte[]{3}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void finalVerifyBilinearity() {
+            // e(a*G1, G2) == e(G1, a*G2) — bilinearity of pairing
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var g1 = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var g2 = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            var scalar = BigInteger.valueOf(7);
+                            var left = Builtins.bls12_381_millerLoop(
+                                           Builtins.bls12_381_G1_scalarMul(scalar, g1), g2);
+                            var right = Builtins.bls12_381_millerLoop(
+                                            g1, Builtins.bls12_381_G2_scalarMul(scalar, g2));
+                            return Builtins.bls12_381_finalVerify(left, right);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{10}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void finalVerifyDifferentPairingsFails() {
+            // e(a, b) != e(c, d) for different points
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] dst) {
+                            var g1a = Builtins.bls12_381_G1_hashToGroup(m1, dst);
+                            var g2a = Builtins.bls12_381_G2_hashToGroup(m1, dst);
+                            var g1b = Builtins.bls12_381_G1_hashToGroup(m2, dst);
+                            var g2b = Builtins.bls12_381_G2_hashToGroup(m2, dst);
+                            var mlA = Builtins.bls12_381_millerLoop(g1a, g2a);
+                            var mlB = Builtins.bls12_381_millerLoop(g1b, g2b);
+                            return Builtins.bls12_381_finalVerify(mlA, mlB);
+                        }
+                    }
+                    """);
+            assertFalse(eval.call("test", new byte[]{1}, new byte[]{2}, new byte[]{}).asBoolean());
+        }
+    }
+
+    // ====== BlsLib wrapper tests (via @OnchainLibrary compilation) ======
+
+    @Nested
+    class BlsLibWrappers {
+
+        @Test
+        void blsLibG1AddCompiles() {
+            // Verify BlsLib.g1Add compiles to correct UPLC and produces valid results
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    import java.math.BigInteger;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var b = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var result = BlsLib.g1Add(a, b);
+                            var expected = Builtins.bls12_381_G1_scalarMul(BigInteger.valueOf(2), a);
+                            return BlsLib.g1Equal(result, expected);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{5}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibG1NegCompiles() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var neg = BlsLib.g1Neg(a);
+                            var negNeg = BlsLib.g1Neg(neg);
+                            return BlsLib.g1Equal(a, negNeg);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{9}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibG1ScalarMulCompiles() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    import java.math.BigInteger;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var tripled = BlsLib.g1ScalarMul(BigInteger.valueOf(3), a);
+                            var added = BlsLib.g1Add(BlsLib.g1Add(a, a), a);
+                            return BlsLib.g1Equal(tripled, added);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{4}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibG1CompressUncompressCompiles() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var g1 = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var roundtripped = BlsLib.g1Uncompress(BlsLib.g1Compress(g1));
+                            return BlsLib.g1Equal(g1, roundtripped);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibG2AddCompiles() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    import java.math.BigInteger;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            var result = BlsLib.g2Add(a, a);
+                            var expected = BlsLib.g2ScalarMul(BigInteger.valueOf(2), a);
+                            return BlsLib.g2Equal(result, expected);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{5}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibMillerLoopAndFinalVerifyCompile() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    import java.math.BigInteger;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var g1 = Builtins.bls12_381_G1_hashToGroup(msg, dst);
+                            var g2 = Builtins.bls12_381_G2_hashToGroup(msg, dst);
+                            var ml = BlsLib.millerLoop(g1, g2);
+                            return BlsLib.finalVerify(ml, ml);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibMulMlResultCompiles() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    class T {
+                        static boolean test(byte[] m1, byte[] m2, byte[] dst) {
+                            var g1a = Builtins.bls12_381_G1_hashToGroup(m1, dst);
+                            var g2a = Builtins.bls12_381_G2_hashToGroup(m1, dst);
+                            var g1b = Builtins.bls12_381_G1_hashToGroup(m2, dst);
+                            var g2b = Builtins.bls12_381_G2_hashToGroup(m2, dst);
+                            var mlA = BlsLib.millerLoop(g1a, g2a);
+                            var mlB = BlsLib.millerLoop(g1b, g2b);
+                            var combined = BlsLib.mulMlResult(mlA, mlB);
+                            return BlsLib.finalVerify(combined, combined);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{2}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibG1HashToGroupCompiles() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = BlsLib.g1HashToGroup(msg, dst);
+                            return BlsLib.g1Equal(a, a);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{}).asBoolean());
+        }
+
+        @Test
+        void blsLibG2HashToGroupCompiles() {
+            var eval = JulcEval.forSource("""
+                    import com.bloxbean.cardano.julc.stdlib.lib.BlsLib;
+                    class T {
+                        static boolean test(byte[] msg, byte[] dst) {
+                            var a = BlsLib.g2HashToGroup(msg, dst);
+                            return BlsLib.g2Equal(a, a);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{}).asBoolean());
+        }
+    }
+}

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/JulcArrayTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/JulcArrayTest.java
@@ -1,0 +1,357 @@
+package com.bloxbean.cardano.julc.stdlib.lib;
+
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.types.JulcArray;
+import com.bloxbean.cardano.julc.core.types.JulcArrayImpl;
+import com.bloxbean.cardano.julc.core.types.JulcList;
+import com.bloxbean.cardano.julc.testkit.JulcEval;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link JulcArray} — PV11 array operations (CIP-156).
+ * On-chain tests use JulcEval to compile and evaluate through the UPLC VM.
+ * Off-chain tests use JulcArrayImpl directly.
+ */
+class JulcArrayTest {
+
+    private static final String IMPORTS = """
+            import com.bloxbean.cardano.julc.stdlib.Builtins;
+            import com.bloxbean.cardano.julc.core.PlutusData;
+            import java.math.BigInteger;
+            """;
+
+    @Nested
+    class OnChainTests {
+
+        @Nested
+        class FromListAndLength {
+
+            @Test
+            void emptyListProducesZeroLength() {
+                // ListToArray operates on UPLC lists, unwrap Data first
+                var eval = JulcEval.forSource(IMPORTS + """
+                        class T {
+                            static BigInteger test(PlutusData data) {
+                                var list = Builtins.unListData(data);
+                                var arr = Builtins.listToArray(list);
+                                return BigInteger.valueOf(Builtins.lengthOfArray(arr));
+                            }
+                        }
+                        """);
+                var empty = new PlutusData.ListData(List.of());
+                assertEquals(0, eval.call("test", empty).asLong());
+            }
+
+            @Test
+            void singleElementLength() {
+                var eval = JulcEval.forSource(IMPORTS + """
+                        class T {
+                            static BigInteger test(PlutusData data) {
+                                var list = Builtins.unListData(data);
+                                var arr = Builtins.listToArray(list);
+                                return BigInteger.valueOf(Builtins.lengthOfArray(arr));
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(42))));
+                assertEquals(1, eval.call("test", list).asLong());
+            }
+
+            @Test
+            void multipleElementLength() {
+                var eval = JulcEval.forSource(IMPORTS + """
+                        class T {
+                            static BigInteger test(PlutusData data) {
+                                var list = Builtins.unListData(data);
+                                var arr = Builtins.listToArray(list);
+                                return BigInteger.valueOf(Builtins.lengthOfArray(arr));
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(1)),
+                        new PlutusData.IntData(BigInteger.valueOf(2)),
+                        new PlutusData.IntData(BigInteger.valueOf(3))));
+                assertEquals(3, eval.call("test", list).asLong());
+            }
+        }
+
+        @Nested
+        class IndexAccess {
+
+            @Test
+            void firstElement() {
+                var eval = JulcEval.forSource(IMPORTS + """
+                        class T {
+                            static BigInteger test(PlutusData data) {
+                                var list = Builtins.unListData(data);
+                                var arr = Builtins.listToArray(list);
+                                return Builtins.unIData(Builtins.indexArray(arr, 0));
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(10)),
+                        new PlutusData.IntData(BigInteger.valueOf(20)),
+                        new PlutusData.IntData(BigInteger.valueOf(30))));
+                assertEquals(10, eval.call("test", list).asLong());
+            }
+
+            @Test
+            void lastElement() {
+                var eval = JulcEval.forSource(IMPORTS + """
+                        class T {
+                            static BigInteger test(PlutusData data) {
+                                var list = Builtins.unListData(data);
+                                var arr = Builtins.listToArray(list);
+                                return Builtins.unIData(Builtins.indexArray(arr, 2));
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(10)),
+                        new PlutusData.IntData(BigInteger.valueOf(20)),
+                        new PlutusData.IntData(BigInteger.valueOf(30))));
+                assertEquals(30, eval.call("test", list).asLong());
+            }
+
+            @Test
+            void middleElement() {
+                var eval = JulcEval.forSource(IMPORTS + """
+                        class T {
+                            static BigInteger test(PlutusData data) {
+                                var list = Builtins.unListData(data);
+                                var arr = Builtins.listToArray(list);
+                                return Builtins.unIData(Builtins.indexArray(arr, 1));
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(10)),
+                        new PlutusData.IntData(BigInteger.valueOf(20)),
+                        new PlutusData.IntData(BigInteger.valueOf(30))));
+                assertEquals(20, eval.call("test", list).asLong());
+            }
+        }
+
+        @Nested
+        class MultiIndex {
+
+            @Test
+            @org.junit.jupiter.api.Disabled("MultiIndexArray not yet supported by Scalus VM backend — works with julc-vm-java")
+            void selectMultiple() {
+                var eval = JulcEval.forSource(IMPORTS + """
+                        class T {
+                            static BigInteger test(PlutusData data) {
+                                var list = Builtins.unListData(data);
+                                var arr = Builtins.listToArray(list);
+                                var indices = Builtins.mkCons(
+                                    Builtins.iData(0),
+                                    Builtins.mkCons(Builtins.iData(2), Builtins.mkNilData()));
+                                var result = Builtins.multiIndexArray(arr, indices);
+                                var first = Builtins.unIData(Builtins.headList(result));
+                                var rest = Builtins.tailList(result);
+                                var second = Builtins.unIData(Builtins.headList(rest));
+                                return first.add(second);
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(10)),
+                        new PlutusData.IntData(BigInteger.valueOf(20)),
+                        new PlutusData.IntData(BigInteger.valueOf(30))));
+                // arr[0] + arr[2] = 10 + 30 = 40
+                assertEquals(40, eval.call("test", list).asLong());
+            }
+        }
+
+        @Nested
+        class TypedArrayOps {
+
+            @Test
+            void toArrayFromListCompiles() {
+                // Uses JulcList.toArray() → ListToArray builtin
+                var eval = JulcEval.forSource("""
+                        import com.bloxbean.cardano.julc.stdlib.Builtins;
+                        import com.bloxbean.cardano.julc.core.PlutusData;
+                        import com.bloxbean.cardano.julc.core.types.JulcList;
+                        import com.bloxbean.cardano.julc.core.types.JulcArray;
+                        import java.math.BigInteger;
+                        class T {
+                            static BigInteger test(JulcList<BigInteger> list) {
+                                JulcArray<BigInteger> arr = list.toArray();
+                                return arr.get(0);
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(99))));
+                assertEquals(99, eval.call("test", list).asLong());
+            }
+
+            @Test
+            void fromListStaticFactory() {
+                var eval = JulcEval.forSource("""
+                        import com.bloxbean.cardano.julc.stdlib.Builtins;
+                        import com.bloxbean.cardano.julc.core.PlutusData;
+                        import com.bloxbean.cardano.julc.core.types.JulcList;
+                        import com.bloxbean.cardano.julc.core.types.JulcArray;
+                        import java.math.BigInteger;
+                        class T {
+                            static BigInteger test(JulcList<BigInteger> list) {
+                                JulcArray<BigInteger> arr = JulcArray.fromList(list);
+                                return BigInteger.valueOf(arr.length());
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(1)),
+                        new PlutusData.IntData(BigInteger.valueOf(2))));
+                assertEquals(2, eval.call("test", list).asLong());
+            }
+
+            @Test
+            void typedGetAtNonZeroIndex() {
+                // Tests TypeMethodRegistry dispatch for arr.get(1) and arr.get(2) with typed array
+                var eval = JulcEval.forSource("""
+                        import com.bloxbean.cardano.julc.stdlib.Builtins;
+                        import com.bloxbean.cardano.julc.core.PlutusData;
+                        import com.bloxbean.cardano.julc.core.types.JulcList;
+                        import com.bloxbean.cardano.julc.core.types.JulcArray;
+                        import java.math.BigInteger;
+                        class T {
+                            static BigInteger test(JulcList<BigInteger> list) {
+                                JulcArray<BigInteger> arr = list.toArray();
+                                BigInteger second = arr.get(1);
+                                BigInteger third = arr.get(2);
+                                return second.add(third);
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(10)),
+                        new PlutusData.IntData(BigInteger.valueOf(20)),
+                        new PlutusData.IntData(BigInteger.valueOf(30))));
+                assertEquals(50, eval.call("test", list).asLong());
+            }
+
+            @Test
+            void fromListThenGetPropagatesElementType() {
+                // Tests element-type propagation through JulcArray.fromList() static factory + wrapDecode
+                var eval = JulcEval.forSource("""
+                        import com.bloxbean.cardano.julc.stdlib.Builtins;
+                        import com.bloxbean.cardano.julc.core.PlutusData;
+                        import com.bloxbean.cardano.julc.core.types.JulcList;
+                        import com.bloxbean.cardano.julc.core.types.JulcArray;
+                        import java.math.BigInteger;
+                        class T {
+                            static BigInteger test(JulcList<BigInteger> list) {
+                                JulcArray<BigInteger> arr = JulcArray.fromList(list);
+                                return arr.get(0);
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(42))));
+                assertEquals(42, eval.call("test", list).asLong());
+            }
+
+            @Test
+            void arrayLengthTyped() {
+                var eval = JulcEval.forSource("""
+                        import com.bloxbean.cardano.julc.stdlib.Builtins;
+                        import com.bloxbean.cardano.julc.core.PlutusData;
+                        import com.bloxbean.cardano.julc.core.types.JulcList;
+                        import com.bloxbean.cardano.julc.core.types.JulcArray;
+                        import java.math.BigInteger;
+                        class T {
+                            static BigInteger test(JulcList<BigInteger> list) {
+                                JulcArray<BigInteger> arr = list.toArray();
+                                return BigInteger.valueOf(arr.length());
+                            }
+                        }
+                        """);
+                var list = new PlutusData.ListData(List.of(
+                        new PlutusData.IntData(BigInteger.valueOf(1)),
+                        new PlutusData.IntData(BigInteger.valueOf(2)),
+                        new PlutusData.IntData(BigInteger.valueOf(3))));
+                assertEquals(3, eval.call("test", list).asLong());
+            }
+        }
+    }
+
+    @Nested
+    class OffChainTests {
+
+        @Test
+        void getReturnsCorrectElement() {
+            JulcList<Integer> list = JulcList.of(10, 20, 30);
+            JulcArray<Integer> arr = JulcArray.fromList(list);
+            assertEquals(20, arr.get(1));
+        }
+
+        @Test
+        void lengthReturnsCount() {
+            JulcList<String> list = JulcList.of("a", "b", "c");
+            JulcArray<String> arr = JulcArray.fromList(list);
+            assertEquals(3, arr.length());
+        }
+
+        @Test
+        void emptyArrayHasZeroLength() {
+            JulcList<Integer> empty = JulcList.empty();
+            JulcArray<Integer> arr = JulcArray.fromList(empty);
+            assertEquals(0, arr.length());
+        }
+
+        @Test
+        void firstAndLastElement() {
+            JulcList<Integer> list = JulcList.of(100, 200, 300);
+            JulcArray<Integer> arr = JulcArray.fromList(list);
+            assertEquals(100, arr.get(0));
+            assertEquals(300, arr.get(2));
+        }
+
+        @Test
+        void toArrayFromJulcList() {
+            JulcList<Integer> list = JulcList.of(5, 10, 15);
+            JulcArray<Integer> arr = list.toArray();
+            assertEquals(3, arr.length());
+            assertEquals(10, arr.get(1));
+        }
+
+        @Test
+        void equalsForSameElements() {
+            JulcArray<Integer> a = JulcArray.fromList(JulcList.of(1, 2, 3));
+            JulcArray<Integer> b = JulcArray.fromList(JulcList.of(1, 2, 3));
+            assertEquals(a, b);
+        }
+
+        @Test
+        void notEqualsForDifferentElements() {
+            JulcArray<Integer> a = JulcArray.fromList(JulcList.of(1, 2, 3));
+            JulcArray<Integer> b = JulcArray.fromList(JulcList.of(1, 2, 4));
+            assertNotEquals(a, b);
+        }
+
+        @Test
+        void hashCodeConsistentWithEquals() {
+            JulcArray<Integer> a = JulcArray.fromList(JulcList.of(10, 20));
+            JulcArray<Integer> b = JulcArray.fromList(JulcList.of(10, 20));
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        void getThrowsOnOutOfBounds() {
+            JulcArray<Integer> arr = JulcArray.fromList(JulcList.of(1, 2));
+            assertThrows(IndexOutOfBoundsException.class, () -> arr.get(5));
+        }
+    }
+}

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/NativeValueLibTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/NativeValueLibTest.java
@@ -1,0 +1,259 @@
+package com.bloxbean.cardano.julc.stdlib.lib;
+
+import com.bloxbean.cardano.julc.testkit.JulcEval;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link NativeValueLib} — PV11 MaryEraValue operations (CIP-153).
+ * All tests use JulcEval to compile and evaluate through the UPLC VM,
+ * since Value is a native UPLC constant type.
+ */
+class NativeValueLibTest {
+
+    private static final String IMPORTS =
+            "import com.bloxbean.cardano.julc.stdlib.Builtins;\n"
+            + "import com.bloxbean.cardano.julc.core.PlutusData;\n"
+            + "import java.math.BigInteger;\n";
+
+    // Empty Value = unValueData(mapData(mkNilPairData()))
+    private static final String EV = "Builtins.unValueData(Builtins.mapData(Builtins.mkNilPairData()))";
+
+    private static String src(String body) {
+        return IMPORTS + "class T {\n" + body + "\n}\n";
+    }
+
+    @Nested
+    class InsertAndLookup {
+
+        @Test
+        void insertThenLookup() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = Builtins.insertCoin(policy, token, 100, empty);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, value));"
+                    + "}"));
+            assertEquals(100, eval.call("test", new byte[]{1, 2, 3}, new byte[]{4, 5}).asLong());
+        }
+
+        @Test
+        void lookupMissing() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, empty));"
+                    + "}"));
+            assertEquals(0, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+
+        @Test
+        void lookupAbsentTokenInPresentPolicy() {
+            // Policy exists with token {4,5} but lookup uses different token {6,7}
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token, byte[] otherToken) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = Builtins.insertCoin(policy, token, 100, empty);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, otherToken, value));"
+                    + "}"));
+            assertEquals(0, eval.call("test", new byte[]{1, 2, 3}, new byte[]{4, 5}, new byte[]{6, 7}).asLong());
+        }
+
+        @Test
+        void insertOverwrite() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var v1 = Builtins.insertCoin(policy, token, 50, empty);"
+                    + "  var v2 = Builtins.insertCoin(policy, token, 200, v1);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, v2));"
+                    + "}"));
+            assertEquals(200, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+    }
+
+    @Nested
+    class UnionAndContains {
+
+        @Test
+        void unionMerges() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var a = Builtins.insertCoin(policy, token, 30, empty);"
+                    + "  var b = Builtins.insertCoin(policy, token, 70, empty);"
+                    + "  var merged = Builtins.unionValue(a, b);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, merged));"
+                    + "}"));
+            assertEquals(100, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+
+        @Test
+        void containsSelf() {
+            var eval = JulcEval.forSource(src(
+                    "static boolean test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = Builtins.insertCoin(policy, token, 50, empty);"
+                    + "  return Builtins.valueContains(value, value);"
+                    + "}"));
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{2}).asBoolean());
+        }
+
+        @Test
+        void containsSmaller() {
+            var eval = JulcEval.forSource(src(
+                    "static boolean test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var bigger = Builtins.insertCoin(policy, token, 100, empty);"
+                    + "  var smaller = Builtins.insertCoin(policy, token, 50, empty);"
+                    + "  return Builtins.valueContains(bigger, smaller);"
+                    + "}"));
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{2}).asBoolean());
+        }
+
+        @Test
+        void doesNotContainLarger() {
+            var eval = JulcEval.forSource(src(
+                    "static boolean test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var smaller = Builtins.insertCoin(policy, token, 50, empty);"
+                    + "  var bigger = Builtins.insertCoin(policy, token, 100, empty);"
+                    + "  return Builtins.valueContains(smaller, bigger);"
+                    + "}"));
+            assertFalse(eval.call("test", new byte[]{1}, new byte[]{2}).asBoolean());
+        }
+    }
+
+    @Nested
+    class ScaleValueTests {
+
+        @Test
+        void scaleByTwo() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = Builtins.insertCoin(policy, token, 50, empty);"
+                    + "  var scaled = Builtins.scaleValue(2, value);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, scaled));"
+                    + "}"));
+            assertEquals(100, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+
+        @Test
+        void scaleByZero() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = Builtins.insertCoin(policy, token, 50, empty);"
+                    + "  var scaled = Builtins.scaleValue(0, value);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, scaled));"
+                    + "}"));
+            assertEquals(0, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+
+        @Test
+        void scaleByNegativeOne() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = Builtins.insertCoin(policy, token, 50, empty);"
+                    + "  var scaled = Builtins.scaleValue(-1, value);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, scaled));"
+                    + "}"));
+            assertEquals(-50, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+    }
+
+    @Nested
+    class DataRoundtrip {
+
+        @Test
+        void valueToDataAndBack() {
+            var eval = JulcEval.forSource(src(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = Builtins.insertCoin(policy, token, 42, empty);"
+                    + "  var data = Builtins.valueData(value);"
+                    + "  var restored = Builtins.unValueData(data);"
+                    + "  return BigInteger.valueOf(Builtins.lookupCoin(policy, token, restored));"
+                    + "}"));
+            assertEquals(42, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+    }
+
+    @Nested
+    class NativeValueLibWrappers {
+
+        private static final String LIB_IMPORTS =
+                "import com.bloxbean.cardano.julc.stdlib.Builtins;\n"
+                + "import com.bloxbean.cardano.julc.stdlib.lib.NativeValueLib;\n"
+                + "import com.bloxbean.cardano.julc.core.PlutusData;\n"
+                + "import java.math.BigInteger;\n";
+
+        private static String libSrc(String body) {
+            return LIB_IMPORTS + "class T {\n" + body + "\n}\n";
+        }
+
+        @Test
+        void insertCoinCompiles() {
+            var eval = JulcEval.forSource(libSrc(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var value = NativeValueLib.insertCoin(policy, token, 77, empty);"
+                    + "  return BigInteger.valueOf(NativeValueLib.lookupCoin(policy, token, value));"
+                    + "}"));
+            assertEquals(77, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+
+        @Test
+        void unionCompiles() {
+            var eval = JulcEval.forSource(libSrc(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var a = NativeValueLib.insertCoin(policy, token, 10, empty);"
+                    + "  var b = NativeValueLib.insertCoin(policy, token, 20, empty);"
+                    + "  var merged = NativeValueLib.union(a, b);"
+                    + "  return BigInteger.valueOf(NativeValueLib.lookupCoin(policy, token, merged));"
+                    + "}"));
+            assertEquals(30, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+
+        @Test
+        void containsCompiles() {
+            var eval = JulcEval.forSource(libSrc(
+                    "static boolean test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var v = NativeValueLib.insertCoin(policy, token, 50, empty);"
+                    + "  return NativeValueLib.contains(v, v);"
+                    + "}"));
+            assertTrue(eval.call("test", new byte[]{1}, new byte[]{2}).asBoolean());
+        }
+
+        @Test
+        void scaleCompiles() {
+            var eval = JulcEval.forSource(libSrc(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var v = NativeValueLib.insertCoin(policy, token, 25, empty);"
+                    + "  var scaled = NativeValueLib.scale(3, v);"
+                    + "  return BigInteger.valueOf(NativeValueLib.lookupCoin(policy, token, scaled));"
+                    + "}"));
+            assertEquals(75, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+
+        @Test
+        void fromDataToDataRoundtrip() {
+            var eval = JulcEval.forSource(libSrc(
+                    "static BigInteger test(byte[] policy, byte[] token) {"
+                    + "  var empty = " + EV + ";"
+                    + "  var v = NativeValueLib.insertCoin(policy, token, 99, empty);"
+                    + "  var data = NativeValueLib.toData(v);"
+                    + "  var restored = NativeValueLib.fromData(data);"
+                    + "  return BigInteger.valueOf(NativeValueLib.lookupCoin(policy, token, restored));"
+                    + "}"));
+            assertEquals(99, eval.call("test", new byte[]{1}, new byte[]{2}).asLong());
+        }
+    }
+}

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/Pv11BuiltinsTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/Pv11BuiltinsTest.java
@@ -1,0 +1,98 @@
+package com.bloxbean.cardano.julc.stdlib.lib;
+
+import com.bloxbean.cardano.julc.testkit.JulcEval;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for PV11 Batch 6 builtins exposed through {@link com.bloxbean.cardano.julc.stdlib.Builtins}.
+ */
+class Pv11BuiltinsTest {
+
+    private static final String IMPORTS = """
+            import com.bloxbean.cardano.julc.stdlib.Builtins;
+            import com.bloxbean.cardano.julc.core.PlutusData;
+            import java.math.BigInteger;
+            """;
+
+    @Nested
+    class DropList {
+
+        @Test
+        void dropZero() {
+            // DropList operates on UPLC lists, so we pass Data and unListData inside
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static BigInteger test(PlutusData data) {
+                            var list = Builtins.unListData(data);
+                            var result = Builtins.dropList(0, list);
+                            return Builtins.unIData(Builtins.headList(result));
+                        }
+                    }
+                    """);
+            var list = new com.bloxbean.cardano.julc.core.PlutusData.ListData(java.util.List.of(
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(1)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(2)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(3))));
+            assertEquals(1, eval.call("test", list).asLong());
+        }
+
+        @Test
+        void dropSome() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static BigInteger test(PlutusData data) {
+                            var list = Builtins.unListData(data);
+                            var result = Builtins.dropList(2, list);
+                            return Builtins.unIData(Builtins.headList(result));
+                        }
+                    }
+                    """);
+            var list = new com.bloxbean.cardano.julc.core.PlutusData.ListData(java.util.List.of(
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(1)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(2)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(3)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(4))));
+            assertEquals(3, eval.call("test", list).asLong());
+        }
+
+        @Test
+        void dropAll() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(PlutusData data) {
+                            var list = Builtins.unListData(data);
+                            var result = Builtins.dropList(100, list);
+                            return Builtins.nullList(result);
+                        }
+                    }
+                    """);
+            var list = new com.bloxbean.cardano.julc.core.PlutusData.ListData(java.util.List.of(
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(1)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(2)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(3))));
+            assertTrue(eval.call("test", list).asBoolean());
+        }
+
+        @Test
+        void dropExactListSize() {
+            // Boundary: drop exactly list.size() elements → empty list
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(PlutusData data) {
+                            var list = Builtins.unListData(data);
+                            var result = Builtins.dropList(3, list);
+                            return Builtins.nullList(result);
+                        }
+                    }
+                    """);
+            var list = new com.bloxbean.cardano.julc.core.PlutusData.ListData(java.util.List.of(
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(1)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(2)),
+                    new com.bloxbean.cardano.julc.core.PlutusData.IntData(java.math.BigInteger.valueOf(3))));
+            assertTrue(eval.call("test", list).asBoolean());
+        }
+    }
+}


### PR DESCRIPTION
- Add 12 PV11 builtin stubs in Builtins.java: DropList (CIP-158), JulcArray ops (CIP-156), MaryEraValue ops (CIP-153)
 - Add JulcArray<T> typed interface + JulcArrayImpl off-chain impl
 - Add ArrayType to PirType + TypeResolver + TypeMethodRegistry dispatch
 - Add NativeValueLib @onchainlibrary for native Value operations
 - Add BlsLib @onchainlibrary wrapping BLS12-381 builtins
 - Register all PV11 builtins in StdlibRegistry (including 4-arg InsertCoin)
 - Add forceCount entries for 5 polymorphic PV11 builtins in UplcGenerator
 - Add inferBuiltinReturnType entries for PV11 ops in PirGenerator
 - Add JulcList.toArray() default method
 - New tests (JulcArrayTest, NativeValueLibTest, Pv11BuiltinsTest)
 - BLS12-381 test suite (BlsLibTest)
 - Off-chain testing guidance Javadoc on NativeValueLib and BlsLib