### PR TITLE
Add REPL, builtin trace diagnostics, and CLI/testkit enhancements     

### DIFF
--- a/docs/source-maps.md
+++ b/docs/source-maps.md
@@ -16,6 +16,9 @@ generated them.
 - [Enabling Source Maps](#enabling-source-maps) — Gradle plugin, annotation processor, programmatic
 - [Usage Patterns](#usage-patterns) — ContractTest, assertions, logging
 - [Execution Tracing](#execution-tracing) — step-by-step trace with budget per line
+- [Builtin Trace](#builtin-trace) — lightweight failure diagnostics
+- [Failure Reports](#failure-reports) — structured diagnostic objects
+- [Choosing the Right Diagnostic Level](#choosing-the-right-diagnostic-level)
 - [Using with QuickTxBuilder](#using-with-quicktxbuilder-julctransactionevaluator) — cardano-client-lib integration
 - [What Gets Mapped](#what-gets-mapped) — which Java constructs produce source map entries
 - [How It Works](#how-it-works) — SourceMap internals
@@ -318,6 +321,195 @@ cost descending — making it easy to find optimization targets.
 
 ---
 
+## Builtin Trace
+
+Builtin trace records the **last 20 builtin function executions** in a ring buffer — function
+name, arguments, and result. It answers **"what values caused the failure?"**, complementary
+to source maps ("where?") and execution tracing ("what path?").
+
+Key properties:
+- **Always on** by default — no compile-time or runtime flags needed
+- **Negligible overhead** — ring buffer of 20 entries, lazy string formatting (hot path stores raw refs)
+- **No source map required** — useful for pre-compiled `.plutus` files in the CLI
+- **SPI-agnostic** — works with any VM backend (uses string summaries, not impl-specific types)
+
+### Comparison
+
+| Aspect | Source Map | Builtin Trace | Execution Trace |
+|--------|-----------|---------------|-----------------|
+| Answers | Where did it fail? | What values caused it? | What path did execution take? |
+| Overhead | Compile-time only | Negligible (ring buffer) | Heavy (per-step recording) |
+| Opt-in | Compile with sourceMap=true | **Always on** (default) | Enable tracing + source map |
+| Output | `MyValidator.java:42` | `EqualsInteger(5, 3) → False` | Full step-by-step trace |
+| Use case | Locate error in source | Quick failure diagnosis | Budget profiling |
+
+### Usage from each entry point
+
+#### JulcEval (fluent API)
+
+```java
+var eval = JulcEval.forClass(MyValidator.class).builtinTrace();
+eval.call("validate", data).asBoolean();
+// On failure: rich FailureReport in exception message
+// After any call:
+List<BuiltinExecution> trace = eval.getLastBuiltinTrace();
+```
+
+> **Note:** `.builtinTrace()` is an alias for `.sourceMap()` — it communicates intent. Builtin
+> trace is always collected regardless.
+
+#### ValidatorTest (static API)
+
+```java
+// Lightweight: builtin trace only (no execution tracing overhead)
+var traced = ValidatorTest.evaluateWithBuiltinTrace(compiled, args);
+traced.builtinTrace(); // → List<BuiltinExecution>
+
+// Lightweight diagnostics: returns FailureReport on failure
+FailureReport report = ValidatorTest.evaluateWithBuiltinDiagnostics(compiled, args);
+if (report != null) System.out.println(FailureReportFormatter.format(report));
+
+// Full diagnostics: both execution trace + builtin trace
+FailureReport report = ValidatorTest.evaluateWithDiagnostics(compiled, args);
+
+// Assert with rich error message on failure
+ValidatorTest.assertValidatesWithDiagnostics(compiled, args);
+```
+
+#### ContractTest (instance methods)
+
+```java
+class MyTest extends ContractTest {
+    @Test void test() {
+        var compiled = compileValidatorWithSourceMap(MyValidator.class);
+
+        // Lightweight eval (no execution tracing)
+        var result = evaluateWithBuiltinTrace(compiled, ctx);
+
+        // Access builtin trace from shared VM
+        List<BuiltinExecution> trace = getLastBuiltinTrace();
+        for (var exec : trace) {
+            System.out.println(exec); // EqualsInteger(5, 3) → False
+        }
+    }
+}
+```
+
+#### CLI (`julc eval`)
+
+```bash
+$ julc eval my-validator.plutus
+FAIL: Error term encountered
+  EqualsInteger(5, 3) → False
+
+  Last builtins:
+    UnIData(<Data>) → 5
+    UnIData(<Data>) → 3
+    EqualsInteger(5, 3) → False
+
+  Budget: CPU=1,234,567  Mem=45,678
+```
+
+The CLI automatically collects builtin trace and uses `AnsiFailureReportFormatter` for
+colored terminal output.
+
+#### Programmatic (JulcVm directly)
+
+```java
+var vm = JulcVm.create();
+EvalResult result = vm.evaluateWithArgs(program, List.of(args));
+
+// Always available after evaluation
+List<BuiltinExecution> trace = vm.getLastBuiltinTrace();
+
+// Optionally disable (if overhead matters in tight loops)
+vm.setBuiltinTraceEnabled(false);
+```
+
+### Advantages
+
+- Zero configuration — always collected, no compile-time or runtime flags needed
+- Negligible overhead — ring buffer of 20 entries, lazy string formatting
+- Pinpoints the **exact comparison that failed** — `findCauseBuiltin()` scans backwards for
+  False-returning comparisons (`EqualsInteger`, `LessThanInteger`, `EqualsByteString`, etc.)
+- Works without source maps — useful for pre-compiled `.plutus` files
+- SPI-agnostic — works with any VM backend
+
+### Limitations
+
+- Only last 20 builtins — earlier operations are lost (ring buffer)
+- No source location per builtin — builtins aren't mapped to Java lines (use source map for that)
+- Values are summarized — ByteStrings truncated to 16 hex chars, strings to 20 chars, complex
+  values shown as `<Data>`, `[N elems]`, `<Pair>`
+- Cannot be disabled per-call from testkit APIs (always collected if VM supports it; disable via
+  `JulcVm.setBuiltinTraceEnabled(false)`)
+
+---
+
+## Failure Reports
+
+`FailureReport` is a structured record that bundles all diagnostic context for a failed
+evaluation: error message, source location, last builtins, execution trace, budget, and
+trace messages.
+
+### Building a FailureReport
+
+`FailureReportBuilder.build()` constructs a report from an evaluation result and optional traces:
+
+```java
+FailureReport report = FailureReportBuilder.build(result, sourceMap, executionTrace, builtinTrace);
+
+// Convenience overloads:
+FailureReport report = FailureReportBuilder.build(result, sourceMap);  // no traces
+FailureReport report = FailureReportBuilder.build(result);             // no source map or traces
+```
+
+Returns `null` if the result is a `Success`.
+
+### Formatting
+
+`FailureReportFormatter.format(report)` produces plain text output:
+
+```
+FAIL at .(VestingValidator.java:42)  return deadline <= currentSlot
+  LessThanEqualsInteger(5, 3) → False
+
+  Last builtins:
+    UnIData(<Data>) → 5
+    UnIData(<Data>) → 3
+    LessThanEqualsInteger(5, 3) → False
+
+  Budget: CPU=1,234,567  Mem=45,678
+```
+
+The header shows the source location (if available) or the error message. The highlighted
+"cause" line is the last comparison builtin that returned `False`, identified by
+`report.findCauseBuiltin()`.
+
+For CLI output, `AnsiFailureReportFormatter` adds ANSI colors: `FAIL` in red, builtin names
+in cyan, `→ False` in red, `→ True` in green, budget in dim.
+
+---
+
+## Choosing the Right Diagnostic Level
+
+From lightest to heaviest:
+
+1. **No diagnostics** — `ValidatorTest.evaluate()` / `ContractTest.evaluate()` — fastest,
+   just success/failure + budget
+2. **Builtin trace only** — `evaluateWithBuiltinTrace()` — adds "what values failed?"
+   at negligible cost
+3. **Builtin diagnostics** — `evaluateWithBuiltinDiagnostics()` — returns structured
+   `FailureReport` with source location + builtins
+4. **Full diagnostics** — `evaluateWithDiagnostics()` — adds per-step execution trace
+   for budget profiling
+
+> **Note:** Builtin trace is always collected by the VM (enabled by default). The difference
+> between levels 1 and 2 is whether you *retrieve* the trace, not whether it's *recorded*.
+> For zero-overhead production evaluation, disable with `vm.setBuiltinTraceEnabled(false)`.
+
+---
+
 ## Using with QuickTxBuilder (JulcTransactionEvaluator)
 
 For offchain integration with cardano-client-lib's `QuickTxBuilder`, use
@@ -504,6 +696,53 @@ ExecutionTraceEntry.formatSummary(entries)   // → String (multi-line, with vis
 // toString() uses IntelliJ-clickable format: "at .(File.java:42)"
 ```
 
+### `BuiltinExecution`
+
+```java
+record BuiltinExecution(DefaultFun fun, String argSummary, String resultSummary)
+// toString() → "EqualsInteger(5, 3) → False"
+```
+
+Values are summarized: ByteStrings truncated to 16 hex chars (`#a1b2c3...`), strings to 20
+chars, complex values shown as `<Data>`, `[N elems]`, `<Pair>`.
+
+### `FailureReport`
+
+```java
+record FailureReport(
+    String errorMessage,            // VM error message
+    SourceLocation sourceLocation,  // Java source location (nullable)
+    List<BuiltinExecution> lastBuiltins,   // last N builtin executions
+    List<ExecutionTraceEntry> lastSteps,    // last N execution trace entries
+    ExBudget consumed,              // budget consumed
+    List<String> traceMessages      // Builtins.trace() messages
+)
+
+report.findCauseBuiltin()   // → last comparison builtin returning False, or null
+```
+
+### `FailureReportBuilder`
+
+```java
+FailureReportBuilder.build(result, sourceMap, executionTrace, builtinTrace) // → FailureReport or null
+FailureReportBuilder.build(result, sourceMap)   // no traces
+FailureReportBuilder.build(result)              // no source map or traces
+```
+
+### `FailureReportFormatter`
+
+```java
+FailureReportFormatter.format(report)   // → plain text multi-line string
+```
+
+### `JulcVm` (builtin trace)
+
+```java
+vm.getLastBuiltinTrace()            // → List<BuiltinExecution> (empty if disabled)
+vm.setBuiltinTraceEnabled(false)    // disable for zero-overhead production eval
+vm.setBuiltinTraceEnabled(true)     // re-enable (enabled by default)
+```
+
 ### `ValidatorTest`
 
 ```java
@@ -515,22 +754,34 @@ ValidatorTest.compileWithSourceMap(javaSource)
 // Evaluate with execution tracing
 ValidatorTest.evaluateWithTrace(compiled, args...)  // → EvalWithTrace
 
+// Evaluate with builtin trace only (lightweight, no execution tracing)
+ValidatorTest.evaluateWithBuiltinTrace(compiled, args...)  // → EvalWithTrace
+
+// Diagnostics: builtin-only (lightweight) or full (with execution trace)
+ValidatorTest.evaluateWithBuiltinDiagnostics(compiled, args...)  // → FailureReport or null
+ValidatorTest.evaluateWithDiagnostics(compiled, args...)          // → FailureReport or null
+
 // Resolve error location
 ValidatorTest.resolveErrorLocation(result, sourceMap) // → SourceLocation or null
 
 // Assert with source location in error message
 ValidatorTest.assertValidatesWithSourceMap(compileResult, args...)
 ValidatorTest.assertRejectsWithSourceMap(compileResult, args...)
+
+// Assert with rich diagnostics (FailureReport) on failure
+ValidatorTest.assertValidatesWithDiagnostics(compiled, args...)
 ```
 
 ### `EvalWithTrace`
 
 ```java
-record EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace)
+record EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace,
+                     List<BuiltinExecution> builtinTrace)
 
 evalWithTrace.formatTrace()          // → formatted step-by-step trace
 evalWithTrace.formatBudgetSummary()  // → formatted per-location budget summary
 evalWithTrace.result()               // → the underlying EvalResult
+evalWithTrace.builtinTrace()         // → List<BuiltinExecution>
 ```
 
 ### `ContractTest`
@@ -543,8 +794,12 @@ compileValidatorWithSourceMap(MyValidator.class, sourceRoot)
 // Evaluate with tracing
 evaluateWithTrace(compiled, args...)     // → EvalResult (trace stored internally)
 
-// Access last execution trace
+// Evaluate with builtin trace only (no execution tracing)
+evaluateWithBuiltinTrace(compiled, args...)  // → EvalResult (trace stored internally)
+
+// Access last traces
 getLastExecutionTrace()                  // → List<ExecutionTraceEntry>
+getLastBuiltinTrace()                    // → List<BuiltinExecution>
 formatExecutionTrace()                   // → formatted step-by-step trace
 formatBudgetSummary()                    // → formatted per-location budget summary
 
@@ -562,8 +817,15 @@ logResult("testName", result, sourceMap)
 ### `JulcEval`
 
 ```java
-JulcEval.forClass(MyClass.class).sourceMap()   // enable source maps
-JulcEval.forSource(javaString).sourceMap()     // works with inline source too
+JulcEval.forClass(MyClass.class).sourceMap()       // enable source maps
+JulcEval.forClass(MyClass.class).builtinTrace()    // alias for sourceMap() — communicates intent
+JulcEval.forClass(MyClass.class).trace()           // enable execution tracing (implies sourceMap)
+JulcEval.forSource(javaString).sourceMap()         // works with inline source too
+
+eval.getLastBuiltinTrace()                         // → List<BuiltinExecution>
+eval.getLastExecutionTrace()                       // → List<ExecutionTraceEntry>
+eval.formatLastTrace()                             // → formatted step-by-step trace
+eval.formatLastBudgetSummary()                     // → formatted per-location budget summary
 ```
 
 ### `JulcScriptLoader`

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -29,7 +29,7 @@ provides a layered testing approach so you can catch bugs early:
 5. [ValidatorTest — Static Utility API](#5-validatortest--static-utility-api) — compile, evaluate, method eval
 6. [Budget and Trace Assertions](#6-budget-and-trace-assertions) — budget limits, traces, script size
 7. [Property-Based Testing with jqwik](#7-property-based-testing-with-jqwik) — CardanoArbitraries, BudgetCollector, ArbitraryScriptContext
-8. [Source Map Debugging](#8-source-map-debugging) — error locations, execution tracing
+8. [Source Map Debugging](#8-source-map-debugging) — error locations, execution tracing, builtin trace
 9. [Integration Testing with Yaci DevKit](#9-integration-testing-with-yaci-devkit) — devnet, admin API
 10. [Testing Patterns and Best Practices](#10-testing-patterns-and-best-practices) — compile-once, sealed interfaces, @Param
 11. [Quick Reference](#11-quick-reference) — which tool for which scenario
@@ -1106,6 +1106,28 @@ System.out.println(evalTrace.formatTrace());
 
 System.out.println(evalTrace.formatBudgetSummary());
 // Per-location budget breakdown
+```
+
+### Builtin Trace (Lightweight Failure Diagnostics)
+
+For quick failure diagnosis without execution tracing overhead, use **builtin trace** — it
+records the last 20 builtin executions and highlights the comparison that returned `False`.
+See [Builtin Trace](source-maps.md#builtin-trace) in the Source Maps guide for full details.
+
+```java
+// Lightweight: builtin trace only (no execution tracing overhead)
+var traced = ValidatorTest.evaluateWithBuiltinTrace(compiled, args);
+traced.builtinTrace(); // → List<BuiltinExecution>
+
+// Returns structured FailureReport on failure, null on success
+FailureReport report = ValidatorTest.evaluateWithBuiltinDiagnostics(compiled, args);
+if (report != null) System.out.println(FailureReportFormatter.format(report));
+
+// Full diagnostics (execution trace + builtin trace)
+FailureReport report = ValidatorTest.evaluateWithDiagnostics(compiled, args);
+
+// Assert with rich error message on failure
+ValidatorTest.assertValidatesWithDiagnostics(compiled, args);
 ```
 
 ### Enabling Source Maps in Gradle

--- a/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekJavaBenchmark.java
+++ b/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekJavaBenchmark.java
@@ -71,6 +71,7 @@ public class CekJavaBenchmark {
     @Setup(Level.Trial)
     public void setup() throws IOException {
         provider = new JavaVmProvider();
+        provider.setBuiltinTraceEnabled(false);
         program = UplcFlatDecoder.decodeProgram(loadFlatBytes(file));
     }
 

--- a/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekTruffleBenchmark.java
+++ b/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekTruffleBenchmark.java
@@ -68,6 +68,7 @@ public class CekTruffleBenchmark {
     @Setup(Level.Trial)
     public void setup() throws IOException {
         provider = new TruffleVmProvider();
+        provider.setBuiltinTraceEnabled(false);
         program = UplcFlatDecoder.decodeProgram(CekJavaBenchmark.loadFlatBytes(file));
     }
 

--- a/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluator.java
+++ b/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluator.java
@@ -21,7 +21,10 @@ import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
 import com.bloxbean.cardano.julc.vm.JulcVm;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -54,7 +57,8 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
     // Source map support
     private final Map<String, SourceMap> scriptSourceMaps = new HashMap<>();
     private final Map<String, Program> scriptPrograms = new HashMap<>();
-    private boolean tracingEnabled = false;
+    private boolean executionTraceEnabled = false;
+    private boolean builtinTraceEnabled = true;
 
     // Last execution traces (per redeemer tag+index) from the most recent evaluateTx call
     private volatile Map<String, List<ExecutionTraceEntry>> lastTraces = Map.of();
@@ -122,13 +126,44 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
     }
 
     /**
-     * Enable or disable execution tracing.
-     * When enabled, per-step budget and source line tracking are included in error messages.
+     * Enable or disable execution tracing (per-step source line and budget tracking).
+     * This is the heavier tracing option — requires source maps for useful output.
+     * <p>
+     * For lightweight diagnostics that show <em>what values</em> caused a failure,
+     * use {@link #enableBuiltinTrace(boolean)} instead (enabled by default).
      *
-     * @param enabled true to enable tracing
+     * @param enabled true to enable execution tracing
      */
     public void enableTracing(boolean enabled) {
-        this.tracingEnabled = enabled;
+        this.executionTraceEnabled = enabled;
+    }
+
+    /**
+     * Enable or disable builtin trace collection.
+     * When enabled, the last N builtin executions (function name, argument values,
+     * result value) are captured and included in failure messages. This shows
+     * developers <em>what values</em> the comparison evaluated to.
+     * <p>
+     * <b>Enabled by default.</b> Overhead is negligible (fixed-size ring buffer of 20 entries).
+     * Disable with {@code enableBuiltinTrace(false)} for zero-overhead production evaluation.
+     * <p>
+     * Example failure output with builtin trace enabled:
+     * <pre>
+     * FAIL: Error term encountered
+     *   LessThanEqualsInteger(5, 3) → False
+     *
+     *   Last builtins:
+     *     UnIData(&lt;Data&gt;) → 5
+     *     UnIData(&lt;Data&gt;) → 3
+     *     LessThanEqualsInteger(5, 3) → False
+     *
+     *   Budget: CPU=1,234,567  Mem=45,678
+     * </pre>
+     *
+     * @param enabled true to enable builtin tracing, false to disable
+     */
+    public void enableBuiltinTrace(boolean enabled) {
+        this.builtinTraceEnabled = enabled;
     }
 
     /**
@@ -183,7 +218,7 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
 
             // 6. Evaluate each redeemer
             List<EvaluationResult> results = new ArrayList<>();
-            var collectedTraces = tracingEnabled
+            var collectedTraces = executionTraceEnabled
                     ? new LinkedHashMap<String, List<ExecutionTraceEntry>>() : null;
 
             for (Redeemer redeemer : redeemers) {
@@ -224,7 +259,8 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
                     if (activeSourceMap != null) {
                         vmProvider.setSourceMap(activeSourceMap);
                     }
-                    if (tracingEnabled) {
+                    vmProvider.setBuiltinTraceEnabled(builtinTraceEnabled);
+                    if (executionTraceEnabled) {
                         vmProvider.setTracingEnabled(true);
                     }
 
@@ -234,18 +270,21 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
 
                     // e. Evaluate with try-finally for provider state reset
                     List<ExecutionTraceEntry> executionTrace;
+                    List<BuiltinExecution> builtinTrace;
                     EvalResult evalResult;
                     try {
                         var langVm = JulcVm.withProvider(vmProvider, resolved.language());
                         evalResult = langVm.evaluateWithArgs(
                                 evalProgram, args, maxBudget);
-                        executionTrace = tracingEnabled
+                        executionTrace = executionTraceEnabled
                                 ? vmProvider.getLastExecutionTrace() : List.of();
+                        builtinTrace = builtinTraceEnabled
+                                ? vmProvider.getLastBuiltinTrace() : List.of();
                     } finally {
                         if (activeSourceMap != null) {
                             vmProvider.setSourceMap(null);
                         }
-                        if (tracingEnabled) {
+                        if (executionTraceEnabled) {
                             vmProvider.setTracingEnabled(false);
                         }
                     }
@@ -270,14 +309,18 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
                         case EvalResult.Failure failure -> {
                             lastTraces = collectedTraces != null
                                     ? Collections.unmodifiableMap(collectedTraces) : Map.of();
-                            return Result.error(formatFailure(
-                                    redeemer, failure, activeSourceMap));
+                            return Result.error(formatEvalError(
+                                    redeemer, "Script evaluation failed for", failure,
+                                    failure.error(), activeSourceMap,
+                                    executionTrace, builtinTrace));
                         }
                         case EvalResult.BudgetExhausted exhausted -> {
                             lastTraces = collectedTraces != null
                                     ? Collections.unmodifiableMap(collectedTraces) : Map.of();
-                            return Result.error(formatBudgetExhausted(
-                                    redeemer, exhausted, activeSourceMap));
+                            return Result.error(formatEvalError(
+                                    redeemer, "Budget exhausted for", exhausted,
+                                    exhausted.consumed().toString(), activeSourceMap,
+                                    executionTrace, builtinTrace));
                         }
                     }
                 } catch (Exception e) {
@@ -553,53 +596,22 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
 
     // ---- Error formatting with source map support ----
 
-    private String formatFailure(Redeemer redeemer, EvalResult.Failure failure,
-                                  SourceMap sourceMap) {
-        var sb = new StringBuilder();
-        sb.append("Script evaluation failed for ")
-                .append(redeemer.getTag()).append('[').append(redeemer.getIndex()).append("]: ")
-                .append(failure.error());
-
-        if (sourceMap != null && failure.failedTerm() != null) {
-            var loc = sourceMap.lookup(failure.failedTerm());
-            if (loc != null) {
-                sb.append("\n  ").append(loc);
-            }
+    private String formatEvalError(Redeemer redeemer, String prefix, EvalResult result,
+                                    String fallbackDetail, SourceMap sourceMap,
+                                    List<ExecutionTraceEntry> executionTrace,
+                                    List<BuiltinExecution> builtinTrace) {
+        var redeemerKey = redeemer.getTag() + "[" + redeemer.getIndex() + "]";
+        var report = FailureReportBuilder.build(result, sourceMap, executionTrace, builtinTrace);
+        if (report != null) {
+            return prefix + " " + redeemerKey + ":\n"
+                    + FailureReportFormatter.format(report);
         }
-
-        String traces = String.join("\n", failure.traces());
-        if (!traces.isEmpty()) {
-            sb.append("\nTraces:\n  ").append(traces.replace("\n", "\n  "));
-        }
-
-        return sb.toString();
-    }
-
-    private String formatBudgetExhausted(Redeemer redeemer, EvalResult.BudgetExhausted exhausted,
-                                          SourceMap sourceMap) {
-        var sb = new StringBuilder();
-        sb.append("Budget exhausted for ")
-                .append(redeemer.getTag()).append('[').append(redeemer.getIndex()).append("]: ")
-                .append(exhausted.consumed());
-
-        if (sourceMap != null && exhausted.failedTerm() != null) {
-            var loc = sourceMap.lookup(exhausted.failedTerm());
-            if (loc != null) {
-                sb.append("\n  ").append(loc);
-            }
-        }
-
-        String traces = String.join("\n", exhausted.traces());
-        if (!traces.isEmpty()) {
-            sb.append("\nTraces:\n  ").append(traces.replace("\n", "\n  "));
-        }
-
-        return sb.toString();
+        return prefix + " " + redeemerKey + ": " + fallbackDetail;
     }
 
     private void captureTrace(String redeemerKey, List<ExecutionTraceEntry> executionTrace,
                                Map<String, List<ExecutionTraceEntry>> collectedTraces) {
-        if (!tracingEnabled || executionTrace.isEmpty()) return;
+        if (!executionTraceEnabled || executionTrace.isEmpty()) return;
         collectedTraces.put(redeemerKey, List.copyOf(executionTrace));
         System.out.println(ExecutionTraceEntry.format(executionTrace));
         System.out.println(ExecutionTraceEntry.formatSummary(executionTrace));

--- a/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluatorTest.java
+++ b/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluatorTest.java
@@ -31,8 +31,10 @@ class JulcTransactionEvaluatorTest {
 
     static PlutusV3Script alwaysTrueScript;
     static PlutusV3Script alwaysFalseScript;
+    static PlutusV3Script comparisonFailScript;
     static String alwaysTrueHash;
     static String alwaysFalseHash;
+    static String comparisonFailHash;
 
     // V2 scripts (3-arg calling convention: datum, redeemer, scriptContext)
     static PlutusV2Script v2AlwaysTrueScript;
@@ -58,6 +60,20 @@ class JulcTransactionEvaluatorTest {
                 Term.lam("ctx", Term.error()));
         alwaysFalseScript = JulcScriptAdapter.fromProgram(alwaysFalseProgram);
         alwaysFalseHash = JulcScriptAdapter.scriptHash(alwaysFalseProgram);
+
+        // Comparison-fail: a script that does a comparison and fails
+        // (\ctx -> ifThenElse(lessThanEqualsInteger(5, 3), (), ERROR))
+        // LessThanEqualsInteger returns False, so IfThenElse takes the Error branch
+        var compare = Term.apply(Term.apply(Term.builtin(DefaultFun.LessThanEqualsInteger),
+                Term.const_(Constant.integer(5))),
+                Term.const_(Constant.integer(3)));
+        var ifThenElse = Term.apply(Term.apply(Term.apply(Term.force(Term.builtin(DefaultFun.IfThenElse)),
+                compare),
+                Term.const_(Constant.unit())),
+                Term.error());
+        var comparisonFailProgram = Program.plutusV3(Term.lam("ctx", ifThenElse));
+        comparisonFailScript = JulcScriptAdapter.fromProgram(comparisonFailProgram);
+        comparisonFailHash = JulcScriptAdapter.scriptHash(comparisonFailProgram);
 
         // V2 always-true (3-arg: \datum redeemer ctx -> ())
         var v2AlwaysTrueProgram = Program.plutusV2(
@@ -400,6 +416,155 @@ class JulcTransactionEvaluatorTest {
         assertTrue(result.isSuccessful(), "Expected success but got: " + result.getResponse());
         assertEquals(1, result.getValue().size());
         assertEquals(RedeemerTag.Spend, result.getValue().getFirst().getRedeemerTag());
+    }
+
+    // --- Builtin Trace Tests ---
+
+    @Test
+    void builtinTrace_defaultEnabled_failureContainsComparisonValues() throws Exception {
+        // Default: builtin trace is on — failure messages should include builtin values
+        String scriptAddr = buildScriptAddress(comparisonFailHash);
+        String txHash = "de".repeat(32);
+
+        Utxo inputUtxo = Utxo.builder()
+                .txHash(txHash)
+                .outputIndex(0)
+                .address(scriptAddr)
+                .amount(List.of(Amount.lovelace(BigInteger.valueOf(5_000_000))))
+                .build();
+
+        var redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.ZERO)
+                .data(new BigIntPlutusData(BigInteger.ZERO))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.ZERO)
+                        .steps(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        var tx = Transaction.builder()
+                .body(TransactionBody.builder()
+                        .inputs(List.of(new TransactionInput(txHash, 0)))
+                        .outputs(List.of())
+                        .fee(BigInteger.valueOf(200_000))
+                        .build())
+                .witnessSet(TransactionWitnessSet.builder()
+                        .redeemers(List.of(redeemer))
+                        .plutusV3Scripts(List.of(comparisonFailScript))
+                        .build())
+                .build();
+
+        var evaluator = createEvaluator(null);
+        // No explicit enableBuiltinTrace() call — it's on by default!
+        byte[] cbor = tx.serialize();
+        var result = evaluator.evaluateTx(cbor, Set.of(inputUtxo));
+
+        assertFalse(result.isSuccessful());
+        // Error message should contain the comparison builtin with actual values
+        String errorMsg = result.getResponse();
+        assertTrue(errorMsg.contains("LessThanEqualsInteger"),
+                "Error should mention the comparison builtin, got: " + errorMsg);
+        assertTrue(errorMsg.contains("False"),
+                "Error should show the comparison result was False, got: " + errorMsg);
+    }
+
+    @Test
+    void builtinTrace_explicitlyDisabled_failureOmitsBuiltinValues() throws Exception {
+        // Developer explicitly disables builtin trace for production
+        String scriptAddr = buildScriptAddress(comparisonFailHash);
+        String txHash = "de".repeat(32);
+
+        Utxo inputUtxo = Utxo.builder()
+                .txHash(txHash)
+                .outputIndex(0)
+                .address(scriptAddr)
+                .amount(List.of(Amount.lovelace(BigInteger.valueOf(5_000_000))))
+                .build();
+
+        var redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.ZERO)
+                .data(new BigIntPlutusData(BigInteger.ZERO))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.ZERO)
+                        .steps(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        var tx = Transaction.builder()
+                .body(TransactionBody.builder()
+                        .inputs(List.of(new TransactionInput(txHash, 0)))
+                        .outputs(List.of())
+                        .fee(BigInteger.valueOf(200_000))
+                        .build())
+                .witnessSet(TransactionWitnessSet.builder()
+                        .redeemers(List.of(redeemer))
+                        .plutusV3Scripts(List.of(comparisonFailScript))
+                        .build())
+                .build();
+
+        var evaluator = createEvaluator(null);
+        evaluator.enableBuiltinTrace(false);  // explicitly off for production
+        byte[] cbor = tx.serialize();
+        var result = evaluator.evaluateTx(cbor, Set.of(inputUtxo));
+
+        assertFalse(result.isSuccessful());
+        // Error message should NOT contain builtin details
+        String errorMsg = result.getResponse();
+        assertFalse(errorMsg.contains("LessThanEqualsInteger"),
+                "With builtin trace off, error should not include builtin details, got: " + errorMsg);
+    }
+
+    @Test
+    void builtinTraceOnly_withoutExecutionTrace() throws Exception {
+        // Developer enables only builtin trace (lightweight), not execution trace
+        String scriptAddr = buildScriptAddress(comparisonFailHash);
+        String txHash = "de".repeat(32);
+
+        Utxo inputUtxo = Utxo.builder()
+                .txHash(txHash)
+                .outputIndex(0)
+                .address(scriptAddr)
+                .amount(List.of(Amount.lovelace(BigInteger.valueOf(5_000_000))))
+                .build();
+
+        var redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.ZERO)
+                .data(new BigIntPlutusData(BigInteger.ZERO))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.ZERO)
+                        .steps(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        var tx = Transaction.builder()
+                .body(TransactionBody.builder()
+                        .inputs(List.of(new TransactionInput(txHash, 0)))
+                        .outputs(List.of())
+                        .fee(BigInteger.valueOf(200_000))
+                        .build())
+                .witnessSet(TransactionWitnessSet.builder()
+                        .redeemers(List.of(redeemer))
+                        .plutusV3Scripts(List.of(comparisonFailScript))
+                        .build())
+                .build();
+
+        var evaluator = createEvaluator(null);
+        evaluator.enableBuiltinTrace(true);   // lightweight diagnostics (default)
+        evaluator.enableTracing(false);        // no heavy execution trace
+        byte[] cbor = tx.serialize();
+        var result = evaluator.evaluateTx(cbor, Set.of(inputUtxo));
+
+        assertFalse(result.isSuccessful());
+        // Builtin values should be in the error message
+        String errorMsg = result.getResponse();
+        assertTrue(errorMsg.contains("LessThanEqualsInteger"),
+                "Builtin trace should be present, got: " + errorMsg);
+        // Execution trace should be absent (not enabled)
+        assertTrue(evaluator.getLastTraces().isEmpty(),
+                "Execution traces should be empty when execution trace is not enabled");
     }
 
     // --- V2 Tests ---

--- a/julc-cli/build.gradle
+++ b/julc-cli/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 
     implementation 'info.picocli:picocli:4.7.7'
     annotationProcessor 'info.picocli:picocli-codegen:4.7.7'
+
+    implementation 'org.jline:jline:3.27.1'
 }
 
 // --- Generate version.properties at build time ---

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/JulcCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/JulcCommand.java
@@ -17,6 +17,7 @@ import picocli.CommandLine.Command;
                 BuildCommand.class,
                 CheckCommand.class,
                 EvalCommand.class,
+                ReplCommand.class,
                 BlueprintCommand.class,
                 UplcCommand.class,
                 VersionCommand.class,

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/EvalCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/EvalCommand.java
@@ -7,12 +7,15 @@ import com.bloxbean.cardano.julc.core.text.UplcParser;
 import com.bloxbean.cardano.julc.core.text.UplcPrinter;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
 import com.bloxbean.julc.cli.output.AnsiColors;
+import com.bloxbean.julc.cli.output.AnsiFailureReportFormatter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 @Command(name = "eval", description = "Evaluate a UPLC program")
 public class EvalCommand implements Runnable {
@@ -26,6 +29,7 @@ public class EvalCommand implements Runnable {
             Program program = loadProgram(file);
             JulcVm vm = JulcVm.create();
             EvalResult result = vm.evaluate(program);
+            var builtinTrace = vm.getLastBuiltinTrace();
 
             switch (result) {
                 case EvalResult.Success s -> {
@@ -39,19 +43,23 @@ public class EvalCommand implements Runnable {
                     }
                 }
                 case EvalResult.Failure f -> {
-                    System.out.println(AnsiColors.red("Failure: " + f.error()));
-                    System.out.println("  CPU:    " + f.consumed().cpuSteps());
-                    System.out.println("  Memory: " + f.consumed().memoryUnits());
-                    if (!f.traces().isEmpty()) {
-                        System.out.println("  Traces:");
-                        f.traces().forEach(t -> System.out.println("    " + t));
+                    var report = FailureReportBuilder.build(f, null, List.of(), builtinTrace);
+                    if (report != null) {
+                        System.out.println(AnsiFailureReportFormatter.format(report));
+                    } else {
+                        System.out.println(AnsiColors.red("Failure: " + f.error()));
                     }
                     System.exit(1);
                 }
                 case EvalResult.BudgetExhausted b -> {
-                    System.out.println(AnsiColors.red("Budget exhausted"));
-                    System.out.println("  CPU:    " + b.consumed().cpuSteps());
-                    System.out.println("  Memory: " + b.consumed().memoryUnits());
+                    var report = FailureReportBuilder.build(b, null, List.of(), builtinTrace);
+                    if (report != null) {
+                        System.out.println(AnsiFailureReportFormatter.format(report));
+                    } else {
+                        System.out.println(AnsiColors.red("Budget exhausted"));
+                        System.out.println("  CPU:    " + b.consumed().cpuSteps());
+                        System.out.println("  Memory: " + b.consumed().memoryUnits());
+                    }
                     System.exit(1);
                 }
             }

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/ReplCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/ReplCommand.java
@@ -1,0 +1,250 @@
+package com.bloxbean.julc.cli.cmd;
+
+import com.bloxbean.julc.cli.JulcVersionProvider;
+import com.bloxbean.julc.cli.output.AnsiColors;
+import com.bloxbean.julc.cli.repl.ReplCompleter;
+import com.bloxbean.julc.cli.repl.ReplEngine;
+import com.bloxbean.julc.cli.repl.ReplResult;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Command(name = "repl", description = "Interactive REPL for evaluating JuLC expressions")
+public class ReplCommand implements Runnable {
+
+    @Option(names = "--no-budget", description = "Hide budget (CPU/mem) display")
+    private boolean noBudget;
+
+    @Option(names = "--no-jline", description = "Disable JLine (use basic stdin)")
+    private boolean noJline;
+
+    private static final String PROMPT = AnsiColors.bold("julc> ");
+    private static final String CONTINUATION = "  ... ";
+
+    @Override
+    public void run() {
+        printBanner();
+
+        var engine = new ReplEngine();
+        if (noBudget) {
+            engine.setShowBudget(false);
+        }
+
+        if (noJline || System.console() == null) {
+            runBasicLoop(engine);
+        } else {
+            try {
+                runJlineLoop(engine);
+            } catch (Exception e) {
+                // Fallback if JLine fails (e.g., native-image issues)
+                System.err.println(AnsiColors.dim("JLine unavailable, falling back to basic mode."));
+                runBasicLoop(engine);
+            }
+        }
+    }
+
+    private void runJlineLoop(ReplEngine engine) throws IOException {
+        // Ensure history directory exists
+        Path historyDir = Path.of(System.getProperty("user.home"), ".julc");
+        Files.createDirectories(historyDir);
+        Path historyFile = historyDir.resolve("repl_history");
+
+        var terminal = org.jline.terminal.TerminalBuilder.builder()
+                .system(true)
+                .build();
+
+        // Custom parser: don't treat '.' as a word break so "MapLib." stays as one token
+        var parser = new org.jline.reader.impl.DefaultParser();
+        parser.setEofOnUnclosedBracket(org.jline.reader.impl.DefaultParser.Bracket.CURLY,
+                org.jline.reader.impl.DefaultParser.Bracket.ROUND);
+
+        var lineReader = org.jline.reader.LineReaderBuilder.builder()
+                .terminal(terminal)
+                .parser(parser)
+                .completer(new ReplCompleter())
+                .variable(org.jline.reader.LineReader.HISTORY_FILE, historyFile)
+                .option(org.jline.reader.LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+                .build();
+
+        while (true) {
+            String input;
+            try {
+                input = lineReader.readLine(PROMPT);
+            } catch (org.jline.reader.UserInterruptException e) {
+                // Ctrl+C — clear line, continue
+                continue;
+            } catch (org.jline.reader.EndOfFileException e) {
+                // Ctrl+D — quit
+                System.out.println("Goodbye!");
+                return;
+            }
+
+            if (input == null) {
+                System.out.println("Goodbye!");
+                return;
+            }
+
+            // Multi-line: collect continuation lines if brackets are unmatched
+            input = collectMultiLine(input, lineReader);
+
+            if (isQuitCommand(input)) {
+                System.out.println("Goodbye!");
+                return;
+            }
+
+            processInput(engine, input);
+        }
+    }
+
+    private void runBasicLoop(ReplEngine engine) {
+        var reader = new BufferedReader(new InputStreamReader(System.in));
+
+        while (true) {
+            System.out.print("julc> ");
+            System.out.flush();
+            String input;
+            try {
+                input = reader.readLine();
+            } catch (IOException e) {
+                break;
+            }
+
+            if (input == null) {
+                System.out.println("Goodbye!");
+                return;
+            }
+
+            // Multi-line: collect continuation lines
+            input = collectMultiLineBasic(input, reader);
+
+            if (isQuitCommand(input)) {
+                System.out.println("Goodbye!");
+                return;
+            }
+
+            processInput(engine, input);
+        }
+    }
+
+    private void processInput(ReplEngine engine, String input) {
+        String trimmed = input.trim();
+        if (trimmed.isEmpty()) return;
+
+        ReplResult result = engine.evaluate(trimmed);
+        if (result == null) return;
+
+        switch (result) {
+            case ReplResult.Success s -> {
+                System.out.println(AnsiColors.green("=> ") + s.formattedValue());
+                if (!s.traces().isEmpty()) {
+                    for (String trace : s.traces()) {
+                        System.out.println(AnsiColors.cyan("   trace: ") + trace);
+                    }
+                }
+                if (engine.isShowBudget() && s.budget().cpuSteps() > 0) {
+                    System.out.println(AnsiColors.dim("   CPU: " +
+                            String.format("%,d", s.budget().cpuSteps()) + "  Mem: " +
+                            String.format("%,d", s.budget().memoryUnits())));
+                }
+            }
+            case ReplResult.Error e -> {
+                System.out.println(AnsiColors.red("Error: ") + e.message());
+                if (!e.traces().isEmpty()) {
+                    for (String trace : e.traces()) {
+                        System.out.println(AnsiColors.cyan("   trace: ") + trace);
+                    }
+                }
+                if (engine.isShowBudget() && e.budget().cpuSteps() > 0) {
+                    System.out.println(AnsiColors.dim("   CPU: " +
+                            String.format("%,d", e.budget().cpuSteps()) + "  Mem: " +
+                            String.format("%,d", e.budget().memoryUnits())));
+                }
+            }
+            case ReplResult.MetaOutput m -> System.out.println(m.text());
+        }
+    }
+
+    private static boolean isQuitCommand(String input) {
+        String trimmed = input.trim().toLowerCase();
+        return trimmed.equals(":quit") || trimmed.equals(":q")
+                || trimmed.equals(":exit") || trimmed.equals("quit") || trimmed.equals("exit");
+    }
+
+    /**
+     * Collect multi-line input when brackets are unmatched (JLine mode).
+     */
+    private String collectMultiLine(String initial, org.jline.reader.LineReader lineReader) {
+        if (!hasUnmatchedBrackets(initial)) {
+            return initial;
+        }
+        var sb = new StringBuilder(initial);
+        while (hasUnmatchedBrackets(sb.toString())) {
+            try {
+                String continuation = lineReader.readLine(CONTINUATION);
+                if (continuation == null) break;
+                sb.append("\n").append(continuation);
+            } catch (org.jline.reader.UserInterruptException | org.jline.reader.EndOfFileException e) {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Collect multi-line input when brackets are unmatched (basic mode).
+     */
+    private String collectMultiLineBasic(String initial, BufferedReader reader) {
+        if (!hasUnmatchedBrackets(initial)) {
+            return initial;
+        }
+        var sb = new StringBuilder(initial);
+        while (hasUnmatchedBrackets(sb.toString())) {
+            System.out.print("  ... ");
+            System.out.flush();
+            try {
+                String continuation = reader.readLine();
+                if (continuation == null) break;
+                sb.append("\n").append(continuation);
+            } catch (IOException e) {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
+    static boolean hasUnmatchedBrackets(String input) {
+        int curly = 0, paren = 0;
+        boolean inString = false;
+        boolean inChar = false;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == '\\' && i + 1 < input.length()) {
+                i++; // skip escaped char
+                continue;
+            }
+            if (c == '"' && !inChar) inString = !inString;
+            else if (c == '\'' && !inString) inChar = !inChar;
+            else if (!inString && !inChar) {
+                if (c == '{') curly++;
+                else if (c == '}') curly--;
+                else if (c == '(') paren++;
+                else if (c == ')') paren--;
+            }
+        }
+        return curly > 0 || paren > 0;
+    }
+
+    private void printBanner() {
+        System.out.println(AnsiColors.bold("JuLC REPL") + " " +
+                AnsiColors.dim("v" + JulcVersionProvider.VERSION));
+        System.out.println("All stdlib libraries are auto-imported. " +
+                "Type " + AnsiColors.cyan(":help") + " for commands, " +
+                AnsiColors.cyan(":quit") + " to exit.");
+        System.out.println();
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/output/AnsiFailureReportFormatter.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/output/AnsiFailureReportFormatter.java
@@ -1,0 +1,85 @@
+package com.bloxbean.julc.cli.output;
+
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
+import com.bloxbean.cardano.julc.vm.trace.FailureReport;
+
+/**
+ * ANSI-colored formatter for {@link FailureReport}.
+ * <p>
+ * Uses {@link AnsiColors} for terminal output:
+ * <ul>
+ *   <li>{@code FAIL} in red, source location in bold</li>
+ *   <li>Builtin names in cyan, {@code → False} in red, {@code → True} in green</li>
+ *   <li>Budget numbers in dim</li>
+ * </ul>
+ */
+public final class AnsiFailureReportFormatter {
+
+    private AnsiFailureReportFormatter() {}
+
+    /**
+     * Format a failure report with ANSI colors.
+     *
+     * @param report the failure report to format
+     * @return multi-line ANSI-colored string
+     */
+    public static String format(FailureReport report) {
+        var sb = new StringBuilder();
+
+        // Header: FAIL in red, source location in bold
+        sb.append(AnsiColors.red("FAIL"));
+        if (report.sourceLocation() != null) {
+            sb.append(' ').append(AnsiColors.bold(report.sourceLocation().toString()));
+        } else {
+            sb.append(": ").append(report.errorMessage());
+        }
+        sb.append('\n');
+
+        // Highlighted cause
+        var causeBuiltin = report.findCauseBuiltin();
+        if (causeBuiltin != null) {
+            sb.append("  ").append(formatBuiltinExecution(causeBuiltin)).append('\n');
+        }
+
+        // Last builtins section
+        if (!report.lastBuiltins().isEmpty()) {
+            sb.append('\n');
+            sb.append("  Last builtins:\n");
+            for (var exec : report.lastBuiltins()) {
+                sb.append("    ").append(formatBuiltinExecution(exec)).append('\n');
+            }
+        }
+
+        // Trace messages
+        if (!report.traceMessages().isEmpty()) {
+            sb.append('\n');
+            sb.append("  Traces:\n");
+            for (var msg : report.traceMessages()) {
+                sb.append("    ").append(msg).append('\n');
+            }
+        }
+
+        // Budget in dim
+        sb.append('\n');
+        sb.append(AnsiColors.dim(String.format("  Budget: CPU=%s  Mem=%s",
+                String.format("%,d", report.consumed().cpuSteps()),
+                String.format("%,d", report.consumed().memoryUnits()))));
+        sb.append('\n');
+
+        return sb.toString();
+    }
+
+    private static String formatBuiltinExecution(BuiltinExecution exec) {
+        var sb = new StringBuilder();
+        sb.append(AnsiColors.cyan(exec.fun().toString()));
+        sb.append('(').append(exec.argSummary()).append(") → ");
+        if ("False".equals(exec.resultSummary())) {
+            sb.append(AnsiColors.red(exec.resultSummary()));
+        } else if ("True".equals(exec.resultSummary())) {
+            sb.append(AnsiColors.green(exec.resultSummary()));
+        } else {
+            sb.append(exec.resultSummary());
+        }
+        return sb.toString();
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/output/DiagnosticFormatter.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/output/DiagnosticFormatter.java
@@ -18,7 +18,7 @@ public final class DiagnosticFormatter {
             case WARNING -> AnsiColors.yellow("warning");
             case INFO -> AnsiColors.blue("info");
         };
-        sb.append(d.fileName()).append(':').append(d.line()).append(':').append(d.column())
+        sb.append("./").append(d.fileName()).append(':').append(d.line()).append(':').append(d.column())
                 .append(": ").append(levelStr).append(": ").append(d.message());
         if (d.hasSuggestion()) {
             sb.append("\n  ").append(AnsiColors.dim("suggestion: " + d.suggestion()));

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ExpressionWrapper.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ExpressionWrapper.java
@@ -1,0 +1,199 @@
+package com.bloxbean.julc.cli.repl;
+
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Wraps bare expressions into a compilable Java class for REPL evaluation.
+ * <p>
+ * Generates a synthetic class with auto-imports for all stdlib libraries,
+ * ledger types, and core types so users can type expressions directly.
+ */
+public final class ExpressionWrapper {
+
+    private ExpressionWrapper() {}
+
+    static final String CLASS_NAME = "__Repl";
+    static final String METHOD_NAME = "__eval";
+
+    /** Known integer-returning method patterns. */
+    private static final Set<String> INTEGER_METHODS = Set.of(
+            "ListsLib.length", "MathLib.abs", "MathLib.max", "MathLib.min",
+            "MathLib.pow", "MathLib.sign", "MathLib.expMod",
+            "Builtins.unIData", "Builtins.lengthOfByteString"
+    );
+
+    /** Known boolean-returning method patterns. */
+    private static final Set<String> BOOLEAN_METHODS = Set.of(
+            "ListsLib.isEmpty", "ListsLib.contains", "ListsLib.containsInt",
+            "ListsLib.containsBytes", "ListsLib.hasDuplicateInts", "ListsLib.hasDuplicateBytes",
+            "MapLib.member", "Builtins.nullList",
+            "ValuesLib.leq", "ValuesLib.eq", "ValuesLib.isZero",
+            "CryptoLib.verifyEcdsaSecp256k1", "CryptoLib.verifySchnorrSecp256k1",
+            "BitwiseLib.readBit", "AddressLib.isScriptAddress", "AddressLib.isPubKeyAddress"
+    );
+
+    /** Known byte[]-returning method patterns. */
+    private static final Set<String> BYTES_METHODS = Set.of(
+            "Builtins.sha2_256", "Builtins.sha3_256", "Builtins.blake2b_224", "Builtins.blake2b_256",
+            "Builtins.bData", "Builtins.unBData",
+            "ByteStringLib.take", "ByteStringLib.integerToByteString",
+            "ByteStringLib.encodeUtf8", "ByteStringLib.serialiseData",
+            "CryptoLib.ripemd_160", "AddressLib.credentialHash",
+            "BitwiseLib.andByteString", "BitwiseLib.orByteString",
+            "BitwiseLib.xorByteString", "BitwiseLib.complementByteString",
+            "BitwiseLib.shiftByteString", "BitwiseLib.rotateByteString"
+    );
+
+    private static final Pattern ARITHMETIC_OPS = Pattern.compile("[+\\-*/%]");
+    private static final Pattern COMPARISON_OPS = Pattern.compile("(==|!=|<=?|>=?|&&|\\|\\|)");
+
+    /**
+     * Wrap an expression in a compilable Java source with auto-imports.
+     *
+     * @param expression   the user's expression
+     * @param userImports  additional user-added imports (from :import)
+     * @return the wrapped Java source code
+     */
+    public static String wrap(String expression, List<String> userImports) {
+        String returnType = inferReturnType(expression);
+        String body = formatBody(expression, returnType);
+        return buildSource(body, returnType, userImports);
+    }
+
+    /**
+     * Wrap with PlutusData return type and cast (fallback when type inference fails).
+     */
+    public static String wrapAsData(String expression, List<String> userImports) {
+        String body = "return (PlutusData)(Object)(" + expression + ");";
+        return buildSource(body, "PlutusData", userImports);
+    }
+
+    /**
+     * Infer the return type from the expression pattern.
+     */
+    static String inferReturnType(String expression) {
+        String trimmed = expression.trim();
+
+        // Boolean literals
+        if (trimmed.equals("true") || trimmed.equals("false")) {
+            return "boolean";
+        }
+
+        // Numeric literals (BigInteger range)
+        if (trimmed.matches("-?\\d+")) {
+            return "BigInteger";
+        }
+
+        // String literals
+        if (trimmed.startsWith("\"")) {
+            return "String";
+        }
+
+        // byte[] construction
+        if (trimmed.startsWith("new byte[]")) {
+            return "byte[]";
+        }
+
+        // Check for known method return types
+        for (String method : INTEGER_METHODS) {
+            if (trimmed.contains(method)) return "BigInteger";
+        }
+        for (String method : BOOLEAN_METHODS) {
+            if (trimmed.contains(method)) return "boolean";
+        }
+        for (String method : BYTES_METHODS) {
+            if (trimmed.contains(method)) return "byte[]";
+        }
+
+        // Comparison/boolean operators
+        if (COMPARISON_OPS.matcher(trimmed).find()) {
+            return "boolean";
+        }
+
+        // Arithmetic operators (but not inside method args)
+        // Simple heuristic: if top-level has arithmetic
+        if (hasTopLevelArithmetic(trimmed)) {
+            return "BigInteger";
+        }
+
+        // Default: PlutusData with cast
+        return "PlutusData";
+    }
+
+    private static boolean hasTopLevelArithmetic(String expr) {
+        int depth = 0;
+        for (int i = 0; i < expr.length(); i++) {
+            char c = expr.charAt(i);
+            if (c == '(' || c == '[' || c == '{') depth++;
+            else if (c == ')' || c == ']' || c == '}') depth--;
+            else if (depth == 0 && (c == '+' || c == '-' || c == '*' || c == '/' || c == '%')) {
+                // Exclude unary minus at start
+                if (c == '-' && i == 0) continue;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String formatBody(String expression, String returnType) {
+        String trimmed = expression.trim();
+
+        // Multi-statement block (contains semicolons not at end)
+        if (trimmed.contains(";") && !trimmed.endsWith(";")) {
+            // Assume it's a block with last expression as return
+            return trimmed;
+        }
+        if (trimmed.contains(";")) {
+            // Multiple statements — last one is the return value
+            // Wrap as-is, user must provide explicit returns
+            return trimmed;
+        }
+
+        // Single expression
+        if (returnType.equals("PlutusData")) {
+            return "return (PlutusData)(Object)(" + trimmed + ");";
+        }
+        return "return " + trimmed + ";";
+    }
+
+    private static String buildSource(String body, String returnType, List<String> userImports) {
+        var sb = new StringBuilder();
+
+        // Auto-imports: all stdlib classes
+        for (String fqcn : StdlibRegistry.stdlibClassFqcns()) {
+            sb.append("import ").append(fqcn).append(";\n");
+        }
+
+        // Core types
+        sb.append("import com.bloxbean.cardano.julc.core.PlutusData;\n");
+        sb.append("import com.bloxbean.cardano.julc.core.types.JulcList;\n");
+        sb.append("import com.bloxbean.cardano.julc.core.types.JulcMap;\n");
+        sb.append("import com.bloxbean.cardano.julc.core.types.Tuple2;\n");
+        sb.append("import com.bloxbean.cardano.julc.core.types.Tuple3;\n");
+
+        // Ledger types (wildcard)
+        sb.append("import com.bloxbean.cardano.julc.ledger.*;\n");
+
+        // Java standard
+        sb.append("import java.math.BigInteger;\n");
+        sb.append("import java.util.List;\n");
+        sb.append("import java.util.Optional;\n");
+
+        // User imports
+        for (String imp : userImports) {
+            sb.append("import ").append(imp).append(";\n");
+        }
+
+        sb.append("\nclass ").append(CLASS_NAME).append(" {\n");
+        sb.append("    static ").append(returnType).append(" ").append(METHOD_NAME).append("() {\n");
+        sb.append("        ").append(body).append("\n");
+        sb.append("    }\n");
+        sb.append("}\n");
+
+        return sb.toString();
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/MethodDocExtractor.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/MethodDocExtractor.java
@@ -1,0 +1,320 @@
+package com.bloxbean.julc.cli.repl;
+
+import com.bloxbean.julc.cli.output.AnsiColors;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts javadoc and method signatures from stdlib Java source strings.
+ * <p>
+ * Used by the REPL's {@code :doc} command to show inline documentation
+ * without leaving the REPL.
+ */
+public final class MethodDocExtractor {
+
+    /**
+     * Extracted documentation for a single method.
+     */
+    public record MethodDoc(String className, String methodName, String signature, String javadoc) {}
+
+    /**
+     * Extracted documentation for a class.
+     */
+    public record ClassDoc(String className, String javadoc, List<String> methodNames) {}
+
+    // Map from "ClassName.methodName" -> MethodDoc
+    private final Map<String, MethodDoc> methodDocs = new LinkedHashMap<>();
+    // Map from "ClassName" -> ClassDoc
+    private final Map<String, ClassDoc> classDocs = new LinkedHashMap<>();
+
+    /**
+     * Matches a javadoc block: /** ... * /
+     * Uses reluctant quantifier to find the nearest closing.
+     */
+    private static final Pattern JAVADOC_PATTERN =
+            Pattern.compile("/\\*\\*(.*?)\\*/", Pattern.DOTALL);
+
+    /**
+     * Matches a public static method declaration (possibly preceded by annotations/@SuppressWarnings).
+     * Captures: return type, method name, parameter list.
+     */
+    private static final Pattern METHOD_DECL_PATTERN =
+            Pattern.compile("public\\s+static\\s+(\\S+(?:<[^>]+>)?)\\s+(\\w+)\\s*\\(([^)]*)\\)");
+
+    /**
+     * Matches a class declaration. Captures the class name.
+     */
+    private static final Pattern CLASS_DECL_PATTERN =
+            Pattern.compile("(?:public\\s+)?class\\s+(\\w+)");
+
+    /**
+     * Build the doc extractor from a library pool (className -> Java source).
+     */
+    public MethodDocExtractor(Map<String, String> libraryPool) {
+        for (var entry : libraryPool.entrySet()) {
+            String className = entry.getKey();
+            String source = entry.getValue();
+            extractFromSource(className, source);
+        }
+    }
+
+    /**
+     * Look up documentation for a method.
+     *
+     * @param key "ClassName.methodName"
+     * @return the MethodDoc, or null if not found
+     */
+    public MethodDoc lookupMethod(String key) {
+        return methodDocs.get(key);
+    }
+
+    /**
+     * Look up documentation for a class.
+     *
+     * @param className simple class name
+     * @return the ClassDoc, or null if not found
+     */
+    public ClassDoc lookupClass(String className) {
+        return classDocs.get(className);
+    }
+
+    /**
+     * Format a method doc for REPL display with ANSI syntax highlighting.
+     * Signature is bold, javadoc body is dim.
+     */
+    public static String formatMethodDoc(MethodDoc doc) {
+        var sb = new StringBuilder();
+        sb.append("  ").append(AnsiColors.bold(doc.signature())).append("\n");
+        if (!doc.javadoc().isEmpty()) {
+            sb.append("\n");
+            for (String line : doc.javadoc().split("\n")) {
+                sb.append("  ").append(AnsiColors.dim(line)).append("\n");
+            }
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    /**
+     * Format a class doc for REPL display with ANSI syntax highlighting.
+     * Class name is bold, method list is cyan.
+     */
+    public static String formatClassDoc(ClassDoc doc) {
+        var sb = new StringBuilder();
+        if (!doc.javadoc().isEmpty()) {
+            sb.append("  ").append(AnsiColors.bold(doc.className()))
+                    .append(AnsiColors.dim(" — " + doc.javadoc())).append("\n");
+        } else {
+            sb.append("  ").append(AnsiColors.bold(doc.className())).append("\n");
+        }
+        if (!doc.methodNames().isEmpty()) {
+            sb.append("  ").append(AnsiColors.dim("Methods: "))
+                    .append(AnsiColors.cyan(String.join(", ", doc.methodNames())));
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    private void extractFromSource(String className, String source) {
+        // 1. Extract class-level javadoc
+        String classJavadoc = extractClassJavadoc(source);
+        List<String> methodNames = new ArrayList<>();
+
+        // 2. Extract method-level javadocs
+        // Strategy: find all javadoc blocks, then check if a public static method follows
+        extractMethodDocs(className, source, methodNames);
+
+        classDocs.put(className, new ClassDoc(className, classJavadoc, List.copyOf(methodNames)));
+    }
+
+    private void extractMethodDocs(String className, String source, List<String> methodNames) {
+        // Find all javadoc positions
+        Matcher javadocMatcher = JAVADOC_PATTERN.matcher(source);
+        while (javadocMatcher.find()) {
+            int javadocEnd = javadocMatcher.end();
+            String javadocBody = javadocMatcher.group(1);
+
+            // Look for a public static method declaration after this javadoc
+            // (allowing annotations/whitespace/SuppressWarnings between)
+            String afterJavadoc = source.substring(javadocEnd);
+            Matcher methodMatcher = METHOD_DECL_PATTERN.matcher(afterJavadoc);
+            if (methodMatcher.find() && isOnlyAnnotationsAndWhitespace(afterJavadoc, methodMatcher.start())) {
+                String returnType = methodMatcher.group(1);
+                String methodName = methodMatcher.group(2);
+                String params = methodMatcher.group(3).trim();
+
+                String signature = buildSignature(className, methodName, returnType, params);
+                String javadoc = cleanJavadoc(javadocBody);
+
+                String key = className + "." + methodName;
+                methodDocs.put(key, new MethodDoc(className, methodName, signature, javadoc));
+                methodNames.add(methodName);
+            }
+        }
+
+        // Also find public static methods WITHOUT javadoc
+        Matcher methodMatcher = METHOD_DECL_PATTERN.matcher(source);
+        while (methodMatcher.find()) {
+            String methodName = methodMatcher.group(2);
+            String key = className + "." + methodName;
+            if (!methodDocs.containsKey(key)) {
+                String returnType = methodMatcher.group(1);
+                String params = methodMatcher.group(3).trim();
+                String signature = buildSignature(className, methodName, returnType, params);
+                methodDocs.put(key, new MethodDoc(className, methodName, signature, ""));
+                methodNames.add(methodName);
+            }
+        }
+    }
+
+    /** Regex to match Java annotations like @Override, @SuppressWarnings("unchecked"), etc. */
+    private static final Pattern ANNOTATION_PATTERN = Pattern.compile("@\\w+(\\([^)]*\\))?");
+
+    /**
+     * Check if the text between javadoc end and method start is only whitespace and annotations.
+     */
+    private static boolean isOnlyAnnotationsAndWhitespace(String text, int endPos) {
+        String between = text.substring(0, endPos).trim();
+        if (between.isEmpty()) return true;
+        String stripped = ANNOTATION_PATTERN.matcher(between).replaceAll("").trim();
+        return stripped.isEmpty();
+    }
+
+    static String buildSignature(String className, String methodName, String returnType, String params) {
+        String cleanParams = cleanParams(params);
+        return className + "." + methodName + "(" + cleanParams + ") -> " + simplifyType(returnType);
+    }
+
+    /**
+     * Clean parameter list for display — simplify types but keep param names.
+     */
+    static String cleanParams(String params) {
+        if (params.isEmpty()) return "";
+
+        var cleaned = new ArrayList<String>();
+        for (String part : splitParams(params)) {
+            String trimmed = part.trim();
+            // Handle annotations in params
+            trimmed = ANNOTATION_PATTERN.matcher(trimmed).replaceAll("").trim();
+            // Split into tokens — last token is param name, everything before is the type
+            String[] tokens = trimmed.split("\\s+");
+            if (tokens.length >= 2) {
+                String name = tokens[tokens.length - 1];
+                String type = String.join(" ", Arrays.copyOf(tokens, tokens.length - 1));
+                cleaned.add(simplifyType(type) + " " + name);
+            } else if (tokens.length == 1) {
+                cleaned.add(tokens[0]);
+            }
+        }
+        return String.join(", ", cleaned);
+    }
+
+    /**
+     * Split parameter list on commas, respecting angle bracket nesting.
+     * E.g. "JulcMap<PlutusData, PlutusData> map, PlutusData key" -> ["JulcMap<PlutusData, PlutusData> map", "PlutusData key"]
+     */
+    static List<String> splitParams(String params) {
+        var result = new ArrayList<String>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < params.length(); i++) {
+            char c = params.charAt(i);
+            if (c == '<') depth++;
+            else if (c == '>') depth--;
+            else if (c == ',' && depth == 0) {
+                result.add(params.substring(start, i));
+                start = i + 1;
+            }
+        }
+        result.add(params.substring(start));
+        return result;
+    }
+
+    /**
+     * Simplify type for display — strip package prefixes from generic args, shorten common types.
+     */
+    static String simplifyType(String type) {
+        // Already simple (no dots, no generics)
+        if (!type.contains(".") && !type.contains("<")) return type;
+
+        // Handle generic types like Tuple2<BigInteger, BigInteger> or Optional<PlutusData>
+        int angleStart = type.indexOf('<');
+        if (angleStart >= 0) {
+            String rawType = simplifyType(type.substring(0, angleStart));
+            String innerContent = type.substring(angleStart + 1, type.length() - 1);
+            // Simplify each generic arg (respecting nested angle brackets)
+            var simplified = new ArrayList<String>();
+            for (String arg : splitParams(innerContent)) {
+                simplified.add(simplifyType(arg.trim()));
+            }
+            return rawType + "<" + String.join(", ", simplified) + ">";
+        }
+
+        // Strip package prefix: com.foo.Bar -> Bar
+        int lastDot = type.lastIndexOf('.');
+        if (lastDot >= 0) {
+            return type.substring(lastDot + 1);
+        }
+        return type;
+    }
+
+    /**
+     * Extract class-level javadoc: the javadoc block immediately before the class declaration.
+     */
+    static String extractClassJavadoc(String source) {
+        Matcher classMatcher = CLASS_DECL_PATTERN.matcher(source);
+        if (!classMatcher.find()) return "";
+
+        int classStart = classMatcher.start();
+        // Find the last javadoc block before the class declaration
+        Matcher javadocMatcher = JAVADOC_PATTERN.matcher(source);
+        String lastJavadoc = null;
+        int lastEnd = -1;
+        while (javadocMatcher.find() && javadocMatcher.end() <= classStart) {
+            lastJavadoc = javadocMatcher.group(1);
+            lastEnd = javadocMatcher.end();
+        }
+
+        if (lastJavadoc == null) return "";
+
+        // Verify only annotations/whitespace between javadoc end and class start
+        String between = source.substring(lastEnd, classStart).trim();
+        String stripped = ANNOTATION_PATTERN.matcher(between).replaceAll("").trim();
+        if (!stripped.isEmpty()) return "";
+
+        return cleanJavadoc(lastJavadoc);
+    }
+
+    /**
+     * Clean javadoc: strip leading * on each line, remove HTML tags, trim.
+     */
+    static String cleanJavadoc(String raw) {
+        String[] lines = raw.split("\n");
+        var cleaned = new ArrayList<String>();
+        for (String line : lines) {
+            // Strip leading whitespace + optional "* "
+            String trimmed = line.trim();
+            if (trimmed.startsWith("* ")) {
+                trimmed = trimmed.substring(2);
+            } else if (trimmed.equals("*")) {
+                trimmed = "";
+            } else if (trimmed.startsWith("*")) {
+                trimmed = trimmed.substring(1);
+            }
+            // Strip <p> tags
+            trimmed = trimmed.replace("<p>", "").trim();
+            // Skip @param, @return, @see, @throws javadoc tags
+            if (trimmed.startsWith("@param") || trimmed.startsWith("@return")
+                    || trimmed.startsWith("@see") || trimmed.startsWith("@throws")) {
+                continue;
+            }
+            cleaned.add(trimmed);
+        }
+
+        // Remove leading/trailing blank lines
+        while (!cleaned.isEmpty() && cleaned.getFirst().isEmpty()) cleaned.removeFirst();
+        while (!cleaned.isEmpty() && cleaned.getLast().isEmpty()) cleaned.removeLast();
+
+        return String.join("\n", cleaned);
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplCompleter.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplCompleter.java
@@ -1,0 +1,197 @@
+package com.bloxbean.julc.cli.repl;
+
+import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * JLine3 tab-completion for the REPL.
+ * <p>
+ * Completes meta-commands, stdlib class names, stdlib methods, and ledger types.
+ * Methods are discovered from two sources:
+ * <ul>
+ *   <li>{@link StdlibRegistry} — PIR-registered builtins (Builtins, ListsLib HOFs)</li>
+ *   <li>Stdlib source files on classpath — source-compiled libraries (MapLib, MathLib, etc.)</li>
+ * </ul>
+ */
+public final class ReplCompleter implements Completer {
+
+    private final List<String> metaCommands = List.of(
+            ":help", ":h", ":quit", ":q", ":exit", ":libs", ":methods", ":doc",
+            ":type", ":uplc", ":pir", ":budget", ":import", ":reset", ":clear"
+    );
+
+    private final List<String> classNames;
+    private final Map<String, Set<String>> methodsByClass;
+    private final List<String> ledgerTypes;
+
+    /** Matches "public static <returnType> methodName(" in Java source. */
+    private static final Pattern STATIC_METHOD_PATTERN =
+            Pattern.compile("public\\s+static\\s+\\S+\\s+(\\w+)\\s*\\(");
+
+    public ReplCompleter() {
+        var registry = StdlibRegistry.defaultRegistry();
+
+        // Collect class simple names from stdlib FQCNs
+        var names = new ArrayList<String>();
+        for (String fqcn : StdlibRegistry.stdlibClassFqcns()) {
+            names.add(fqcn.substring(fqcn.lastIndexOf('.') + 1));
+        }
+        this.classNames = List.copyOf(names);
+
+        // Collect methods per class — merge StdlibRegistry + source-scanned methods
+        this.methodsByClass = new LinkedHashMap<>();
+
+        // 1. From StdlibRegistry (Builtins, ListsLib HOFs, etc.)
+        for (String name : classNames) {
+            var methods = registry.methodsForClass(name);
+            if (!methods.isEmpty()) {
+                methodsByClass.computeIfAbsent(name, k -> new TreeSet<>()).addAll(methods);
+            }
+        }
+
+        // 2. From stdlib source files on classpath (MapLib, MathLib, ByteStringLib, etc.)
+        var librarySources = LibrarySourceResolver.scanClasspathSources(
+                Thread.currentThread().getContextClassLoader());
+        for (var entry : librarySources.entrySet()) {
+            String className = entry.getKey();
+            String source = entry.getValue();
+            Set<String> methods = extractPublicStaticMethods(source);
+            if (!methods.isEmpty()) {
+                methodsByClass.computeIfAbsent(className, k -> new TreeSet<>()).addAll(methods);
+            }
+        }
+
+        // Common ledger types
+        this.ledgerTypes = List.of(
+                "TxInfo", "TxOut", "TxOutRef", "TxInInfo", "ScriptContext",
+                "Address", "Credential", "Value", "OutputDatum",
+                "Interval", "IntervalBound", "IntervalBoundType",
+                "PubKeyHash", "ScriptHash", "ValidatorHash", "PolicyId",
+                "TokenName", "DatumHash", "TxId",
+                "ScriptInfo", "ScriptPurpose", "Vote", "DRep", "Voter",
+                "TxCert", "GovernanceAction", "ProposalProcedure"
+        );
+    }
+
+    /**
+     * Extract public static method names from a Java source string.
+     */
+    static Set<String> extractPublicStaticMethods(String source) {
+        var methods = new TreeSet<String>();
+        Matcher m = STATIC_METHOD_PATTERN.matcher(source);
+        while (m.find()) {
+            methods.add(m.group(1));
+        }
+        return methods;
+    }
+
+    @Override
+    public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+        // JLine compares candidates against line.word(), so we use that for matching.
+        String word = line.word();
+
+        // Meta-command completion: word starts with ":"
+        if (word.startsWith(":")) {
+            for (String mc : metaCommands) {
+                if (mc.startsWith(word)) {
+                    candidates.add(new Candidate(mc));
+                }
+            }
+            return;
+        }
+
+        // Check if previous word in the line is a meta-command that takes a class arg
+        List<String> words = line.words();
+        int wordIndex = line.wordIndex();
+        if (wordIndex > 0) {
+            String prevWord = words.get(wordIndex - 1);
+            if (prevWord.equals(":methods") || prevWord.equals(":type")
+                    || prevWord.equals(":uplc") || prevWord.equals(":pir")) {
+                addClassCompletions(word, candidates);
+                return;
+            }
+            if (prevWord.equals(":doc")) {
+                addDocCompletions(word, candidates);
+                return;
+            }
+        }
+
+        // ClassName.method completion: word contains "."
+        if (addMethodCompletions(word, candidates)) {
+            return;
+        }
+
+        // General identifier completion: class names + ledger types
+        if (!word.isEmpty()) {
+            addClassCompletions(word, candidates);
+            addLedgerTypeCompletions(word, candidates);
+        }
+    }
+
+    private void addClassCompletions(String prefix, List<Candidate> candidates) {
+        for (String name : classNames) {
+            if (name.toLowerCase().startsWith(prefix.toLowerCase())) {
+                candidates.add(new Candidate(name));
+            }
+        }
+    }
+
+    private void addDocCompletions(String word, List<Candidate> candidates) {
+        if (!addMethodCompletions(word, candidates)) {
+            addClassCompletions(word, candidates);
+        }
+    }
+
+    /**
+     * Complete "ClassName.methodPrefix" patterns. Returns true if a class match was found.
+     */
+    private boolean addMethodCompletions(String word, List<Candidate> candidates) {
+        int dotPos = word.lastIndexOf('.');
+        if (dotPos < 0) return false;
+
+        String className = word.substring(0, dotPos);
+        String methodPrefix = word.substring(dotPos + 1);
+        var methods = methodsByClass.get(className);
+        if (methods == null) return false;
+
+        for (String method : methods) {
+            if (method.toLowerCase().startsWith(methodPrefix.toLowerCase())) {
+                candidates.add(new Candidate(
+                        className + "." + method,
+                        method, null, null, null, null, false));
+            }
+        }
+        return true;
+    }
+
+    private void addLedgerTypeCompletions(String prefix, List<Candidate> candidates) {
+        for (String type : ledgerTypes) {
+            if (type.toLowerCase().startsWith(prefix.toLowerCase())) {
+                candidates.add(new Candidate(type));
+            }
+        }
+    }
+
+    /** Exposed for testing: the class names available for completion. */
+    List<String> getClassNames() {
+        return classNames;
+    }
+
+    /** Exposed for testing: methods available for a given class. */
+    Set<String> getMethodsForClass(String className) {
+        return methodsByClass.getOrDefault(className, Set.of());
+    }
+
+    /** Exposed for testing: meta-command list. */
+    List<String> getMetaCommands() {
+        return metaCommands;
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplEngine.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplEngine.java
@@ -1,0 +1,419 @@
+package com.bloxbean.julc.cli.repl;
+
+import com.bloxbean.cardano.julc.compiler.CompileResult;
+import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
+import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.text.UplcPrinter;
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.ExBudget;
+import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.TermExtractor;
+
+import java.math.BigInteger;
+import java.util.*;
+
+/**
+ * Core evaluation engine for the REPL.
+ * <p>
+ * Wraps user expressions in a synthetic class, compiles via {@link JulcCompiler#compileMethod},
+ * evaluates via {@link JulcVm}, and extracts results via {@link TermExtractor}.
+ */
+public final class ReplEngine {
+
+    private final JulcCompiler compiler;
+    private final JulcVm vm;
+    private final Map<String, String> libraryPool;
+    private final MethodDocExtractor docExtractor;
+    private final List<String> userImports = new ArrayList<>();
+    private boolean showBudget = true;
+
+    public ReplEngine() {
+        this.compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
+        this.vm = JulcVm.create();
+        this.libraryPool = LibrarySourceResolver.scanClasspathSources(
+                Thread.currentThread().getContextClassLoader());
+        this.docExtractor = new MethodDocExtractor(libraryPool);
+    }
+
+    /**
+     * Evaluate user input. Handles meta-commands and expressions.
+     */
+    public ReplResult evaluate(String input) {
+        String trimmed = input.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+
+        // Meta-commands
+        if (trimmed.startsWith(":")) {
+            return handleMetaCommand(trimmed);
+        }
+
+        return evaluateExpression(trimmed);
+    }
+
+    /**
+     * Evaluate an expression by wrapping, compiling, and running it.
+     */
+    ReplResult evaluateExpression(String expression) {
+        // First attempt: inferred return type
+        String source = ExpressionWrapper.wrap(expression, userImports);
+        ReplResult result = compileAndEval(source);
+
+        // Fallback: if compilation failed, try PlutusData cast wrapper
+        if (result instanceof ReplResult.Error) {
+            String fallbackSource = ExpressionWrapper.wrapAsData(expression, userImports);
+            ReplResult fallbackResult = compileAndEval(fallbackSource);
+            if (fallbackResult instanceof ReplResult.Success) {
+                return fallbackResult;
+            }
+            // Return original error (more meaningful)
+        }
+
+        return result;
+    }
+
+    private ReplResult compileAndEval(String source) {
+        try {
+            // Resolve libraries needed by the expression
+            var resolvedLibs = LibrarySourceResolver.resolve(source, libraryPool);
+
+            // Compile
+            CompileResult compileResult = compiler.compileMethod(
+                    source, ExpressionWrapper.METHOD_NAME, resolvedLibs);
+
+            if (compileResult.hasErrors()) {
+                var msg = formatDiagnostics(compileResult.diagnostics());
+                return new ReplResult.Error(msg);
+            }
+
+            // Evaluate
+            EvalResult evalResult = vm.evaluate(compileResult.program());
+
+            return switch (evalResult) {
+                case EvalResult.Success s -> {
+                    Object value = TermExtractor.extract(s.resultTerm());
+                    String formatted = formatValue(value);
+                    String uplc = compileResult.uplcFormatted();
+                    String pir = compileResult.pirFormatted();
+                    yield new ReplResult.Success(formatted, s.consumed(), s.traces(), uplc, pir);
+                }
+                case EvalResult.Failure f ->
+                        new ReplResult.Error(f.error(), f.consumed(), f.traces());
+                case EvalResult.BudgetExhausted b ->
+                        new ReplResult.Error("Budget exhausted", b.consumed(), b.traces());
+            };
+        } catch (CompilerException e) {
+            String msg = e.diagnostics().isEmpty()
+                    ? e.getMessage()
+                    : formatDiagnostics(e.diagnostics());
+            return new ReplResult.Error(msg);
+        } catch (Exception e) {
+            return new ReplResult.Error(e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Compile-only evaluation for :type, :uplc, :pir commands.
+     */
+    ReplResult compileOnly(String expression) {
+        String source = ExpressionWrapper.wrap(expression, userImports);
+        try {
+            var resolvedLibs = LibrarySourceResolver.resolve(source, libraryPool);
+            CompileResult result = compiler.compileMethod(
+                    source, ExpressionWrapper.METHOD_NAME, resolvedLibs);
+            if (result.hasErrors()) {
+                return new ReplResult.Error(formatDiagnostics(result.diagnostics()));
+            }
+            String uplc = result.uplcFormatted();
+            String pir = result.pirFormatted();
+            return new ReplResult.Success("(compiled)", ExBudget.ZERO, List.of(), uplc, pir);
+        } catch (CompilerException e) {
+            return new ReplResult.Error(e.getMessage());
+        }
+    }
+
+    private ReplResult handleMetaCommand(String input) {
+        String[] parts = input.split("\\s+", 2);
+        String cmd = parts[0].toLowerCase();
+        String arg = parts.length > 1 ? parts[1].trim() : "";
+
+        return switch (cmd) {
+            case ":help", ":h" -> helpText();
+            case ":quit", ":q", ":exit" -> null; // Signal to quit (handled by ReplCommand)
+            case ":libs" -> listLibs();
+            case ":methods" -> listMethods(arg);
+            case ":type" -> {
+                if (arg.isEmpty()) yield new ReplResult.Error(":type requires an expression");
+                ReplResult r = compileOnly(arg);
+                if (r instanceof ReplResult.Success s) {
+                    yield new ReplResult.MetaOutput("Type: " + ExpressionWrapper.inferReturnType(arg));
+                }
+                yield r;
+            }
+            case ":uplc" -> {
+                if (arg.isEmpty()) yield new ReplResult.Error(":uplc requires an expression");
+                ReplResult r = evaluateExpression(arg);
+                if (r instanceof ReplResult.Success s && s.uplc() != null) {
+                    yield new ReplResult.MetaOutput(s.uplc());
+                }
+                yield r;
+            }
+            case ":pir" -> {
+                if (arg.isEmpty()) yield new ReplResult.Error(":pir requires an expression");
+                ReplResult r = compileOnly(arg);
+                if (r instanceof ReplResult.Success s && s.pir() != null) {
+                    yield new ReplResult.MetaOutput(s.pir());
+                } else if (r instanceof ReplResult.Success) {
+                    yield new ReplResult.MetaOutput("(PIR not available — compile with details)");
+                }
+                yield r;
+            }
+            case ":budget" -> {
+                if (arg.equalsIgnoreCase("on")) {
+                    showBudget = true;
+                    yield new ReplResult.MetaOutput("Budget display: on");
+                } else if (arg.equalsIgnoreCase("off")) {
+                    showBudget = false;
+                    yield new ReplResult.MetaOutput("Budget display: off");
+                } else {
+                    yield new ReplResult.MetaOutput("Budget display: " + (showBudget ? "on" : "off"));
+                }
+            }
+            case ":import" -> {
+                if (arg.isEmpty()) {
+                    if (userImports.isEmpty()) {
+                        yield new ReplResult.MetaOutput("No user imports.");
+                    }
+                    var sb = new StringBuilder("User imports:\n");
+                    for (var imp : userImports) {
+                        sb.append("  import ").append(imp).append(";\n");
+                    }
+                    yield new ReplResult.MetaOutput(sb.toString());
+                }
+                userImports.add(arg);
+                yield new ReplResult.MetaOutput("Added import: " + arg);
+            }
+            case ":reset" -> {
+                userImports.clear();
+                yield new ReplResult.MetaOutput("Session reset.");
+            }
+            case ":clear" -> new ReplResult.MetaOutput("\033[H\033[2J");
+            case ":doc" -> handleDoc(arg);
+            default -> new ReplResult.Error("Unknown command: " + cmd + ". Type :help for available commands.");
+        };
+    }
+
+    private ReplResult.MetaOutput helpText() {
+        return new ReplResult.MetaOutput("""
+                JuLC REPL Commands:
+                  :help, :h           Show this help
+                  :quit, :q, :exit    Exit (also 'quit', 'exit', Ctrl+D)
+                  :libs               List auto-imported stdlib classes
+                  :methods CLASS      List methods for a class (e.g., :methods ListsLib)
+                  :doc CLASS.method   Show documentation for a method or class
+                  :type EXPR          Show inferred type of expression
+                  :uplc EXPR          Show UPLC representation
+                  :pir EXPR           Show PIR intermediate representation
+                  :budget on|off      Toggle budget display
+                  :import CLASS       Add a user import for the session
+                  :reset              Clear session state (user imports)
+                  :clear              Clear screen
+
+                Examples:
+                  1 + 2                           => 3
+                  MathLib.pow(2, 10)              => 1024
+                  ListsLib.length(List.of(1,2,3)) => 3
+                  Builtins.sha2_256(new byte[]{1,2,3})
+                  :doc MathLib.pow
+                  :methods ListsLib
+                  :uplc 1 + 2""");
+    }
+
+    private ReplResult.MetaOutput listLibs() {
+        var sb = new StringBuilder("Auto-imported stdlib libraries:\n");
+        var descriptions = Map.ofEntries(
+                Map.entry("Builtins", "Low-level UPLC builtins (sha2_256, iData, headList, ...)"),
+                Map.entry("ListsLib", "List operations (length, head, tail, map, filter, ...)"),
+                Map.entry("MapLib", "Map operations (lookup, member, insert, delete, ...)"),
+                Map.entry("ValuesLib", "Value/multi-asset operations (leq, eq, singleton, ...)"),
+                Map.entry("OutputLib", "Transaction output helpers (outputsAt, lovelacePaidTo, ...)"),
+                Map.entry("ContextsLib", "ScriptContext accessors (txInfoMint, findOwnInput, ...)"),
+                Map.entry("MathLib", "Math operations (pow, abs, max, min, divMod, ...)"),
+                Map.entry("IntervalLib", "Interval operations (between, isEmpty, finiteBounds, ...)"),
+                Map.entry("CryptoLib", "Cryptographic operations (ECDSA, Schnorr, RIPEMD-160)"),
+                Map.entry("ByteStringLib", "ByteString operations (take, integerToByteString, ...)"),
+                Map.entry("BitwiseLib", "Bitwise operations (and, or, xor, shift, rotate, ...)"),
+                Map.entry("AddressLib", "Address operations (credentialHash, isScriptAddress, ...)"),
+                Map.entry("BlsLib", "BLS12-381 curve operations"),
+                Map.entry("NativeValueLib", "Native Value helpers")
+        );
+
+        for (String fqcn : StdlibRegistry.stdlibClassFqcns()) {
+            String simpleName = fqcn.substring(fqcn.lastIndexOf('.') + 1);
+            String desc = descriptions.getOrDefault(simpleName, "");
+            sb.append("  ").append(String.format("%-16s", simpleName));
+            if (!desc.isEmpty()) {
+                sb.append(" - ").append(desc);
+            }
+            sb.append("\n");
+        }
+        return new ReplResult.MetaOutput(sb.toString());
+    }
+
+    private ReplResult listMethods(String className) {
+        if (className.isEmpty()) {
+            return new ReplResult.Error(":methods requires a class name (e.g., :methods ListsLib)");
+        }
+        // Merge methods from StdlibRegistry (PIR builtins) + source files (compiled libs)
+        var methods = new TreeSet<String>();
+        methods.addAll(StdlibRegistry.defaultRegistry().methodsForClass(className));
+
+        // Scan source file for public static methods
+        String source = libraryPool.get(className);
+        if (source != null) {
+            methods.addAll(ReplCompleter.extractPublicStaticMethods(source));
+        }
+
+        if (methods.isEmpty()) {
+            return new ReplResult.Error("No methods found for class: " + className);
+        }
+        var sb = new StringBuilder(className).append(": ");
+        sb.append(String.join(", ", methods));
+        return new ReplResult.MetaOutput(sb.toString());
+    }
+
+    private ReplResult handleDoc(String arg) {
+        if (arg.isEmpty()) {
+            return new ReplResult.MetaOutput(
+                    "Usage: :doc ClassName.method  or  :doc ClassName\n"
+                    + "Example: :doc MathLib.pow, :doc MapLib");
+        }
+
+        if (arg.contains(".")) {
+            // Method lookup: ClassName.methodName
+            var doc = docExtractor.lookupMethod(arg);
+            if (doc == null) {
+                return new ReplResult.Error("No documentation found for: " + arg);
+            }
+            return new ReplResult.MetaOutput(MethodDocExtractor.formatMethodDoc(doc));
+        } else {
+            // Class lookup
+            var doc = docExtractor.lookupClass(arg);
+            if (doc == null) {
+                return new ReplResult.Error("No documentation found for class: " + arg);
+            }
+            return new ReplResult.MetaOutput(MethodDocExtractor.formatClassDoc(doc));
+        }
+    }
+
+    public boolean isShowBudget() {
+        return showBudget;
+    }
+
+    public void setShowBudget(boolean showBudget) {
+        this.showBudget = showBudget;
+    }
+
+    static String formatValue(Object value) {
+        if (value == null) {
+            return "()";
+        }
+        if (value instanceof byte[] bytes) {
+            return "#" + bytesToHex(bytes);
+        }
+        if (value instanceof BigInteger bi) {
+            return bi.toString();
+        }
+        if (value instanceof Boolean b) {
+            return b.toString();
+        }
+        if (value instanceof String s) {
+            return "\"" + s + "\"";
+        }
+        if (value instanceof Optional<?> opt) {
+            return opt.map(v -> "Some(" + formatValue(v) + ")")
+                    .orElse("None");
+        }
+        if (value instanceof List<?> list) {
+            var sb = new StringBuilder("[");
+            for (int i = 0; i < list.size(); i++) {
+                if (i > 0) sb.append(", ");
+                sb.append(formatValue(list.get(i)));
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+        if (value instanceof PlutusData data) {
+            return formatPlutusData(data);
+        }
+        return value.toString();
+    }
+
+    private static String formatPlutusData(PlutusData data) {
+        return switch (data) {
+            case PlutusData.IntData i -> i.value().toString();
+            case PlutusData.BytesData b -> "#" + bytesToHex(b.value());
+            case PlutusData.ConstrData c -> {
+                var sb = new StringBuilder("Constr(").append(c.tag());
+                if (!c.fields().isEmpty()) {
+                    sb.append(", [");
+                    for (int i = 0; i < c.fields().size(); i++) {
+                        if (i > 0) sb.append(", ");
+                        sb.append(formatPlutusData(c.fields().get(i)));
+                    }
+                    sb.append("]");
+                }
+                sb.append(")");
+                yield sb.toString();
+            }
+            case PlutusData.ListData l -> {
+                var sb = new StringBuilder("[");
+                for (int i = 0; i < l.items().size(); i++) {
+                    if (i > 0) sb.append(", ");
+                    sb.append(formatPlutusData(l.items().get(i)));
+                }
+                sb.append("]");
+                yield sb.toString();
+            }
+            case PlutusData.MapData m -> {
+                var sb = new StringBuilder("{");
+                for (int i = 0; i < m.entries().size(); i++) {
+                    if (i > 0) sb.append(", ");
+                    var entry = m.entries().get(i);
+                    sb.append(formatPlutusData(entry.key()))
+                            .append(": ")
+                            .append(formatPlutusData(entry.value()));
+                }
+                sb.append("}");
+                yield sb.toString();
+            }
+        };
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        var sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+
+    private static String formatDiagnostics(List<CompilerDiagnostic> diagnostics) {
+        var sb = new StringBuilder();
+        for (var d : diagnostics) {
+            if (d.isError()) {
+                sb.append(d.message());
+                if (d.hasSuggestion()) {
+                    sb.append("\n  suggestion: ").append(d.suggestion());
+                }
+                sb.append("\n");
+            }
+        }
+        return sb.toString().trim();
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplResult.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplResult.java
@@ -1,0 +1,39 @@
+package com.bloxbean.julc.cli.repl;
+
+import com.bloxbean.cardano.julc.vm.ExBudget;
+
+import java.util.List;
+
+/**
+ * Sealed result type for REPL evaluation outcomes.
+ */
+public sealed interface ReplResult {
+
+    /**
+     * Successful evaluation with extracted value and budget.
+     */
+    record Success(String formattedValue, ExBudget budget, List<String> traces,
+                   String uplc, String pir) implements ReplResult {
+        public Success {
+            traces = List.copyOf(traces);
+        }
+    }
+
+    /**
+     * Evaluation or compilation error.
+     */
+    record Error(String message, ExBudget budget, List<String> traces) implements ReplResult {
+        public Error {
+            traces = List.copyOf(traces);
+        }
+
+        public Error(String message) {
+            this(message, ExBudget.ZERO, List.of());
+        }
+    }
+
+    /**
+     * Output from a meta-command (:help, :libs, :methods, etc.).
+     */
+    record MetaOutput(String text) implements ReplResult {}
+}

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/ReplCommandTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/ReplCommandTest.java
@@ -1,0 +1,33 @@
+package com.bloxbean.julc.cli.cmd;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReplCommandTest {
+
+    @Test
+    void hasUnmatchedBrackets_balanced_returnsFalse() {
+        assertFalse(ReplCommand.hasUnmatchedBrackets("1 + 2"));
+        assertFalse(ReplCommand.hasUnmatchedBrackets("foo(1, 2)"));
+        assertFalse(ReplCommand.hasUnmatchedBrackets("{ return 1; }"));
+        assertFalse(ReplCommand.hasUnmatchedBrackets(""));
+    }
+
+    @Test
+    void hasUnmatchedBrackets_openParen_returnsTrue() {
+        assertTrue(ReplCommand.hasUnmatchedBrackets("foo(1,"));
+        assertTrue(ReplCommand.hasUnmatchedBrackets("List.of(1, 2, 3"));
+    }
+
+    @Test
+    void hasUnmatchedBrackets_openCurly_returnsTrue() {
+        assertTrue(ReplCommand.hasUnmatchedBrackets("if (true) {"));
+        assertTrue(ReplCommand.hasUnmatchedBrackets("new byte[]{1, 2"));
+    }
+
+    @Test
+    void hasUnmatchedBrackets_insideString_ignored() {
+        assertFalse(ReplCommand.hasUnmatchedBrackets("\"hello { world\""));
+    }
+}

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/output/DiagnosticFormatterTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/output/DiagnosticFormatterTest.java
@@ -16,7 +16,7 @@ class DiagnosticFormatterTest {
                 "unexpected type",
                 "MyValidator.java", 14, 8);
         String formatted = DiagnosticFormatter.format(diag);
-        assertTrue(formatted.contains("MyValidator.java:14:8"));
+        assertTrue(formatted.contains("./MyValidator.java:14:8"));
         assertTrue(formatted.contains("unexpected type"));
     }
 

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ExpressionWrapperTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ExpressionWrapperTest.java
@@ -1,0 +1,132 @@
+package com.bloxbean.julc.cli.repl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExpressionWrapperTest {
+
+    @Test
+    void numericLiteral_infersBigInteger() {
+        assertEquals("BigInteger", ExpressionWrapper.inferReturnType("42"));
+    }
+
+    @Test
+    void negativeLiteral_infersBigInteger() {
+        assertEquals("BigInteger", ExpressionWrapper.inferReturnType("-7"));
+    }
+
+    @Test
+    void booleanTrue_infersBoolean() {
+        assertEquals("boolean", ExpressionWrapper.inferReturnType("true"));
+    }
+
+    @Test
+    void booleanFalse_infersBoolean() {
+        assertEquals("boolean", ExpressionWrapper.inferReturnType("false"));
+    }
+
+    @Test
+    void stringLiteral_infersString() {
+        assertEquals("String", ExpressionWrapper.inferReturnType("\"hello\""));
+    }
+
+    @Test
+    void byteArrayConstruction_infersByteArray() {
+        assertEquals("byte[]", ExpressionWrapper.inferReturnType("new byte[]{1,2,3}"));
+    }
+
+    @Test
+    void arithmeticExpression_infersBigInteger() {
+        assertEquals("BigInteger", ExpressionWrapper.inferReturnType("1 + 2"));
+    }
+
+    @Test
+    void comparisonExpression_infersBoolean() {
+        assertEquals("boolean", ExpressionWrapper.inferReturnType("1 == 2"));
+    }
+
+    @Test
+    void booleanOperator_infersBoolean() {
+        assertEquals("boolean", ExpressionWrapper.inferReturnType("a && b"));
+    }
+
+    @Test
+    void knownIntegerMethod_infersBigInteger() {
+        assertEquals("BigInteger", ExpressionWrapper.inferReturnType("ListsLib.length(xs)"));
+    }
+
+    @Test
+    void knownBooleanMethod_infersBoolean() {
+        assertEquals("boolean", ExpressionWrapper.inferReturnType("ListsLib.isEmpty(xs)"));
+    }
+
+    @Test
+    void knownBytesMethod_infersByteArray() {
+        assertEquals("byte[]", ExpressionWrapper.inferReturnType("Builtins.sha2_256(data)"));
+    }
+
+    @Test
+    void unknownExpression_infersPlutusData() {
+        assertEquals("PlutusData", ExpressionWrapper.inferReturnType("someUnknown(x)"));
+    }
+
+    @Test
+    void wrapNumericExpression_generatesValidClass() {
+        String source = ExpressionWrapper.wrap("1 + 2", List.of());
+        assertTrue(source.contains("class __Repl"));
+        assertTrue(source.contains("static BigInteger __eval()"));
+        assertTrue(source.contains("return 1 + 2;"));
+    }
+
+    @Test
+    void wrapBooleanExpression_generatesValidClass() {
+        String source = ExpressionWrapper.wrap("true", List.of());
+        assertTrue(source.contains("static boolean __eval()"));
+        assertTrue(source.contains("return true;"));
+    }
+
+    @Test
+    void wrapPlutusDataExpression_addsCastWrapper() {
+        String source = ExpressionWrapper.wrap("someCall(x)", List.of());
+        assertTrue(source.contains("static PlutusData __eval()"));
+        assertTrue(source.contains("(PlutusData)(Object)"));
+    }
+
+    @Test
+    void wrapAsData_alwaysUsesCastWrapper() {
+        String source = ExpressionWrapper.wrapAsData("1 + 2", List.of());
+        assertTrue(source.contains("static PlutusData __eval()"));
+        assertTrue(source.contains("(PlutusData)(Object)"));
+    }
+
+    @Test
+    void wrapIncludesAutoImports() {
+        String source = ExpressionWrapper.wrap("1", List.of());
+        assertTrue(source.contains("import com.bloxbean.cardano.julc.stdlib.Builtins;"));
+        assertTrue(source.contains("import com.bloxbean.cardano.julc.stdlib.lib.ListsLib;"));
+        assertTrue(source.contains("import com.bloxbean.cardano.julc.stdlib.lib.MapLib;"));
+        assertTrue(source.contains("import java.math.BigInteger;"));
+        assertTrue(source.contains("import com.bloxbean.cardano.julc.ledger.*;"));
+        assertTrue(source.contains("import com.bloxbean.cardano.julc.core.PlutusData;"));
+    }
+
+    @Test
+    void wrapIncludesUserImports() {
+        String source = ExpressionWrapper.wrap("1", List.of("com.example.MyLib"));
+        assertTrue(source.contains("import com.example.MyLib;"));
+    }
+
+    @Test
+    void mathPow_infersBigInteger() {
+        assertEquals("BigInteger", ExpressionWrapper.inferReturnType("MathLib.pow(2, 10)"));
+    }
+
+    @Test
+    void arithmeticInsideParens_notDetectedAsTopLevel() {
+        // "foo(1 + 2)" — the + is inside parens, so not top-level arithmetic
+        assertEquals("PlutusData", ExpressionWrapper.inferReturnType("foo(1 + 2)"));
+    }
+}

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/MethodDocExtractorTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/MethodDocExtractorTest.java
@@ -1,0 +1,342 @@
+package com.bloxbean.julc.cli.repl;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MethodDocExtractorTest {
+
+    private static MethodDocExtractor extractor;
+
+    private static final String SAMPLE_SOURCE = """
+            package com.example;
+
+            import java.math.BigInteger;
+
+            /**
+             * Mathematical operations compiled from Java source to UPLC.
+             */
+            public class MathLib {
+
+                /** Returns the absolute value of an integer. */
+                public static BigInteger abs(BigInteger x) {
+                    return x;
+                }
+
+                /**
+                 * Returns base raised to the power of exp.
+                 *
+                 * Exponent must be non-negative.
+                 */
+                public static BigInteger pow(BigInteger base, BigInteger exp) {
+                    return base;
+                }
+
+                /** Returns (base^exp) mod modulus using the builtin ExpModInteger operation. */
+                public static BigInteger expMod(BigInteger base, BigInteger exp, BigInteger mod) {
+                    return base;
+                }
+
+                public static BigInteger noJavadoc(BigInteger x) {
+                    return x;
+                }
+
+                private static void hidden() {}
+            }
+            """;
+
+    private static final String MAP_SOURCE = """
+            package com.example;
+
+            import java.util.Optional;
+
+            /**
+             * Map (association list) operations compiled from Java source to UPLC.
+             *
+             * Uses JulcMap for type-safe map manipulation.
+             */
+            public class MapLib {
+
+                /** Return an empty map. */
+                @SuppressWarnings("unchecked")
+                public static JulcMap<PlutusData, PlutusData> empty() {
+                    return null;
+                }
+
+                /** Look up a key. Returns Optional.of(value) if found, Optional.empty() if not. */
+                @SuppressWarnings("unchecked")
+                public static Optional<PlutusData> lookup(JulcMap<PlutusData, PlutusData> map, PlutusData key) {
+                    return null;
+                }
+            }
+            """;
+
+    private static final String NO_JAVADOC_SOURCE = """
+            package com.example;
+
+            public class Bare {
+                public static int add(int a, int b) {
+                    return a + b;
+                }
+            }
+            """;
+
+    @BeforeAll
+    static void setup() {
+        extractor = new MethodDocExtractor(Map.of(
+                "MathLib", SAMPLE_SOURCE,
+                "MapLib", MAP_SOURCE,
+                "Bare", NO_JAVADOC_SOURCE));
+    }
+
+    @Test
+    void lookupMethod_found() {
+        var doc = extractor.lookupMethod("MathLib.abs");
+        assertNotNull(doc);
+        assertEquals("MathLib", doc.className());
+        assertEquals("abs", doc.methodName());
+        assertTrue(doc.signature().contains("MathLib.abs("));
+        assertTrue(doc.signature().contains("BigInteger x"));
+        assertTrue(doc.signature().contains("-> BigInteger"));
+        assertTrue(doc.javadoc().contains("absolute value"));
+    }
+
+    @Test
+    void lookupMethod_pow_multiLineJavadoc() {
+        var doc = extractor.lookupMethod("MathLib.pow");
+        assertNotNull(doc);
+        assertTrue(doc.signature().contains("BigInteger base, BigInteger exp"));
+        assertTrue(doc.javadoc().contains("base raised to the power"));
+        assertTrue(doc.javadoc().contains("non-negative"));
+    }
+
+    @Test
+    void lookupMethod_threeParams() {
+        var doc = extractor.lookupMethod("MathLib.expMod");
+        assertNotNull(doc);
+        assertTrue(doc.signature().contains("BigInteger base, BigInteger exp, BigInteger mod"));
+    }
+
+    @Test
+    void lookupMethod_noJavadoc_emptyString() {
+        var doc = extractor.lookupMethod("MathLib.noJavadoc");
+        assertNotNull(doc, "Methods without javadoc should still be found");
+        assertEquals("", doc.javadoc());
+        assertTrue(doc.signature().contains("MathLib.noJavadoc("));
+    }
+
+    @Test
+    void lookupMethod_privateNotIncluded() {
+        var doc = extractor.lookupMethod("MathLib.hidden");
+        assertNull(doc, "Private methods should not be extracted");
+    }
+
+    @Test
+    void lookupMethod_unknown_returnsNull() {
+        assertNull(extractor.lookupMethod("UnknownClass.foo"));
+        assertNull(extractor.lookupMethod("MathLib.nonexistent"));
+    }
+
+    @Test
+    void lookupClass_found() {
+        var doc = extractor.lookupClass("MathLib");
+        assertNotNull(doc);
+        assertEquals("MathLib", doc.className());
+        assertTrue(doc.javadoc().contains("Mathematical operations"));
+        assertTrue(doc.methodNames().contains("abs"));
+        assertTrue(doc.methodNames().contains("pow"));
+        assertTrue(doc.methodNames().contains("expMod"));
+        assertTrue(doc.methodNames().contains("noJavadoc"));
+    }
+
+    @Test
+    void lookupClass_unknown_returnsNull() {
+        assertNull(extractor.lookupClass("UnknownClass"));
+    }
+
+    @Test
+    void lookupClass_mapLib_multiLineClassJavadoc() {
+        var doc = extractor.lookupClass("MapLib");
+        assertNotNull(doc);
+        assertTrue(doc.javadoc().contains("Map (association list)"));
+        assertTrue(doc.methodNames().contains("empty"));
+        assertTrue(doc.methodNames().contains("lookup"));
+    }
+
+    @Test
+    void lookupMethod_withAnnotation_javadocExtracted() {
+        var doc = extractor.lookupMethod("MapLib.empty");
+        assertNotNull(doc);
+        assertTrue(doc.javadoc().contains("empty map"));
+    }
+
+    @Test
+    void lookupMethod_withAnnotation_signatureCorrect() {
+        var doc = extractor.lookupMethod("MapLib.lookup");
+        assertNotNull(doc);
+        // Generic types should be simplified and commas inside <> preserved
+        assertTrue(doc.signature().contains("MapLib.lookup("), "Got: " + doc.signature());
+        assertTrue(doc.signature().contains("JulcMap<PlutusData, PlutusData> map"),
+                "Generic params should be intact, got: " + doc.signature());
+    }
+
+    @Test
+    void lookupClass_noJavadoc_emptyString() {
+        var doc = extractor.lookupClass("Bare");
+        assertNotNull(doc);
+        assertEquals("", doc.javadoc());
+        assertTrue(doc.methodNames().contains("add"));
+    }
+
+    // --- Formatting tests ---
+
+    @Test
+    void formatMethodDoc_signature_and_javadoc() {
+        var doc = extractor.lookupMethod("MathLib.abs");
+        String formatted = MethodDocExtractor.formatMethodDoc(doc);
+        assertTrue(formatted.contains("MathLib.abs("));
+        assertTrue(formatted.contains("absolute value"));
+    }
+
+    @Test
+    void formatMethodDoc_noJavadoc() {
+        var doc = extractor.lookupMethod("MathLib.noJavadoc");
+        String formatted = MethodDocExtractor.formatMethodDoc(doc);
+        assertTrue(formatted.contains("MathLib.noJavadoc("));
+        // Should not have extra blank lines
+        assertFalse(formatted.contains("\n\n"));
+    }
+
+    @Test
+    void formatClassDoc_showsMethodList() {
+        var doc = extractor.lookupClass("MathLib");
+        String formatted = MethodDocExtractor.formatClassDoc(doc);
+        assertTrue(formatted.contains("MathLib"));
+        assertTrue(formatted.contains("Methods:"));
+        assertTrue(formatted.contains("abs"));
+        assertTrue(formatted.contains("pow"));
+    }
+
+    // --- Static helper tests ---
+
+    @Test
+    void cleanJavadoc_stripsStars() {
+        String raw = " * First line.\n * Second line.\n ";
+        String cleaned = MethodDocExtractor.cleanJavadoc(raw);
+        assertEquals("First line.\nSecond line.", cleaned);
+    }
+
+    @Test
+    void cleanJavadoc_stripsParagraphTag() {
+        String raw = " * Line one.\n * <p>\n * Line two.\n ";
+        String cleaned = MethodDocExtractor.cleanJavadoc(raw);
+        assertTrue(cleaned.contains("Line one."));
+        assertTrue(cleaned.contains("Line two."));
+        assertFalse(cleaned.contains("<p>"));
+    }
+
+    @Test
+    void cleanJavadoc_skipsParamTags() {
+        String raw = " * Does something.\n * @param x the value\n * @return the result\n ";
+        String cleaned = MethodDocExtractor.cleanJavadoc(raw);
+        assertEquals("Does something.", cleaned);
+    }
+
+    @Test
+    void simplifyType_simple() {
+        assertEquals("BigInteger", MethodDocExtractor.simplifyType("BigInteger"));
+        assertEquals("int", MethodDocExtractor.simplifyType("int"));
+    }
+
+    @Test
+    void simplifyType_fullyQualified() {
+        assertEquals("BigInteger", MethodDocExtractor.simplifyType("java.math.BigInteger"));
+    }
+
+    @Test
+    void simplifyType_generic() {
+        assertEquals("Optional<PlutusData>",
+                MethodDocExtractor.simplifyType("Optional<PlutusData>"));
+        assertEquals("Tuple2<BigInteger, BigInteger>",
+                MethodDocExtractor.simplifyType("Tuple2<BigInteger, BigInteger>"));
+    }
+
+    @Test
+    void simplifyType_nestedGeneric() {
+        assertEquals("JulcMap<PlutusData, PlutusData>",
+                MethodDocExtractor.simplifyType("JulcMap<PlutusData, PlutusData>"));
+    }
+
+    @Test
+    void cleanParams_simple() {
+        assertEquals("BigInteger x", MethodDocExtractor.cleanParams("BigInteger x"));
+    }
+
+    @Test
+    void cleanParams_multiple() {
+        assertEquals("BigInteger a, BigInteger b",
+                MethodDocExtractor.cleanParams("BigInteger a, BigInteger b"));
+    }
+
+    @Test
+    void cleanParams_empty() {
+        assertEquals("", MethodDocExtractor.cleanParams(""));
+    }
+
+    @Test
+    void cleanParams_genericType_commaPreserved() {
+        assertEquals("JulcMap<PlutusData, PlutusData> map, PlutusData key",
+                MethodDocExtractor.cleanParams("JulcMap<PlutusData, PlutusData> map, PlutusData key"));
+    }
+
+    @Test
+    void splitParams_respectsAngleBrackets() {
+        var result = MethodDocExtractor.splitParams("JulcMap<PlutusData, PlutusData> map, PlutusData key");
+        assertEquals(2, result.size());
+        assertTrue(result.get(0).contains("JulcMap<PlutusData, PlutusData>"));
+        assertTrue(result.get(1).contains("PlutusData key"));
+    }
+
+    @Test
+    void splitParams_noGenerics() {
+        var result = MethodDocExtractor.splitParams("BigInteger a, BigInteger b");
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void buildSignature_format() {
+        String sig = MethodDocExtractor.buildSignature("MathLib", "pow", "BigInteger", "BigInteger base, BigInteger exp");
+        assertEquals("MathLib.pow(BigInteger base, BigInteger exp) -> BigInteger", sig);
+    }
+
+    // --- Integration with real stdlib sources ---
+
+    @Test
+    void realLibraryPool_mathLibPow() {
+        var pool = com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.scanClasspathSources(
+                Thread.currentThread().getContextClassLoader());
+        if (pool.containsKey("MathLib")) {
+            var realExtractor = new MethodDocExtractor(pool);
+            var doc = realExtractor.lookupMethod("MathLib.pow");
+            assertNotNull(doc, "MathLib.pow should be found in real stdlib");
+            assertTrue(doc.signature().contains("pow"));
+            assertFalse(doc.javadoc().isEmpty(), "MathLib.pow should have javadoc");
+        }
+        // Skip if stdlib not on classpath (CI without julc-stdlib dependency)
+    }
+
+    @Test
+    void realLibraryPool_classDocExists() {
+        var pool = com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.scanClasspathSources(
+                Thread.currentThread().getContextClassLoader());
+        if (pool.containsKey("MapLib")) {
+            var realExtractor = new MethodDocExtractor(pool);
+            var doc = realExtractor.lookupClass("MapLib");
+            assertNotNull(doc);
+            assertFalse(doc.methodNames().isEmpty(), "MapLib should have methods");
+        }
+    }
+}

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ReplCompleterTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ReplCompleterTest.java
@@ -1,0 +1,97 @@
+package com.bloxbean.julc.cli.repl;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReplCompleterTest {
+
+    private static ReplCompleter completer;
+
+    @BeforeAll
+    static void setup() {
+        completer = new ReplCompleter();
+    }
+
+    @Test
+    void classNamesIncludeListsLib() {
+        assertTrue(completer.getClassNames().contains("ListsLib"));
+    }
+
+    @Test
+    void classNamesIncludeBuiltins() {
+        assertTrue(completer.getClassNames().contains("Builtins"));
+    }
+
+    @Test
+    void classNamesIncludeMapLib() {
+        assertTrue(completer.getClassNames().contains("MapLib"));
+    }
+
+    @Test
+    void methodsForBuiltins_containsSha2() {
+        var methods = completer.getMethodsForClass("Builtins");
+        assertTrue(methods.contains("sha2_256"), "Expected sha2_256 in Builtins methods");
+    }
+
+    @Test
+    void methodsForMapLib_containsLookup() {
+        var methods = completer.getMethodsForClass("MapLib");
+        assertTrue(methods.contains("lookup"), "Expected lookup in MapLib methods, got: " + methods);
+    }
+
+    @Test
+    void methodsForMathLib_containsPow() {
+        var methods = completer.getMethodsForClass("MathLib");
+        assertTrue(methods.contains("pow"), "Expected pow in MathLib methods, got: " + methods);
+    }
+
+    @Test
+    void methodsForByteStringLib_notEmpty() {
+        var methods = completer.getMethodsForClass("ByteStringLib");
+        assertFalse(methods.isEmpty(), "ByteStringLib should have methods");
+    }
+
+    @Test
+    void methodsForUnknownClass_isEmpty() {
+        assertTrue(completer.getMethodsForClass("UnknownClass").isEmpty());
+    }
+
+    @Test
+    void extractPublicStaticMethods_parsesSource() {
+        var source = """
+                public class Foo {
+                    public static BigInteger bar(int x) { return null; }
+                    public static boolean baz() { return true; }
+                    private static void hidden() {}
+                    public void instance() {}
+                }
+                """;
+        var methods = ReplCompleter.extractPublicStaticMethods(source);
+        assertTrue(methods.contains("bar"));
+        assertTrue(methods.contains("baz"));
+        assertFalse(methods.contains("hidden"));
+        assertFalse(methods.contains("instance"));
+    }
+
+    @Test
+    void metaCommandsIncludeHelp() {
+        assertTrue(completer.getMetaCommands().contains(":help"));
+    }
+
+    @Test
+    void metaCommandsIncludeQuit() {
+        assertTrue(completer.getMetaCommands().contains(":quit"));
+    }
+
+    @Test
+    void metaCommandsIncludeMethods() {
+        assertTrue(completer.getMetaCommands().contains(":methods"));
+    }
+
+    @Test
+    void metaCommandsIncludeDoc() {
+        assertTrue(completer.getMetaCommands().contains(":doc"));
+    }
+}

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ReplEngineTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ReplEngineTest.java
@@ -1,0 +1,237 @@
+package com.bloxbean.julc.cli.repl;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReplEngineTest {
+
+    private static ReplEngine engine;
+
+    @BeforeAll
+    static void setup() {
+        engine = new ReplEngine();
+    }
+
+    @Test
+    void evaluateSimpleAddition() {
+        var result = engine.evaluate("1 + 2");
+        assertInstanceOf(ReplResult.Success.class, result);
+        assertEquals("3", ((ReplResult.Success) result).formattedValue());
+    }
+
+    @Test
+    void evaluateBooleanTrue() {
+        var result = engine.evaluate("true");
+        assertInstanceOf(ReplResult.Success.class, result);
+        assertEquals("true", ((ReplResult.Success) result).formattedValue());
+    }
+
+    @Test
+    void evaluateBooleanFalse() {
+        var result = engine.evaluate("false");
+        assertInstanceOf(ReplResult.Success.class, result);
+        assertEquals("false", ((ReplResult.Success) result).formattedValue());
+    }
+
+    @Test
+    void evaluateMultiplication() {
+        var result = engine.evaluate("3 * 7");
+        assertInstanceOf(ReplResult.Success.class, result);
+        assertEquals("21", ((ReplResult.Success) result).formattedValue());
+    }
+
+    @Test
+    void evaluateComparison() {
+        var result = engine.evaluate("1 == 1");
+        assertInstanceOf(ReplResult.Success.class, result);
+        assertEquals("true", ((ReplResult.Success) result).formattedValue());
+    }
+
+    @Test
+    void evaluateComparisonFalse() {
+        var result = engine.evaluate("1 == 2");
+        assertInstanceOf(ReplResult.Success.class, result);
+        assertEquals("false", ((ReplResult.Success) result).formattedValue());
+    }
+
+    @Test
+    void evaluateMathPow() {
+        var result = engine.evaluate("MathLib.pow(2, 10)");
+        assertInstanceOf(ReplResult.Success.class, result);
+        assertEquals("1024", ((ReplResult.Success) result).formattedValue());
+    }
+
+    @Test
+    void evaluateSha2_256() {
+        var result = engine.evaluate("Builtins.sha2_256(new byte[]{1, 2, 3})");
+        assertInstanceOf(ReplResult.Success.class, result);
+        String value = ((ReplResult.Success) result).formattedValue();
+        assertTrue(value.startsWith("#"), "Expected hex bytes, got: " + value);
+        assertEquals(65, value.length(), "sha2_256 should produce 32 bytes (64 hex chars + #)");
+    }
+
+    @Test
+    void evaluateBudgetPopulated() {
+        var result = engine.evaluate("1 + 2");
+        assertInstanceOf(ReplResult.Success.class, result);
+        var success = (ReplResult.Success) result;
+        assertTrue(success.budget().cpuSteps() > 0, "CPU should be > 0");
+        assertTrue(success.budget().memoryUnits() > 0, "Mem should be > 0");
+    }
+
+    @Test
+    void evaluateEmptyInput_returnsNull() {
+        assertNull(engine.evaluate(""));
+        assertNull(engine.evaluate("   "));
+    }
+
+    @Test
+    void compilationError_returnsError() {
+        var result = engine.evaluate("undeclaredVar.foo()");
+        assertInstanceOf(ReplResult.Error.class, result);
+    }
+
+    @Test
+    void helpCommand_returnsMetaOutput() {
+        var result = engine.evaluate(":help");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        assertTrue(((ReplResult.MetaOutput) result).text().contains(":quit"));
+    }
+
+    @Test
+    void libsCommand_listsStdlib() {
+        var result = engine.evaluate(":libs");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        var text = ((ReplResult.MetaOutput) result).text();
+        assertTrue(text.contains("ListsLib"));
+        assertTrue(text.contains("MapLib"));
+        assertTrue(text.contains("Builtins"));
+    }
+
+    @Test
+    void methodsCommand_listsMethodsForClass() {
+        var result = engine.evaluate(":methods Builtins");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        var text = ((ReplResult.MetaOutput) result).text();
+        assertTrue(text.contains("sha2_256"));
+    }
+
+    @Test
+    void methodsCommand_noClassName_returnsError() {
+        var result = engine.evaluate(":methods");
+        assertInstanceOf(ReplResult.Error.class, result);
+    }
+
+    @Test
+    void budgetCommand_toggle() {
+        engine.setShowBudget(true);
+        var result = engine.evaluate(":budget off");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        assertFalse(engine.isShowBudget());
+
+        result = engine.evaluate(":budget on");
+        assertTrue(engine.isShowBudget());
+    }
+
+    @Test
+    void importCommand_addsImport() {
+        var result = engine.evaluate(":import com.example.Foo");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        assertTrue(((ReplResult.MetaOutput) result).text().contains("com.example.Foo"));
+    }
+
+    @Test
+    void resetCommand_clearsState() {
+        engine.evaluate(":import com.example.Bar");
+        var result = engine.evaluate(":reset");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+    }
+
+    @Test
+    void unknownCommand_returnsError() {
+        var result = engine.evaluate(":foo");
+        assertInstanceOf(ReplResult.Error.class, result);
+        assertTrue(((ReplResult.Error) result).message().contains("Unknown command"));
+    }
+
+    @Test
+    void docCommand_method_showsSignature() {
+        var result = engine.evaluate(":doc MathLib.pow");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        var text = ((ReplResult.MetaOutput) result).text();
+        assertTrue(text.contains("MathLib.pow("), "Expected signature, got: " + text);
+        assertTrue(text.contains("BigInteger"), "Expected return type, got: " + text);
+    }
+
+    @Test
+    void docCommand_method_showsJavadoc() {
+        var result = engine.evaluate(":doc MathLib.abs");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        var text = ((ReplResult.MetaOutput) result).text();
+        assertTrue(text.contains("absolute value"), "Expected javadoc, got: " + text);
+    }
+
+    @Test
+    void docCommand_class_showsMethods() {
+        var result = engine.evaluate(":doc MathLib");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        var text = ((ReplResult.MetaOutput) result).text();
+        assertTrue(text.contains("MathLib"), "Expected class name, got: " + text);
+        assertTrue(text.contains("Methods:"), "Expected method list, got: " + text);
+    }
+
+    @Test
+    void docCommand_noArg_showsUsage() {
+        var result = engine.evaluate(":doc");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        var text = ((ReplResult.MetaOutput) result).text();
+        assertTrue(text.contains("Usage:"), "Expected usage hint, got: " + text);
+    }
+
+    @Test
+    void docCommand_unknownMethod_returnsError() {
+        var result = engine.evaluate(":doc UnknownClass.foo");
+        assertInstanceOf(ReplResult.Error.class, result);
+    }
+
+    @Test
+    void docCommand_unknownClass_returnsError() {
+        var result = engine.evaluate(":doc UnknownClass");
+        assertInstanceOf(ReplResult.Error.class, result);
+    }
+
+    @Test
+    void helpCommand_mentionsDoc() {
+        var result = engine.evaluate(":help");
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        assertTrue(((ReplResult.MetaOutput) result).text().contains(":doc"));
+    }
+
+    @Test
+    void formatValue_integer() {
+        assertEquals("42", ReplEngine.formatValue(java.math.BigInteger.valueOf(42)));
+    }
+
+    @Test
+    void formatValue_byteArray() {
+        assertEquals("#0102ff", ReplEngine.formatValue(new byte[]{1, 2, (byte) 0xff}));
+    }
+
+    @Test
+    void formatValue_boolean() {
+        assertEquals("true", ReplEngine.formatValue(true));
+        assertEquals("false", ReplEngine.formatValue(false));
+    }
+
+    @Test
+    void formatValue_null() {
+        assertEquals("()", ReplEngine.formatValue(null));
+    }
+
+    @Test
+    void formatValue_string() {
+        assertEquals("\"hello\"", ReplEngine.formatValue("hello"));
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/FailureReportIntegrationTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/FailureReportIntegrationTest.java
@@ -1,0 +1,239 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+import com.bloxbean.cardano.julc.testkit.ValidatorTest;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end integration tests: compile real {@code @Validator} classes with source maps,
+ * evaluate with failing arguments, and verify the BuiltinTrace + FailureReport
+ * contain the expected comparison values and source location.
+ */
+class FailureReportIntegrationTest {
+
+    // Minting validator that checks: 99 == 42 → always fails
+    static final String EQUALITY_FAIL_MINT = """
+            import java.math.BigInteger;
+
+            @Validator
+            class EqualityFailMint {
+                @Entrypoint
+                static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                    BigInteger expected = BigInteger.valueOf(42);
+                    BigInteger actual = BigInteger.valueOf(99);
+                    return actual == expected;
+                }
+            }
+            """;
+
+    // Minting validator that checks: 5 >= 10 → always fails
+    static final String COMPARISON_FAIL_MINT = """
+            import java.math.BigInteger;
+
+            @Validator
+            class ComparisonFailMint {
+                @Entrypoint
+                static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                    BigInteger amount = BigInteger.valueOf(5);
+                    BigInteger threshold = BigInteger.valueOf(10);
+                    return amount >= threshold;
+                }
+            }
+            """;
+
+    // Minting validator that always succeeds
+    static final String ALWAYS_PASS_MINT = """
+            @Validator
+            class AlwaysPassMint {
+                @Entrypoint
+                static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                    return true;
+                }
+            }
+            """;
+
+    @Test
+    void comparisonFailure_capturesLessThanEqualsWithValues() {
+        var options = new CompilerOptions().setSourceMapEnabled(true);
+        var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry(), options);
+        var compiled = compiler.compile(COMPARISON_FAIL_MINT);
+        assertFalse(compiled.hasErrors(), "Compilation should succeed: " + compiled.diagnostics());
+        assertTrue(compiled.hasSourceMap());
+
+        var vm = JulcVm.create();
+        vm.setSourceMap(compiled.sourceMap());
+
+        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()));
+
+        assertInstanceOf(EvalResult.Failure.class, result, "Validator should fail: " + result);
+
+        // Verify builtin trace contains comparison with actual values
+        var builtinTrace = vm.getLastBuiltinTrace();
+        assertFalse(builtinTrace.isEmpty(), "BuiltinTrace should capture builtins");
+
+        var compEntry = builtinTrace.stream()
+                .filter(e -> e.fun() == DefaultFun.LessThanEqualsInteger
+                        && "False".equals(e.resultSummary()))
+                .findFirst().orElse(null);
+        assertNotNull(compEntry,
+                "Should capture LessThanEqualsInteger → False. Got: " + builtinTrace);
+        assertTrue(compEntry.argSummary().contains("10"),
+                "Should contain threshold value 10. Got: " + compEntry.argSummary());
+        assertTrue(compEntry.argSummary().contains("5"),
+                "Should contain amount value 5. Got: " + compEntry.argSummary());
+
+        // Build and format FailureReport
+        var report = FailureReportBuilder.build(result, compiled.sourceMap(),
+                List.of(), builtinTrace);
+        assertNotNull(report);
+
+        var formatted = FailureReportFormatter.format(report);
+        assertTrue(formatted.contains("FAIL"), "Report should start with FAIL");
+        assertTrue(formatted.contains("False"), "Report should contain → False");
+        assertTrue(formatted.contains("Last builtins:"), "Report should show builtins section");
+        assertTrue(formatted.contains("CPU="), "Report should show budget");
+
+        vm.setSourceMap(null);
+    }
+
+    @Test
+    void equalityFailure_capturesEqualsIntegerWithValues() {
+        var options = new CompilerOptions().setSourceMapEnabled(true);
+        var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry(), options);
+        var compiled = compiler.compile(EQUALITY_FAIL_MINT);
+        assertFalse(compiled.hasErrors(), "Compilation should succeed: " + compiled.diagnostics());
+
+        var vm = JulcVm.create();
+        vm.setSourceMap(compiled.sourceMap());
+
+        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()));
+
+        assertInstanceOf(EvalResult.Failure.class, result, "Validator should fail: " + result);
+
+        var builtinTrace = vm.getLastBuiltinTrace();
+        var equalsEntry = builtinTrace.stream()
+                .filter(e -> e.fun() == DefaultFun.EqualsInteger
+                        && "False".equals(e.resultSummary()))
+                .findFirst().orElse(null);
+        assertNotNull(equalsEntry,
+                "Should capture EqualsInteger → False. Got: " + builtinTrace);
+        assertTrue(equalsEntry.argSummary().contains("99"),
+                "Should contain value 99. Got: " + equalsEntry.argSummary());
+        assertTrue(equalsEntry.argSummary().contains("42"),
+                "Should contain value 42. Got: " + equalsEntry.argSummary());
+
+        vm.setSourceMap(null);
+    }
+
+    @Test
+    void validatorSuccess_builtinTraceCapturedButNoFailureReport() {
+        var options = new CompilerOptions().setSourceMapEnabled(true);
+        var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry(), options);
+        var compiled = compiler.compile(ALWAYS_PASS_MINT);
+
+        var vm = JulcVm.create();
+        vm.setSourceMap(compiled.sourceMap());
+
+        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()));
+        assertTrue(result.isSuccess(), "Validator should succeed: " + result);
+
+        // BuiltinTrace is still active on success (ring buffer captured builtins from ScriptContext deconstruction)
+        var builtinTrace = vm.getLastBuiltinTrace();
+        // Even a trivial validator that returns true will have some builtins from ScriptContext processing
+        // (at minimum the IfThenElse guard). But an always-true may have zero if it's optimized away.
+        // Just verify the API works without crashing.
+        assertNotNull(builtinTrace);
+
+        // FailureReportBuilder returns null for success
+        assertNull(FailureReportBuilder.build(result, compiled.sourceMap()));
+
+        vm.setSourceMap(null);
+    }
+
+    @Test
+    void evaluateWithDiagnostics_failure_producesReport() {
+        var compiled = ValidatorTest.compileWithSourceMap(EQUALITY_FAIL_MINT);
+
+        var report = ValidatorTest.evaluateWithDiagnostics(compiled, buildMintingCtx());
+        assertNotNull(report, "Failing validator should produce a FailureReport");
+        assertEquals("Error term encountered", report.errorMessage());
+        assertFalse(report.lastBuiltins().isEmpty(),
+                "FailureReport should include builtin trace");
+
+        var formatted = FailureReportFormatter.format(report);
+        assertTrue(formatted.contains("FAIL"));
+        assertTrue(formatted.contains("False"));
+    }
+
+    @Test
+    void evaluateWithDiagnostics_success_returnsNull() {
+        var compiled = ValidatorTest.compileWithSourceMap(ALWAYS_PASS_MINT);
+
+        var report = ValidatorTest.evaluateWithDiagnostics(compiled, buildMintingCtx());
+        assertNull(report, "Succeeding validator should return null");
+    }
+
+    @Test
+    void assertValidatesWithDiagnostics_failureMessage_containsBuiltinValues() {
+        var compiled = ValidatorTest.compileWithSourceMap(EQUALITY_FAIL_MINT);
+
+        var error = assertThrows(AssertionError.class,
+                () -> ValidatorTest.assertValidatesWithDiagnostics(compiled, buildMintingCtx()));
+
+        var message = error.getMessage();
+        assertTrue(message.contains("FAIL"), "Error message should contain FAIL");
+        assertTrue(message.contains("False"), "Error message should contain → False");
+        assertTrue(message.contains("Last builtins:"),
+                "Error message should contain Last builtins section");
+    }
+
+    // --- ScriptContext helpers ---
+
+    private static PlutusData buildMintingCtx() {
+        var txInfo = buildMinimalTxInfo();
+        var redeemer = PlutusData.integer(0);
+        // MintingScript = Constr(0, [policyId])
+        var scriptInfo = PlutusData.constr(0, PlutusData.bytes(new byte[28]));
+        return PlutusData.constr(0, txInfo, redeemer, scriptInfo);
+    }
+
+    private static PlutusData buildMinimalTxInfo() {
+        return PlutusData.constr(0,
+                PlutusData.list(),                          // 0: inputs
+                PlutusData.list(),                          // 1: referenceInputs
+                PlutusData.list(),                          // 2: outputs
+                PlutusData.integer(2000000),                // 3: fee
+                PlutusData.map(),                           // 4: mint
+                PlutusData.list(),                          // 5: certificates
+                PlutusData.map(),                           // 6: withdrawals
+                alwaysInterval(),                           // 7: validRange
+                PlutusData.list(),                          // 8: signatories
+                PlutusData.map(),                           // 9: redeemers
+                PlutusData.map(),                           // 10: datums
+                PlutusData.bytes(new byte[32]),             // 11: txId
+                PlutusData.map(),                           // 12: votes
+                PlutusData.list(),                          // 13: proposalProcedures
+                PlutusData.constr(1),                       // 14: currentTreasuryAmount (None)
+                PlutusData.constr(1)                        // 15: treasuryDonation (None)
+        );
+    }
+
+    private static PlutusData alwaysInterval() {
+        var negInf = PlutusData.constr(0);
+        var posInf = PlutusData.constr(2);
+        var trueVal = PlutusData.constr(1);
+        var lowerBound = PlutusData.constr(0, negInf, trueVal);
+        var upperBound = PlutusData.constr(0, posInf, trueVal);
+        return PlutusData.constr(0, lowerBound, upperBound);
+    }
+}

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
@@ -216,6 +216,30 @@ public final class StdlibRegistry implements StdlibLookup {
     }
 
     /**
+     * Returns the set of method names registered for a given class.
+     * Matches by simple name (e.g., "ListsLib") or FQCN against registry keys.
+     *
+     * @param className the simple class name or FQCN
+     * @return set of method names, or empty set if class has no registered methods
+     */
+    public java.util.Set<String> methodsForClass(String className) {
+        var methods = new java.util.TreeSet<String>();
+        // Direct prefix match (works for FQCN keys)
+        String directPrefix = className + ".";
+        // Simple name match: look for ".ClassName." within FQCN keys
+        String simplePrefix = "." + className + ".";
+        for (var key : registry.keySet()) {
+            if (key.startsWith(directPrefix)) {
+                methods.add(key.substring(directPrefix.length()));
+            } else if (key.contains(simplePrefix)) {
+                int idx = key.indexOf(simplePrefix) + simplePrefix.length();
+                methods.add(key.substring(idx));
+            }
+        }
+        return methods;
+    }
+
+    /**
      * Returns the set of all registered class FQCNs.
      * Used to populate ImportResolver's knownFqcns so that imports of stdlib classes
      * (e.g., {@code import com.bloxbean.cardano.julc.stdlib.Builtins;}) resolve correctly.

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/BudgetAssertions.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/BudgetAssertions.java
@@ -3,6 +3,11 @@ package com.bloxbean.cardano.julc.testkit;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
+import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
+import com.bloxbean.cardano.julc.vm.trace.FailureReport;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -179,13 +184,23 @@ public final class BudgetAssertions {
      * Describe a result with source location info if a source map is available.
      */
     public static String describeResult(EvalResult result, SourceMap sourceMap) {
-        var base = describeResult(result);
-        if (sourceMap == null) return base;
-        var location = ValidatorTest.resolveErrorLocation(result, sourceMap);
-        if (location != null) {
-            return base + "\n  at " + location;
+        return describeResult(result, sourceMap, List.of(), List.of());
+    }
+
+    /**
+     * Describe a result with full diagnostic context.
+     */
+    public static String describeResult(EvalResult result, SourceMap sourceMap,
+                                         List<ExecutionTraceEntry> executionTrace,
+                                         List<BuiltinExecution> builtinTrace) {
+        if (!result.isSuccess()) {
+            FailureReport report = FailureReportBuilder.build(
+                    result, sourceMap, executionTrace, builtinTrace);
+            if (report != null) {
+                return FailureReportFormatter.format(report);
+            }
         }
-        return base;
+        return describeResult(result);
     }
 
     private static String describeResult(EvalResult result) {

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ContractTest.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ContractTest.java
@@ -14,6 +14,7 @@ import com.bloxbean.cardano.julc.ledger.Voter;
 import com.bloxbean.cardano.julc.stdlib.Builtins;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.io.IOException;
@@ -382,9 +383,29 @@ public abstract class ContractTest {
      * @return the evaluation result
      */
     protected EvalResult evaluateWithTrace(CompileResult compiled, PlutusData... args) {
+        return doEvaluate(compiled, true, args);
+    }
+
+    /**
+     * Evaluate a compiled program with source map but WITHOUT execution tracing.
+     * Retrieves the builtin trace (always collected by the VM) for lightweight diagnostics.
+     *
+     * @param compiled the compile result (with source map)
+     * @param args     the PlutusData arguments
+     * @return the evaluation result
+     */
+    protected EvalResult evaluateWithBuiltinTrace(CompileResult compiled, PlutusData... args) {
+        return doEvaluate(compiled, false, args);
+    }
+
+    /**
+     * Shared evaluate helper — sets source map, optionally enables tracing,
+     * evaluates, and cleans up the shared VM state.
+     */
+    private EvalResult doEvaluate(CompileResult compiled, boolean tracing, PlutusData... args) {
         var v = vm();
         v.setSourceMap(compiled.sourceMap());
-        v.setTracingEnabled(true);
+        if (tracing) v.setTracingEnabled(true);
         try {
             if (args.length == 0) {
                 return v.evaluate(compiled.program());
@@ -394,6 +415,14 @@ public abstract class ContractTest {
             v.setTracingEnabled(false);
             v.setSourceMap(null);
         }
+    }
+
+    /**
+     * Returns the builtin trace from the most recent evaluation.
+     * Builtin tracing is always on by default — no opt-in required.
+     */
+    protected java.util.List<BuiltinExecution> getLastBuiltinTrace() {
+        return vm().getLastBuiltinTrace();
     }
 
     /**

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/JulcEval.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/JulcEval.java
@@ -3,10 +3,11 @@ package com.bloxbean.cardano.julc.testkit;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
 import com.bloxbean.cardano.julc.core.Term;
-import com.bloxbean.cardano.julc.core.source.SourceLocation;
-import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -53,6 +54,7 @@ public final class JulcEval {
     private boolean sourceMapEnabled;
     private boolean tracingEnabled;
     private volatile List<ExecutionTraceEntry> lastExecutionTrace = List.of();
+    private volatile List<BuiltinExecution> lastBuiltinTrace = List.of();
 
     private JulcEval(String javaSource, Class<?> sourceClass, Path sourceRoot,
                      com.bloxbean.cardano.julc.core.PlutusData[] params) {
@@ -132,6 +134,25 @@ public final class JulcEval {
     }
 
     /**
+     * Alias for {@link #sourceMap()} that communicates intent to retrieve builtin trace.
+     * <p>
+     * Since builtin trace is always collected by the VM, this just ensures the
+     * source map is set (for error location resolution) and that builtin trace
+     * is captured after evaluation. Functionally identical to {@code sourceMap()}.
+     * <p>
+     * Example:
+     * <pre>{@code
+     * var eval = JulcEval.forClass(MyValidator.class).builtinTrace();
+     * eval.call("validate", data).asBoolean();
+     * System.out.println(eval.getLastBuiltinTrace());
+     * }</pre>
+     */
+    public JulcEval builtinTrace() {
+        this.sourceMapEnabled = true;
+        return this;
+    }
+
+    /**
      * Enable execution tracing. Implies {@link #sourceMap()}.
      * After each call, the execution trace is accessible via {@link #getLastExecutionTrace()}
      * and {@link #formatLastTrace()}.
@@ -170,6 +191,14 @@ public final class JulcEval {
      */
     public String formatLastBudgetSummary() {
         return ExecutionTraceEntry.formatSummary(lastExecutionTrace);
+    }
+
+    /**
+     * Returns the builtin trace from the most recent call.
+     * Builtin tracing is always on by default — no opt-in required.
+     */
+    public List<BuiltinExecution> getLastBuiltinTrace() {
+        return lastBuiltinTrace;
     }
 
     // --- Interface proxy ---
@@ -281,6 +310,7 @@ public final class JulcEval {
             }
         } finally {
             this.lastExecutionTrace = vm.getLastExecutionTrace();
+            this.lastBuiltinTrace = vm.getLastBuiltinTrace();
             vm.setTracingEnabled(false);
             vm.setSourceMap(null);
         }
@@ -289,18 +319,18 @@ public final class JulcEval {
             return s.resultTerm();
         }
 
-        // Resolve source location for error message
-        var location = ValidatorTest.resolveErrorLocation(result, compiled.sourceMap());
-        var errorMsg = switch (result) {
-            case EvalResult.Failure f -> "Evaluation failed: " + f.error();
-            case EvalResult.BudgetExhausted b -> "Budget exhausted: " + b.consumed();
-            default -> "Evaluation failed: " + result;
-        };
-        if (location != null) {
-            errorMsg += "\n  at " + location;
-        }
-        if (tracingEnabled && !lastExecutionTrace.isEmpty()) {
-            errorMsg += "\n" + ExecutionTraceEntry.format(lastExecutionTrace);
+        // Build rich error report (reuses FailureReportBuilder+FailureReportFormatter)
+        var report = FailureReportBuilder.build(result, compiled.sourceMap(),
+                lastExecutionTrace, lastBuiltinTrace);
+        String errorMsg;
+        if (report != null) {
+            errorMsg = FailureReportFormatter.format(report);
+        } else {
+            errorMsg = switch (result) {
+                case EvalResult.Failure f -> "Evaluation failed: " + f.error();
+                case EvalResult.BudgetExhausted b -> "Budget exhausted: " + b.consumed();
+                default -> "Evaluation failed: " + result;
+            };
         }
         throw new com.bloxbean.cardano.julc.vm.TermExtractor.ExtractionException(errorMsg);
     }

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ValidatorTest.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ValidatorTest.java
@@ -11,7 +11,11 @@ import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
 import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
+import com.bloxbean.cardano.julc.vm.trace.FailureReport;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
+import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -527,6 +531,38 @@ public final class ValidatorTest {
         BudgetAssertions.assertFailure(result, compileResult.sourceMap());
     }
 
+    // --- Builtin trace (lightweight) ---
+
+    /**
+     * Evaluate a compiled program with source map but WITHOUT execution tracing.
+     * Retrieves the builtin trace (always collected by the VM) for lightweight diagnostics.
+     * <p>
+     * This is cheaper than {@link #evaluateWithTrace} because it does not enable
+     * per-step execution tracing.
+     *
+     * @param compiled the compile result (with source map)
+     * @param args     the PlutusData arguments
+     * @return the result with empty execution trace and populated builtin trace
+     */
+    public static EvalWithTrace evaluateWithBuiltinTrace(CompileResult compiled, PlutusData... args) {
+        return doEvaluate(compiled, false, args);
+    }
+
+    /**
+     * Evaluate a compiled program with builtin-only diagnostics (no execution tracing).
+     * Returns a {@link FailureReport} if the evaluation fails, or null on success.
+     * <p>
+     * Lighter-weight alternative to {@link #evaluateWithDiagnostics} — useful for
+     * diagnosing validator failures without the overhead of full execution tracing.
+     *
+     * @param compiled the compile result (with source map)
+     * @param args     the PlutusData arguments
+     * @return a FailureReport on failure, null on success
+     */
+    public static FailureReport evaluateWithBuiltinDiagnostics(CompileResult compiled, PlutusData... args) {
+        return buildReportIfFailed(evaluateWithBuiltinTrace(compiled, args), compiled.sourceMap());
+    }
+
     // --- Execution tracing ---
 
     /**
@@ -538,25 +574,19 @@ public final class ValidatorTest {
      * @return the result and execution trace
      */
     public static EvalWithTrace evaluateWithTrace(CompileResult compiled, PlutusData... args) {
-        var vm = JulcVm.create();
-        vm.setSourceMap(compiled.sourceMap());
-        vm.setTracingEnabled(true);
-        EvalResult result;
-        if (args.length == 0) {
-            result = vm.evaluate(compiled.program());
-        } else {
-            result = vm.evaluateWithArgs(compiled.program(), List.of(args));
-        }
-        var trace = vm.getLastExecutionTrace();
-        vm.setTracingEnabled(false);
-        vm.setSourceMap(null);
-        return new EvalWithTrace(result, trace);
+        return doEvaluate(compiled, true, args);
     }
 
     /**
-     * Holds an evaluation result together with its execution trace.
+     * Holds an evaluation result together with its execution trace and builtin trace.
      */
-    public record EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace) {
+    public record EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace,
+                                 List<BuiltinExecution> builtinTrace) {
+        /** Backward-compatible constructor (no builtin trace). */
+        public EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace) {
+            this(result, trace, List.of());
+        }
+
         /** Format the trace as a readable multi-line string. */
         public String formatTrace() {
             return ExecutionTraceEntry.format(trace);
@@ -566,6 +596,65 @@ public final class ValidatorTest {
         public String formatBudgetSummary() {
             return ExecutionTraceEntry.formatSummary(trace);
         }
+    }
+
+    // --- Diagnostic evaluation ---
+
+    /**
+     * Evaluate a compiled program with full diagnostics (source map, execution trace, builtin trace).
+     * Returns a {@link FailureReport} if the evaluation fails, or null on success.
+     *
+     * @param compiled the compile result (with source map)
+     * @param args     the PlutusData arguments
+     * @return a FailureReport on failure, null on success
+     */
+    public static FailureReport evaluateWithDiagnostics(CompileResult compiled, PlutusData... args) {
+        return buildReportIfFailed(evaluateWithTrace(compiled, args), compiled.sourceMap());
+    }
+
+    /**
+     * Assert that the program evaluates successfully, with rich diagnostics on failure.
+     * <p>
+     * On failure, the assertion error includes source location, last builtin executions,
+     * and budget consumed — the full {@link FailureReport}.
+     *
+     * @param compiled the compile result (with source map)
+     * @param args     the arguments to apply
+     */
+    public static void assertValidatesWithDiagnostics(CompileResult compiled, PlutusData... args) {
+        var report = evaluateWithDiagnostics(compiled, args);
+        if (report != null) {
+            throw new AssertionError("Expected validator to succeed, but got:\n"
+                    + FailureReportFormatter.format(report));
+        }
+    }
+
+    /**
+     * Shared evaluate helper — creates a VM, sets source map, optionally enables tracing,
+     * evaluates, and collects traces. The VM is throwaway (no cleanup needed).
+     */
+    private static EvalWithTrace doEvaluate(CompileResult compiled, boolean tracing, PlutusData... args) {
+        var vm = JulcVm.create();
+        vm.setSourceMap(compiled.sourceMap());
+        if (tracing) vm.setTracingEnabled(true);
+        EvalResult result;
+        if (args.length == 0) {
+            result = vm.evaluate(compiled.program());
+        } else {
+            result = vm.evaluateWithArgs(compiled.program(), List.of(args));
+        }
+        var executionTrace = tracing ? vm.getLastExecutionTrace() : List.<ExecutionTraceEntry>of();
+        var builtinTrace = vm.getLastBuiltinTrace();
+        return new EvalWithTrace(result, executionTrace, builtinTrace);
+    }
+
+    /**
+     * Build a FailureReport if evaluation failed, null otherwise.
+     */
+    private static FailureReport buildReportIfFailed(EvalWithTrace traced, SourceMap sourceMap) {
+        if (traced.result().isSuccess()) return null;
+        return FailureReportBuilder.build(traced.result(), sourceMap,
+                traced.trace(), traced.builtinTrace());
     }
 
     private static String formatResult(EvalResult result) {

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/CekMachine.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/CekMachine.java
@@ -10,7 +10,9 @@ import com.bloxbean.cardano.julc.vm.java.builtins.BuiltinRuntime;
 import com.bloxbean.cardano.julc.vm.java.builtins.BuiltinTable;
 import com.bloxbean.cardano.julc.vm.java.cost.CostTracker;
 import com.bloxbean.cardano.julc.vm.java.cost.MachineCosts.StepKind;
+import com.bloxbean.cardano.julc.vm.java.trace.BuiltinTraceCollector;
 import com.bloxbean.cardano.julc.vm.java.trace.ExecutionTraceCollector;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.ArrayDeque;
@@ -38,6 +40,7 @@ public final class CekMachine {
     private final BuiltinTable.VersionedBuiltinTable builtinTable;
     private final SourceMap sourceMap;
     private final ExecutionTraceCollector executionTraceCollector;
+    private final BuiltinTraceCollector builtinTraceCollector;
 
     // Machine state
     private Term currentTerm;
@@ -60,15 +63,33 @@ public final class CekMachine {
         this(costTracker, language, null, false);
     }
 
-    /** Create a CekMachine with optional cost tracking, language version, source map and tracing. */
+    /**
+     * Create a CekMachine with optional cost tracking, language version, source map and tracing.
+     * Builtin trace is enabled by default.
+     */
     public CekMachine(CostTracker costTracker, PlutusLanguage language,
                       SourceMap sourceMap, boolean tracingEnabled) {
+        this(costTracker, language, sourceMap, tracingEnabled, true);
+    }
+
+    /**
+     * Create a CekMachine with fine-grained trace control.
+     *
+     * @param costTracker         optional cost tracking
+     * @param language            Plutus language version
+     * @param sourceMap           optional source map for source-level diagnostics
+     * @param executionTraceEnabled  true to record per-step execution trace (requires sourceMap)
+     * @param builtinTraceEnabled    true to record last N builtin executions with argument values
+     */
+    public CekMachine(CostTracker costTracker, PlutusLanguage language,
+                      SourceMap sourceMap, boolean executionTraceEnabled, boolean builtinTraceEnabled) {
         this.costTracker = costTracker;
         this.language = language;
         this.builtinTable = BuiltinTable.forLanguage(language);
         this.sourceMap = sourceMap;
-        this.executionTraceCollector = (tracingEnabled && sourceMap != null && !sourceMap.isEmpty())
+        this.executionTraceCollector = (executionTraceEnabled && sourceMap != null && !sourceMap.isEmpty())
                 ? new ExecutionTraceCollector(costTracker) : null;
+        this.builtinTraceCollector = builtinTraceEnabled ? new BuiltinTraceCollector(20) : null;
     }
 
     /**
@@ -120,6 +141,12 @@ public final class CekMachine {
     public List<ExecutionTraceEntry> getExecutionTrace() {
         if (executionTraceCollector == null) return List.of();
         return executionTraceCollector.getEntries();
+    }
+
+    /** Returns the last N builtin executions (empty if builtin tracing is disabled). */
+    public List<BuiltinExecution> getBuiltinTrace() {
+        if (builtinTraceCollector == null) return List.of();
+        return builtinTraceCollector.getEntries();
     }
 
     // === COMPUTE phase ===
@@ -341,7 +368,18 @@ public final class CekMachine {
         }
 
         BuiltinRuntime runtime = builtinTable.getRuntime(vb.fun());
-        return runtime.execute(vb.collectedArgs());
+        try {
+            CekValue result = runtime.execute(vb.collectedArgs());
+            if (builtinTraceCollector != null) {
+                builtinTraceCollector.record(vb.fun(), vb.collectedArgs(), result);
+            }
+            return result;
+        } catch (Exception e) {
+            if (builtinTraceCollector != null) {
+                builtinTraceCollector.recordError(vb.fun(), vb.collectedArgs(), e);
+            }
+            throw e;
+        }
     }
 
     private void chargeStep(StepKind kind) {

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/JavaVmProvider.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/JavaVmProvider.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.julc.core.Term;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.vm.*;
 import com.bloxbean.cardano.julc.vm.java.cost.*;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.List;
@@ -26,7 +27,9 @@ public class JavaVmProvider implements JulcVmProvider {
     private volatile CostModelParser.ParsedCostModel customV3CostModel;
     private volatile SourceMap sourceMap;
     private volatile boolean tracingEnabled;
+    private volatile boolean builtinTraceEnabled = true;
     private volatile List<ExecutionTraceEntry> lastExecutionTrace = List.of();
+    private volatile List<BuiltinExecution> lastBuiltinTrace = List.of();
 
     @Override
     public void setCostModelParams(long[] costModelValues, PlutusLanguage language,
@@ -67,25 +70,24 @@ public class JavaVmProvider implements JulcVmProvider {
             bcm = DefaultCostModel.defaultBuiltinCostModel(language);
         }
         var costTracker = new CostTracker(mc, bcm, budget);
-        var machine = new CekMachine(costTracker, language, sourceMap, tracingEnabled);
+        var machine = new CekMachine(costTracker, language, sourceMap, tracingEnabled, builtinTraceEnabled);
         try {
             CekValue result = machine.evaluate(term);
-            lastExecutionTrace = machine.getExecutionTrace();
             Term resultTerm = ValueConverter.toTerm(result);
             return new EvalResult.Success(resultTerm, costTracker.consumed(), machine.getTraces());
         } catch (BudgetExhaustedException e) {
-            lastExecutionTrace = machine.getExecutionTrace();
             return new EvalResult.BudgetExhausted(costTracker.consumed(), machine.getTraces(),
                     e.failedTerm());
         } catch (CekEvaluationException e) {
-            lastExecutionTrace = machine.getExecutionTrace();
             String errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             return new EvalResult.Failure(errorMsg, costTracker.consumed(), machine.getTraces(),
                     e.failedTerm());
         } catch (Exception e) {
-            lastExecutionTrace = machine.getExecutionTrace();
             String errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             return new EvalResult.Failure(errorMsg, costTracker.consumed(), machine.getTraces());
+        } finally {
+            lastExecutionTrace = machine.getExecutionTrace();
+            lastBuiltinTrace = machine.getBuiltinTrace();
         }
     }
 
@@ -108,8 +110,18 @@ public class JavaVmProvider implements JulcVmProvider {
     }
 
     @Override
+    public void setBuiltinTraceEnabled(boolean enabled) {
+        this.builtinTraceEnabled = enabled;
+    }
+
+    @Override
     public List<ExecutionTraceEntry> getLastExecutionTrace() {
         return lastExecutionTrace;
+    }
+
+    @Override
+    public List<BuiltinExecution> getLastBuiltinTrace() {
+        return lastBuiltinTrace;
     }
 
     @Override

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/trace/BuiltinTraceCollector.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/trace/BuiltinTraceCollector.java
@@ -1,0 +1,140 @@
+package com.bloxbean.cardano.julc.vm.java.trace;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.vm.java.CekValue;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
+
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Ring buffer that records the last N builtin executions during CEK machine evaluation.
+ * <p>
+ * Stores raw references on the hot path and defers string formatting to {@link #getEntries()},
+ * which runs once after evaluation completes.
+ */
+public final class BuiltinTraceCollector {
+
+    private static final HexFormat HEX = HexFormat.of();
+
+    private record RawEntry(DefaultFun fun, List<CekValue> args, CekValue result, String errorSummary) {}
+
+    private final RawEntry[] buffer;
+    private int head = 0;  // next write position
+    private int size = 0;
+
+    /**
+     * Create a collector with the given ring buffer capacity.
+     *
+     * @param capacity maximum number of recent builtin executions to retain
+     */
+    public BuiltinTraceCollector(int capacity) {
+        if (capacity <= 0) throw new IllegalArgumentException("capacity must be > 0");
+        this.buffer = new RawEntry[capacity];
+    }
+
+    /**
+     * Record a builtin execution. Only stores references — no string formatting on the hot path.
+     *
+     * @param fun    the builtin function
+     * @param args   the arguments (as CekValues)
+     * @param result the result (as CekValue)
+     */
+    public void record(DefaultFun fun, List<CekValue> args, CekValue result) {
+        addEntry(new RawEntry(fun, args, result, null));
+    }
+
+    /**
+     * Record a builtin execution that threw an exception.
+     *
+     * @param fun  the builtin function
+     * @param args the arguments (as CekValues)
+     * @param e    the exception thrown
+     */
+    public void recordError(DefaultFun fun, List<CekValue> args, Exception e) {
+        addEntry(new RawEntry(fun, args, null, e.getClass().getSimpleName()));
+    }
+
+    private void addEntry(RawEntry entry) {
+        buffer[head] = entry;
+        head = (head + 1) % buffer.length;
+        if (size < buffer.length) size++;
+    }
+
+    /**
+     * Return the recorded builtin executions in chronological order,
+     * formatting argument/result summaries lazily.
+     */
+    public List<BuiltinExecution> getEntries() {
+        if (size == 0) return List.of();
+        var result = new ArrayList<BuiltinExecution>(size);
+        int start = (size < buffer.length) ? 0 : head;
+        for (int i = 0; i < size; i++) {
+            var raw = buffer[(start + i) % buffer.length];
+            String resultSummary = raw.result != null
+                    ? formatValue(raw.result)
+                    : "<ERROR: " + raw.errorSummary + ">";
+            result.add(new BuiltinExecution(raw.fun, formatArgs(raw.args), resultSummary));
+        }
+        return List.copyOf(result);
+    }
+
+    private static String formatArgs(List<CekValue> args) {
+        if (args.isEmpty()) return "";
+        var sb = new StringBuilder();
+        for (int i = 0; i < args.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(formatValue(args.get(i)));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Convert a CekValue to a short human-readable string.
+     */
+    static String formatValue(CekValue value) {
+        return switch (value) {
+            case CekValue.VCon vcon -> formatConstant(vcon.constant());
+            case CekValue.VDelay _ -> "<Delay>";
+            case CekValue.VLam _ -> "<Lambda>";
+            case CekValue.VConstr vc -> "<Constr:" + vc.tag() + ">";
+            case CekValue.VBuiltin vb -> "<Builtin:" + vb.fun() + ">";
+        };
+    }
+
+    private static String formatConstant(Constant c) {
+        return switch (c) {
+            case Constant.IntegerConst ic -> ic.value().toString();
+            case Constant.BoolConst bc -> bc.value() ? "True" : "False";
+            case Constant.ByteStringConst bs -> formatByteString(bs.value());
+            case Constant.StringConst sc -> formatString(sc.value());
+            case Constant.UnitConst _ -> "()";
+            case Constant.DataConst _ -> "<Data>";
+            case Constant.ListConst lc -> "[" + lc.values().size() + " elems]";
+            case Constant.PairConst _ -> "<Pair>";
+            case Constant.ArrayConst ac -> "[" + ac.values().size() + " elems]";
+            case Constant.ValueConst vc -> "<Value:" + vc.entries().size() + " policies>";
+            case Constant.Bls12_381_G1Element _ -> "<G1>";
+            case Constant.Bls12_381_G2Element _ -> "<G2>";
+            case Constant.Bls12_381_MlResult _ -> "<MlResult>";
+        };
+    }
+
+    private static String formatByteString(byte[] bytes) {
+        if (bytes.length == 0) return "#";
+        String hex = HEX.formatHex(bytes);
+        if (bytes.length > 8) {
+            return "#" + hex.substring(0, 16) + "...";
+        }
+        return "#" + hex;
+    }
+
+    private static String formatString(String s) {
+        if (s.length() > 20) {
+            return "\"" + s.substring(0, 17) + "...\"";
+        }
+        return "\"" + s + "\"";
+    }
+}

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/BuiltinTraceIntegrationTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/BuiltinTraceIntegrationTest.java
@@ -1,0 +1,260 @@
+package com.bloxbean.cardano.julc.vm.java;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.core.source.SourceLocation;
+import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.java.cost.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.IdentityHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test verifying that CekMachine captures builtin executions
+ * in its trace with fine-grained control over builtin vs execution tracing.
+ */
+class BuiltinTraceIntegrationTest {
+
+    @Test
+    void booleanGuardFailure_capturesComparisonBuiltin() {
+        // Build: IfThenElse(LessThanEqualsInteger(5, 3), True, Error)
+        // This simulates: return 5 <= 3 → Error branch
+        var lessThanEquals = applyBuiltin(DefaultFun.LessThanEqualsInteger,
+                new Term.Const(Constant.integer(5)),
+                new Term.Const(Constant.integer(3)));
+        var ifThenElse = applyBuiltin(DefaultFun.IfThenElse,
+                lessThanEquals,
+                new Term.Const(Constant.bool(true)),
+                new Term.Error());
+
+        // Create a non-empty source map so the collector activates
+        var sourceMap = createSourceMap(ifThenElse, "test.java", 1, "5 <= 3");
+
+        var mc = DefaultCostModel.defaultMachineCosts(PlutusLanguage.PLUTUS_V3);
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(PlutusLanguage.PLUTUS_V3);
+        var costTracker = new CostTracker(mc, bcm, null);
+        var machine = new CekMachine(costTracker, PlutusLanguage.PLUTUS_V3, sourceMap, false);
+
+        assertThrows(CekEvaluationException.class, () -> machine.evaluate(ifThenElse));
+
+        var builtinTrace = machine.getBuiltinTrace();
+        assertFalse(builtinTrace.isEmpty(), "Builtin trace should not be empty");
+
+        // Should have captured LessThanEqualsInteger → False
+        boolean foundComparison = builtinTrace.stream()
+                .anyMatch(e -> e.fun() == DefaultFun.LessThanEqualsInteger
+                        && "False".equals(e.resultSummary()));
+        assertTrue(foundComparison,
+                "Should capture LessThanEqualsInteger(5, 3) → False, got: " + builtinTrace);
+    }
+
+    @Test
+    void successfulEvaluation_capturesBuiltinTrace() {
+        // Build: AddInteger(3, 5)
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)),
+                new Term.Const(Constant.integer(5)));
+
+        var sourceMap = createSourceMap(add, "Test.java", 1, "3 + 5");
+
+        var mc = DefaultCostModel.defaultMachineCosts(PlutusLanguage.PLUTUS_V3);
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(PlutusLanguage.PLUTUS_V3);
+        var costTracker = new CostTracker(mc, bcm, null);
+        var machine = new CekMachine(costTracker, PlutusLanguage.PLUTUS_V3, sourceMap, false);
+
+        CekValue result = machine.evaluate(add);
+        assertInstanceOf(CekValue.VCon.class, result);
+
+        var builtinTrace = machine.getBuiltinTrace();
+        assertEquals(1, builtinTrace.size());
+        assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
+        assertEquals("3, 5", builtinTrace.getFirst().argSummary());
+        assertEquals("8", builtinTrace.getFirst().resultSummary());
+    }
+
+    @Test
+    void noSourceMap_stillCapturesBuiltinTrace() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(1)),
+                new Term.Const(Constant.integer(2)));
+
+        var mc = DefaultCostModel.defaultMachineCosts(PlutusLanguage.PLUTUS_V3);
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(PlutusLanguage.PLUTUS_V3);
+        var costTracker = new CostTracker(mc, bcm, null);
+        var machine = new CekMachine(costTracker, PlutusLanguage.PLUTUS_V3, null, false);
+
+        machine.evaluate(add);
+        var builtinTrace = machine.getBuiltinTrace();
+        assertFalse(builtinTrace.isEmpty(), "Builtin trace should be captured even without source map");
+        assertEquals(1, builtinTrace.size());
+        assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
+        assertEquals("1, 2", builtinTrace.getFirst().argSummary());
+        assertEquals("3", builtinTrace.getFirst().resultSummary());
+    }
+
+    @Test
+    void emptySourceMap_stillCapturesBuiltinTrace() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(1)),
+                new Term.Const(Constant.integer(2)));
+
+        var mc = DefaultCostModel.defaultMachineCosts(PlutusLanguage.PLUTUS_V3);
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(PlutusLanguage.PLUTUS_V3);
+        var costTracker = new CostTracker(mc, bcm, null);
+        var machine = new CekMachine(costTracker, PlutusLanguage.PLUTUS_V3, SourceMap.EMPTY, false);
+
+        machine.evaluate(add);
+        var builtinTrace = machine.getBuiltinTrace();
+        assertFalse(builtinTrace.isEmpty(), "Builtin trace should be captured even with empty source map");
+        assertEquals(1, builtinTrace.size());
+        assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
+    }
+
+    @Test
+    void providerChain_exposesBuiltinTrace() {
+        var provider = new JavaVmProvider();
+        var dummy = new Term.Const(Constant.integer(0));
+        var sourceMap = createSourceMap(dummy, "Test.java", 1, "dummy");
+        provider.setSourceMap(sourceMap);
+
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)),
+                new Term.Const(Constant.integer(5)));
+        var program = new com.bloxbean.cardano.julc.core.Program(1, 1, 0, add);
+
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        assertInstanceOf(EvalResult.Success.class, result);
+
+        var builtinTrace = provider.getLastBuiltinTrace();
+        assertFalse(builtinTrace.isEmpty());
+        assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
+
+        provider.setSourceMap(null);
+    }
+
+    @Test
+    void multipleBuiltins_ringBufferCapturesLast5() {
+        // Build a chain of additions: ((1+2) + (3+4)) + (5+6)
+        // This will execute 3 AddInteger builtins total
+        var a1 = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(1)), new Term.Const(Constant.integer(2)));
+        var a2 = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)), new Term.Const(Constant.integer(4)));
+        var a3 = applyBuiltin(DefaultFun.AddInteger, a1, a2);
+
+        var dummy = new Term.Const(Constant.integer(0));
+        var sourceMap = createSourceMap(dummy, "Test.java", 1, "dummy");
+
+        var mc = DefaultCostModel.defaultMachineCosts(PlutusLanguage.PLUTUS_V3);
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(PlutusLanguage.PLUTUS_V3);
+        var costTracker = new CostTracker(mc, bcm, null);
+        var machine = new CekMachine(costTracker, PlutusLanguage.PLUTUS_V3, sourceMap, false);
+
+        machine.evaluate(a3);
+        var builtinTrace = machine.getBuiltinTrace();
+        assertEquals(3, builtinTrace.size());
+        // First: 1+2=3, Second: 3+4=7, Third: 3+7=10
+        assertEquals("3", builtinTrace.get(0).resultSummary());
+        assertEquals("7", builtinTrace.get(1).resultSummary());
+        assertEquals("10", builtinTrace.get(2).resultSummary());
+    }
+
+    @Test
+    void builtinTraceDisabled_returnsEmptyTrace() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(1)),
+                new Term.Const(Constant.integer(2)));
+
+        var mc = DefaultCostModel.defaultMachineCosts(PlutusLanguage.PLUTUS_V3);
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(PlutusLanguage.PLUTUS_V3);
+        var costTracker = new CostTracker(mc, bcm, null);
+        // 5-arg constructor: executionTrace=false, builtinTrace=false
+        var machine = new CekMachine(costTracker, PlutusLanguage.PLUTUS_V3, null, false, false);
+
+        machine.evaluate(add);
+        assertTrue(machine.getBuiltinTrace().isEmpty(),
+                "Builtin trace should be empty when explicitly disabled");
+    }
+
+    @Test
+    void builtinTraceOnly_noExecutionTrace() {
+        // Demonstrates enabling builtin trace without execution trace
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)),
+                new Term.Const(Constant.integer(5)));
+
+        var sourceMap = createSourceMap(add, "Test.java", 1, "3 + 5");
+
+        var mc = DefaultCostModel.defaultMachineCosts(PlutusLanguage.PLUTUS_V3);
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(PlutusLanguage.PLUTUS_V3);
+        var costTracker = new CostTracker(mc, bcm, null);
+        // executionTrace=false, builtinTrace=true
+        var machine = new CekMachine(costTracker, PlutusLanguage.PLUTUS_V3, sourceMap, false, true);
+
+        machine.evaluate(add);
+
+        // Builtin trace should be captured
+        var builtinTrace = machine.getBuiltinTrace();
+        assertEquals(1, builtinTrace.size());
+        assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
+
+        // Execution trace should be empty (not enabled)
+        assertTrue(machine.getExecutionTrace().isEmpty(),
+                "Execution trace should be empty when only builtin trace is enabled");
+    }
+
+    @Test
+    void providerLevel_builtinTraceControl() {
+        var provider = new JavaVmProvider();
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)),
+                new Term.Const(Constant.integer(5)));
+        var program = new com.bloxbean.cardano.julc.core.Program(1, 1, 0, add);
+
+        // Default: builtin trace enabled
+        var result1 = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        assertInstanceOf(EvalResult.Success.class, result1);
+        assertFalse(provider.getLastBuiltinTrace().isEmpty(),
+                "Builtin trace should be on by default");
+
+        // Disable builtin trace
+        provider.setBuiltinTraceEnabled(false);
+        var result2 = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        assertInstanceOf(EvalResult.Success.class, result2);
+        assertTrue(provider.getLastBuiltinTrace().isEmpty(),
+                "Builtin trace should be empty when disabled via provider");
+
+        // Re-enable
+        provider.setBuiltinTraceEnabled(true);
+        var result3 = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        assertInstanceOf(EvalResult.Success.class, result3);
+        assertFalse(provider.getLastBuiltinTrace().isEmpty(),
+                "Builtin trace should be captured again after re-enabling");
+    }
+
+    // --- helpers ---
+
+    private static SourceMap createSourceMap(Term term, String file, int line, String fragment) {
+        var map = new IdentityHashMap<Term, SourceLocation>();
+        map.put(term, new SourceLocation(file, line, 1, fragment));
+        return SourceMap.of(map);
+    }
+
+    private static Term applyBuiltin(DefaultFun fun, Term... args) {
+        var table = com.bloxbean.cardano.julc.vm.java.builtins.BuiltinTable.forLanguage(PlutusLanguage.PLUTUS_V3);
+        var sig = table.getSignature(fun);
+        Term t = new Term.Builtin(fun);
+        for (int i = 0; i < sig.forceCount(); i++) {
+            t = new Term.Force(t);
+        }
+        for (Term arg : args) {
+            t = new Term.Apply(t, arg);
+        }
+        return t;
+    }
+}

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/trace/BuiltinTraceCollectorTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/trace/BuiltinTraceCollectorTest.java
@@ -1,0 +1,203 @@
+package com.bloxbean.cardano.julc.vm.java.trace;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.vm.java.CekValue;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BuiltinTraceCollectorTest {
+
+    @Test
+    void emptyCollector_returnsEmptyList() {
+        var collector = new BuiltinTraceCollector(5);
+        assertEquals(List.of(), collector.getEntries());
+    }
+
+    @Test
+    void recordSingleEntry() {
+        var collector = new BuiltinTraceCollector(5);
+        collector.record(DefaultFun.AddInteger,
+                List.of(vcon(Constant.integer(3)), vcon(Constant.integer(5))),
+                vcon(Constant.integer(8)));
+
+        var entries = collector.getEntries();
+        assertEquals(1, entries.size());
+        assertEquals(DefaultFun.AddInteger, entries.getFirst().fun());
+        assertEquals("3, 5", entries.getFirst().argSummary());
+        assertEquals("8", entries.getFirst().resultSummary());
+    }
+
+    @Test
+    void recordMultipleEntries_preservesOrder() {
+        var collector = new BuiltinTraceCollector(5);
+        collector.record(DefaultFun.UnIData,
+                List.of(vcon(Constant.data(new PlutusData.IntData(BigInteger.valueOf(42))))),
+                vcon(Constant.integer(42)));
+        collector.record(DefaultFun.EqualsInteger,
+                List.of(vcon(Constant.integer(42)), vcon(Constant.integer(42))),
+                vcon(Constant.bool(true)));
+
+        var entries = collector.getEntries();
+        assertEquals(2, entries.size());
+        assertEquals(DefaultFun.UnIData, entries.get(0).fun());
+        assertEquals(DefaultFun.EqualsInteger, entries.get(1).fun());
+    }
+
+    @Test
+    void ringBuffer_evictsOldest() {
+        var collector = new BuiltinTraceCollector(3);
+        for (int i = 0; i < 5; i++) {
+            collector.record(DefaultFun.AddInteger,
+                    List.of(vcon(Constant.integer(i))),
+                    vcon(Constant.integer(i + 1)));
+        }
+
+        var entries = collector.getEntries();
+        assertEquals(3, entries.size());
+        // Should have entries for i=2,3,4 (oldest 0,1 evicted)
+        assertEquals("2", entries.get(0).argSummary());
+        assertEquals("3", entries.get(1).argSummary());
+        assertEquals("4", entries.get(2).argSummary());
+    }
+
+    @Test
+    void ringBuffer_exactCapacity() {
+        var collector = new BuiltinTraceCollector(3);
+        for (int i = 0; i < 3; i++) {
+            collector.record(DefaultFun.AddInteger,
+                    List.of(vcon(Constant.integer(i))),
+                    vcon(Constant.integer(i)));
+        }
+        var entries = collector.getEntries();
+        assertEquals(3, entries.size());
+        assertEquals("0", entries.get(0).argSummary());
+        assertEquals("2", entries.get(2).argSummary());
+    }
+
+    @Test
+    void formatValue_integer() {
+        assertEquals("42", BuiltinTraceCollector.formatValue(vcon(Constant.integer(42))));
+    }
+
+    @Test
+    void formatValue_bool() {
+        assertEquals("True", BuiltinTraceCollector.formatValue(vcon(Constant.bool(true))));
+        assertEquals("False", BuiltinTraceCollector.formatValue(vcon(Constant.bool(false))));
+    }
+
+    @Test
+    void formatValue_byteString_short() {
+        assertEquals("#a1b2", BuiltinTraceCollector.formatValue(
+                vcon(Constant.byteString(new byte[]{(byte) 0xa1, (byte) 0xb2}))));
+    }
+
+    @Test
+    void formatValue_byteString_truncated() {
+        byte[] longBytes = new byte[32]; // e.g., TxId
+        for (int i = 0; i < longBytes.length; i++) longBytes[i] = (byte) i;
+        String result = BuiltinTraceCollector.formatValue(vcon(Constant.byteString(longBytes)));
+        assertTrue(result.startsWith("#"));
+        assertTrue(result.endsWith("..."));
+        // 8 bytes = 16 hex chars + # + ...
+        assertEquals("#0001020304050607...", result);
+    }
+
+    @Test
+    void formatValue_byteString_empty() {
+        assertEquals("#", BuiltinTraceCollector.formatValue(
+                vcon(Constant.byteString(new byte[0]))));
+    }
+
+    @Test
+    void formatValue_string() {
+        assertEquals("\"hello\"", BuiltinTraceCollector.formatValue(
+                vcon(Constant.string("hello"))));
+    }
+
+    @Test
+    void formatValue_string_truncated() {
+        String longStr = "a".repeat(30);
+        String result = BuiltinTraceCollector.formatValue(vcon(Constant.string(longStr)));
+        assertTrue(result.endsWith("...\""));
+        // "aaaaaaaaaaaaaaaaa..." → quote(1) + 17 chars + ...(3) + quote(1) = 22
+        assertEquals(22, result.length());
+    }
+
+    @Test
+    void formatValue_unit() {
+        assertEquals("()", BuiltinTraceCollector.formatValue(vcon(Constant.unit())));
+    }
+
+    @Test
+    void formatValue_data() {
+        assertEquals("<Data>", BuiltinTraceCollector.formatValue(
+                vcon(Constant.data(new PlutusData.IntData(BigInteger.ONE)))));
+    }
+
+    @Test
+    void formatValue_list() {
+        assertEquals("[2 elems]", BuiltinTraceCollector.formatValue(
+                vcon(new Constant.ListConst(
+                        com.bloxbean.cardano.julc.core.DefaultUni.INTEGER,
+                        List.of(Constant.integer(1), Constant.integer(2))))));
+    }
+
+    @Test
+    void formatValue_pair() {
+        assertEquals("<Pair>", BuiltinTraceCollector.formatValue(
+                vcon(new Constant.PairConst(Constant.integer(1), Constant.integer(2)))));
+    }
+
+    @Test
+    void formatValue_delay() {
+        assertEquals("<Delay>", BuiltinTraceCollector.formatValue(
+                new CekValue.VDelay(null, null)));
+    }
+
+    @Test
+    void formatValue_lambda() {
+        assertEquals("<Lambda>", BuiltinTraceCollector.formatValue(
+                new CekValue.VLam("x", null, null)));
+    }
+
+    @Test
+    void toString_format() {
+        var collector = new BuiltinTraceCollector(5);
+        collector.record(DefaultFun.LessThanEqualsInteger,
+                List.of(vcon(Constant.integer(5)), vcon(Constant.integer(3))),
+                vcon(Constant.bool(false)));
+
+        var entry = collector.getEntries().getFirst();
+        assertEquals("LessThanEqualsInteger(5, 3) → False", entry.toString());
+    }
+
+    @Test
+    void recordError_capturesExceptionType() {
+        var collector = new BuiltinTraceCollector(5);
+        collector.recordError(DefaultFun.HeadList,
+                List.of(vcon(new Constant.ListConst(
+                        com.bloxbean.cardano.julc.core.DefaultUni.INTEGER, List.of()))),
+                new RuntimeException("boom"));
+
+        var entries = collector.getEntries();
+        assertEquals(1, entries.size());
+        assertEquals(DefaultFun.HeadList, entries.getFirst().fun());
+        assertEquals("<ERROR: RuntimeException>", entries.getFirst().resultSummary());
+    }
+
+    @Test
+    void invalidCapacity_throws() {
+        assertThrows(IllegalArgumentException.class, () -> new BuiltinTraceCollector(0));
+        assertThrows(IllegalArgumentException.class, () -> new BuiltinTraceCollector(-1));
+    }
+
+    private static CekValue vcon(Constant c) {
+        return new CekValue.VCon(c);
+    }
+}

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVm.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVm.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.julc.vm;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.Comparator;
@@ -192,12 +193,31 @@ public final class JulcVm {
      * When enabled (and a source map is set), each statement-level CEK step
      * is recorded with its Java source location.
      * <p>
+     * This is the heavier tracing option — for lightweight diagnostics, use
+     * {@link #setBuiltinTraceEnabled(boolean)} instead.
+     * <p>
      * No-op if the active provider does not support tracing.
      *
-     * @param enabled true to enable tracing, false to disable
+     * @param enabled true to enable execution tracing, false to disable
      */
     public void setTracingEnabled(boolean enabled) {
         provider.setTracingEnabled(enabled);
+    }
+
+    /**
+     * Enable or disable builtin trace collection.
+     * When enabled, the last N builtin executions (function name, argument values,
+     * result value) are recorded. This is lightweight and useful for showing
+     * <em>what values</em> caused a validator failure.
+     * <p>
+     * Enabled by default. Disable for zero-overhead production evaluation.
+     * <p>
+     * No-op if the active provider does not support builtin tracing.
+     *
+     * @param enabled true to enable builtin tracing, false to disable
+     */
+    public void setBuiltinTraceEnabled(boolean enabled) {
+        provider.setBuiltinTraceEnabled(enabled);
     }
 
     /**
@@ -207,6 +227,14 @@ public final class JulcVm {
      */
     public List<ExecutionTraceEntry> getLastExecutionTrace() {
         return provider.getLastExecutionTrace();
+    }
+
+    /**
+     * Returns the last N builtin executions from the most recent evaluation.
+     * Empty list if builtin tracing was disabled or the active provider does not support this.
+     */
+    public List<BuiltinExecution> getLastBuiltinTrace() {
+        return provider.getLastBuiltinTrace();
     }
 
     /** The name of the active VM provider. */

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVmProvider.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVmProvider.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.Term;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.List;
@@ -91,20 +92,47 @@ public interface JulcVmProvider {
      * When enabled (and a source map is set), each statement-level CEK step
      * is recorded with its Java source location.
      * <p>
+     * This is the heavier tracing option — for lightweight diagnostics, use
+     * {@link #setBuiltinTraceEnabled(boolean)} instead.
+     * <p>
      * Providers that do not support tracing ignore this call.
      *
-     * @param enabled true to enable tracing, false to disable
+     * @param enabled true to enable execution tracing, false to disable
      */
     default void setTracingEnabled(boolean enabled) {
         // Default: ignore (provider does not support tracing)
     }
 
     /**
+     * Enable or disable builtin trace collection.
+     * When enabled, the last N builtin executions (function name, argument values,
+     * result value) are recorded in a ring buffer. This is lightweight and useful
+     * for showing <em>what values</em> caused a validator failure.
+     * <p>
+     * Enabled by default. Disable for zero-overhead production evaluation.
+     * <p>
+     * Providers that do not support builtin tracing ignore this call.
+     *
+     * @param enabled true to enable builtin tracing, false to disable
+     */
+    default void setBuiltinTraceEnabled(boolean enabled) {
+        // Default: ignore (provider does not support builtin tracing)
+    }
+
+    /**
      * Returns the execution trace from the most recent evaluation.
-     * Empty list if tracing was disabled, no source map was set, or
+     * Empty list if execution tracing was disabled, no source map was set, or
      * the provider does not support tracing.
      */
     default List<ExecutionTraceEntry> getLastExecutionTrace() {
+        return List.of();
+    }
+
+    /**
+     * Returns the last N builtin executions from the most recent evaluation.
+     * Empty list if builtin tracing was disabled or the provider does not support this.
+     */
+    default List<BuiltinExecution> getLastBuiltinTrace() {
         return List.of();
     }
 

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/BuiltinExecution.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/BuiltinExecution.java
@@ -1,0 +1,21 @@
+package com.bloxbean.cardano.julc.vm.trace;
+
+import com.bloxbean.cardano.julc.core.DefaultFun;
+
+/**
+ * Records a single builtin function execution during CEK machine evaluation.
+ * <p>
+ * Uses String summaries (not raw CekValue) so this record can live in the SPI
+ * layer ({@code julc-vm}) without depending on implementation-specific types.
+ *
+ * @param fun           the builtin function that was executed
+ * @param argSummary    short string summarizing the arguments (e.g., "5, 3")
+ * @param resultSummary short string summarizing the result (e.g., "False")
+ */
+public record BuiltinExecution(DefaultFun fun, String argSummary, String resultSummary) {
+
+    @Override
+    public String toString() {
+        return fun + "(" + argSummary + ") → " + resultSummary;
+    }
+}

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReport.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReport.java
@@ -1,0 +1,65 @@
+package com.bloxbean.cardano.julc.vm.trace;
+
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.source.SourceLocation;
+import com.bloxbean.cardano.julc.vm.ExBudget;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Structured report of a validator failure, bundling all diagnostic context.
+ *
+ * @param errorMessage   the error message from the VM (e.g., "Error term encountered")
+ * @param sourceLocation the Java source location that caused the failure (nullable)
+ * @param lastBuiltins   the last N builtin executions before the failure
+ * @param lastSteps      the last N execution trace entries before the failure
+ * @param consumed       the budget consumed before the failure
+ * @param traceMessages  trace messages emitted via {@code Builtins.trace()} before the failure
+ */
+public record FailureReport(
+        String errorMessage,
+        SourceLocation sourceLocation,
+        List<BuiltinExecution> lastBuiltins,
+        List<ExecutionTraceEntry> lastSteps,
+        ExBudget consumed,
+        List<String> traceMessages
+) {
+    /** Builtin functions that are comparison/equality operations. */
+    public static final Set<DefaultFun> COMPARISON_BUILTINS = Set.of(
+            DefaultFun.EqualsInteger, DefaultFun.LessThanInteger,
+            DefaultFun.LessThanEqualsInteger,
+            DefaultFun.EqualsByteString, DefaultFun.LessThanByteString,
+            DefaultFun.LessThanEqualsByteString,
+            DefaultFun.EqualsString, DefaultFun.EqualsData,
+            DefaultFun.VerifyEd25519Signature,
+            DefaultFun.VerifyEcdsaSecp256k1Signature,
+            DefaultFun.VerifySchnorrSecp256k1Signature
+    );
+
+    public FailureReport {
+        Objects.requireNonNull(errorMessage);
+        lastBuiltins = lastBuiltins != null ? List.copyOf(lastBuiltins) : List.of();
+        lastSteps = lastSteps != null ? List.copyOf(lastSteps) : List.of();
+        Objects.requireNonNull(consumed);
+        traceMessages = traceMessages != null ? List.copyOf(traceMessages) : List.of();
+    }
+
+    /**
+     * Find the last comparison/equality builtin that returned False — the likely "cause"
+     * of a boolean validator failure.
+     *
+     * @return the cause builtin execution, or null if none found
+     */
+    public BuiltinExecution findCauseBuiltin() {
+        for (int i = lastBuiltins.size() - 1; i >= 0; i--) {
+            var exec = lastBuiltins.get(i);
+            if (COMPARISON_BUILTINS.contains(exec.fun())
+                    && "False".equals(exec.resultSummary())) {
+                return exec;
+            }
+        }
+        return null;
+    }
+}

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReportBuilder.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReportBuilder.java
@@ -1,0 +1,72 @@
+package com.bloxbean.cardano.julc.vm.trace;
+
+import com.bloxbean.cardano.julc.core.source.SourceLocation;
+import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+
+import java.util.List;
+
+/**
+ * Builds a {@link FailureReport} from an {@link EvalResult} and optional diagnostic traces.
+ */
+public final class FailureReportBuilder {
+
+    private FailureReportBuilder() {}
+
+    /**
+     * Build a FailureReport from a failed evaluation result.
+     *
+     * @param result         the failed EvalResult (Failure or BudgetExhausted)
+     * @param sourceMap      the source map for resolving error locations (nullable)
+     * @param executionTrace the execution trace entries (nullable or empty)
+     * @param builtinTrace   the last N builtin executions (nullable or empty)
+     * @return the structured failure report, or null if the result is a Success
+     */
+    public static FailureReport build(EvalResult result, SourceMap sourceMap,
+                                       List<ExecutionTraceEntry> executionTrace,
+                                       List<BuiltinExecution> builtinTrace) {
+        if (result instanceof EvalResult.Success) return null;
+
+        String errorMessage = switch (result) {
+            case EvalResult.Failure f -> f.error();
+            case EvalResult.BudgetExhausted _ -> "Budget exhausted";
+            case EvalResult.Success _ -> throw new IllegalStateException();
+        };
+
+        // Resolve source location from failed term
+        SourceLocation location = null;
+        if (sourceMap != null) {
+            var failedTerm = switch (result) {
+                case EvalResult.Failure f -> f.failedTerm();
+                case EvalResult.BudgetExhausted b -> b.failedTerm();
+                case EvalResult.Success _ -> null;
+            };
+            if (failedTerm != null) {
+                location = sourceMap.lookup(failedTerm);
+            }
+        }
+
+        return new FailureReport(
+                errorMessage,
+                location,
+                builtinTrace != null ? builtinTrace : List.of(),
+                executionTrace != null ? executionTrace : List.of(),
+                result.budgetConsumed(),
+                result.traces()
+        );
+    }
+
+    /**
+     * Build a FailureReport with only a source map (no builtin/execution traces).
+     */
+    public static FailureReport build(EvalResult result, SourceMap sourceMap) {
+        return build(result, sourceMap, List.of(), List.of());
+    }
+
+    /**
+     * Build a FailureReport with no source map or traces.
+     */
+    public static FailureReport build(EvalResult result) {
+        return build(result, null, List.of(), List.of());
+    }
+}

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReportFormatter.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReportFormatter.java
@@ -1,0 +1,73 @@
+package com.bloxbean.cardano.julc.vm.trace;
+
+/**
+ * Plain-text formatter for {@link FailureReport}.
+ * <p>
+ * Produces output like:
+ * <pre>
+ * FAIL at .(VestingValidator.java:42)  return deadline <= currentSlot
+ *   LessThanEqualsInteger(5, 3) → False
+ *
+ *   Last builtins:
+ *     UnIData(&lt;Data&gt;) → 5
+ *     UnIData(&lt;Data&gt;) → 3
+ *     LessThanEqualsInteger(5, 3) → False
+ *
+ *   Budget: CPU=1,234,567  Mem=45,678
+ * </pre>
+ */
+public final class FailureReportFormatter {
+
+    private FailureReportFormatter() {}
+
+    /**
+     * Format a failure report as plain text.
+     *
+     * @param report the failure report to format
+     * @return multi-line formatted string
+     */
+    public static String format(FailureReport report) {
+        var sb = new StringBuilder();
+
+        // Header: FAIL at .(File.java:line) fragment
+        sb.append("FAIL");
+        if (report.sourceLocation() != null) {
+            sb.append(' ').append(report.sourceLocation());
+        } else {
+            sb.append(": ").append(report.errorMessage());
+        }
+        sb.append('\n');
+
+        // Highlighted cause: the last comparison builtin that returned False
+        var causeBuiltin = report.findCauseBuiltin();
+        if (causeBuiltin != null) {
+            sb.append("  ").append(causeBuiltin).append('\n');
+        }
+
+        // Last builtins section
+        if (!report.lastBuiltins().isEmpty()) {
+            sb.append('\n');
+            sb.append("  Last builtins:\n");
+            for (var exec : report.lastBuiltins()) {
+                sb.append("    ").append(exec).append('\n');
+            }
+        }
+
+        // Trace messages
+        if (!report.traceMessages().isEmpty()) {
+            sb.append('\n');
+            sb.append("  Traces:\n");
+            for (var msg : report.traceMessages()) {
+                sb.append("    ").append(msg).append('\n');
+            }
+        }
+
+        // Budget
+        sb.append('\n');
+        sb.append(String.format("  Budget: CPU=%s  Mem=%s%n",
+                String.format("%,d", report.consumed().cpuSteps()),
+                String.format("%,d", report.consumed().memoryUnits())));
+
+        return sb.toString();
+    }
+}

--- a/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/trace/FailureReportFormatterTest.java
+++ b/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/trace/FailureReportFormatterTest.java
@@ -1,0 +1,183 @@
+package com.bloxbean.cardano.julc.vm.trace;
+
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.source.SourceLocation;
+import com.bloxbean.cardano.julc.vm.ExBudget;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FailureReportFormatterTest {
+
+    @Test
+    void format_withSourceLocation_andBuiltinContext() {
+        var report = new FailureReport(
+                "Error term encountered",
+                new SourceLocation("VestingValidator.java", 42, 5, "return deadline <= currentSlot"),
+                List.of(
+                        new BuiltinExecution(DefaultFun.UnIData, "<Data>", "5"),
+                        new BuiltinExecution(DefaultFun.UnIData, "<Data>", "3"),
+                        new BuiltinExecution(DefaultFun.LessThanEqualsInteger, "5, 3", "False")
+                ),
+                List.of(),
+                new ExBudget(1_234_567, 45_678),
+                List.of()
+        );
+
+        var output = FailureReportFormatter.format(report);
+        assertTrue(output.contains("FAIL"));
+        assertTrue(output.contains("VestingValidator.java:42"));
+        assertTrue(output.contains("return deadline <= currentSlot"));
+        assertTrue(output.contains("LessThanEqualsInteger(5, 3) → False"));
+        assertTrue(output.contains("Last builtins:"));
+        assertTrue(output.contains("UnIData(<Data>) → 5"));
+        assertTrue(output.contains("UnIData(<Data>) → 3"));
+        assertTrue(output.contains("CPU=1,234,567"));
+        assertTrue(output.contains("Mem=45,678"));
+    }
+
+    @Test
+    void format_withoutSourceLocation() {
+        var report = new FailureReport(
+                "Error term encountered",
+                null, // no source location
+                List.of(
+                        new BuiltinExecution(DefaultFun.EqualsInteger, "42, 99", "False")
+                ),
+                List.of(),
+                new ExBudget(500, 200),
+                List.of()
+        );
+
+        var output = FailureReportFormatter.format(report);
+        assertTrue(output.contains("FAIL: Error term encountered"));
+        assertTrue(output.contains("EqualsInteger(42, 99) → False"));
+        assertTrue(output.contains("CPU=500"));
+    }
+
+    @Test
+    void format_withoutBuiltinContext() {
+        var report = new FailureReport(
+                "Error term encountered",
+                new SourceLocation("Test.java", 10, 1, "throw new Error()"),
+                List.of(), // no builtins
+                List.of(),
+                new ExBudget(100, 50),
+                List.of()
+        );
+
+        var output = FailureReportFormatter.format(report);
+        assertTrue(output.contains("FAIL"));
+        assertTrue(output.contains("Test.java:10"));
+        assertFalse(output.contains("Last builtins:"));
+        assertTrue(output.contains("CPU=100"));
+    }
+
+    @Test
+    void format_withTraceMessages() {
+        var report = new FailureReport(
+                "Error term encountered",
+                null,
+                List.of(),
+                List.of(),
+                new ExBudget(100, 50),
+                List.of("debug: checking amount", "debug: amount is negative")
+        );
+
+        var output = FailureReportFormatter.format(report);
+        assertTrue(output.contains("Traces:"));
+        assertTrue(output.contains("debug: checking amount"));
+        assertTrue(output.contains("debug: amount is negative"));
+    }
+
+    @Test
+    void format_budgetExhausted() {
+        var report = new FailureReport(
+                "Budget exhausted",
+                new SourceLocation("HeavyValidator.java", 99, 1, "while(true)"),
+                List.of(
+                        new BuiltinExecution(DefaultFun.AddInteger, "1000000, 1", "1000001")
+                ),
+                List.of(),
+                new ExBudget(10_000_000_000L, 14_000_000),
+                List.of()
+        );
+
+        var output = FailureReportFormatter.format(report);
+        assertTrue(output.contains("FAIL"));
+        assertTrue(output.contains("HeavyValidator.java:99"));
+        // AddInteger doesn't produce False so no "cause" highlight
+        assertTrue(output.contains("Last builtins:"));
+        assertTrue(output.contains("AddInteger(1000000, 1) → 1000001"));
+    }
+
+    @Test
+    void format_emptyReport() {
+        var report = new FailureReport(
+                "Error term encountered",
+                null,
+                List.of(),
+                List.of(),
+                ExBudget.ZERO,
+                List.of()
+        );
+
+        var output = FailureReportFormatter.format(report);
+        assertTrue(output.contains("FAIL: Error term encountered"));
+        assertFalse(output.contains("Last builtins:"));
+        assertFalse(output.contains("Traces:"));
+        assertTrue(output.contains("CPU=0"));
+    }
+
+    @Test
+    void findCauseBuiltin_findsLastComparison() {
+        var report = new FailureReport(
+                "Error",
+                null,
+                List.of(
+                        new BuiltinExecution(DefaultFun.UnIData, "<Data>", "5"),
+                        new BuiltinExecution(DefaultFun.EqualsInteger, "5, 3", "False"),
+                        new BuiltinExecution(DefaultFun.AddInteger, "1, 2", "3")
+                ),
+                List.of(),
+                ExBudget.ZERO,
+                List.of()
+        );
+
+        var cause = report.findCauseBuiltin();
+        assertNotNull(cause);
+        assertEquals(DefaultFun.EqualsInteger, cause.fun());
+    }
+
+    @Test
+    void findCauseBuiltin_ignoresTrue() {
+        var report = new FailureReport(
+                "Error",
+                null,
+                List.of(
+                        new BuiltinExecution(DefaultFun.EqualsInteger, "5, 5", "True")
+                ),
+                List.of(),
+                ExBudget.ZERO,
+                List.of()
+        );
+
+        assertNull(report.findCauseBuiltin());
+    }
+
+    @Test
+    void findCauseBuiltin_emptyBuiltins() {
+        var report = new FailureReport(
+                "Error",
+                null,
+                List.of(),
+                List.of(),
+                ExBudget.ZERO,
+                List.of()
+        );
+
+        assertNull(report.findCauseBuiltin());
+    }
+}


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                               ## Summary                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                 
  - **REPL** (`julc repl`): Interactive Read-Eval-Print Loop for exploring JuLC expressions with tab completion, `:doc` inline stdlib documentation, and expression auto-wrapping                                                                                                                                                
  - **Builtin trace diagnostics**: Lightweight failure reporting that records the last 20 builtin executions in a ring buffer (always-on, negligible overhead). Highlights the exact comparison that returned `False` (e.g., `EqualsInteger(5, 3) → False`)                                                                    
  - **FailureReport pipeline**: Structured `FailureReport` record + `FailureReportBuilder` + `FailureReportFormatter` (plain text) + `AnsiFailureReportFormatter` (colored CLI output)                                                                                                                                           
  - **Testkit APIs**: `evaluateWithBuiltinTrace()`, `evaluateWithBuiltinDiagnostics()`, `evaluateWithDiagnostics()`, `assertValidatesWithDiagnostics()` across ValidatorTest, ContractTest, and JulcEval                                                                                                                         
  - **CLI eval improvements**: `julc eval` now shows rich failure reports with builtin trace and ANSI-colored output                                                                                                                                                                                                             
  - **JulcTransactionEvaluator refactor**: Improved script registration and trace collection for QuickTxBuilder integration                                                                                                                                                                                                      
  - **Docs**: Comprehensive builtin trace documentation in `source-maps.md` (new sections: Builtin Trace, Failure Reports, Choosing the Right Diagnostic Level) and cross-reference in `testing-guide.md`                                                                                                                        
  - **IDE linkable filenames**: Source location `toString()` uses `at .(File.java:line)` format for IntelliJ click-through                 