### PR TITLE
Make VM evaluation thread-safe by removing mutable per-evaluation state

### DIFF
--- a/docs/source-maps.md
+++ b/docs/source-maps.md
@@ -417,13 +417,20 @@ colored terminal output.
 
 ```java
 var vm = JulcVm.create();
-EvalResult result = vm.evaluateWithArgs(program, List.of(args));
 
-// Always available after evaluation
-List<BuiltinExecution> trace = vm.getLastBuiltinTrace();
+// Per-evaluation options — thread-safe, no shared state
+var options = EvalOptions.DEFAULT
+        .withSourceMap(sourceMap)
+        .withTracing(true);
+EvalResult result = vm.evaluateWithArgs(program, List.of(args), options);
 
-// Optionally disable (if overhead matters in tight loops)
-vm.setBuiltinTraceEnabled(false);
+// Traces are in the result
+List<BuiltinExecution> trace = result.builtinTrace();
+List<ExecutionTraceEntry> execTrace = result.executionTrace();
+
+// Disable builtin trace for zero-overhead production eval
+var prodOptions = EvalOptions.DEFAULT.withBuiltinTrace(false);
+EvalResult result2 = vm.evaluate(program, prodOptions);
 ```
 
 ### Advantages
@@ -735,12 +742,21 @@ FailureReportBuilder.build(result)              // no source map or traces
 FailureReportFormatter.format(report)   // → plain text multi-line string
 ```
 
-### `JulcVm` (builtin trace)
+### `EvalResult` (traces)
 
 ```java
-vm.getLastBuiltinTrace()            // → List<BuiltinExecution> (empty if disabled)
-vm.setBuiltinTraceEnabled(false)    // disable for zero-overhead production eval
-vm.setBuiltinTraceEnabled(true)     // re-enable (enabled by default)
+result.builtinTrace()               // → List<BuiltinExecution> (empty if disabled)
+result.executionTrace()             // → List<ExecutionTraceEntry> (empty if tracing off)
+```
+
+### `EvalOptions` (per-evaluation configuration)
+
+```java
+EvalOptions.DEFAULT                             // no source map, no tracing, builtin trace ON
+EvalOptions.DEFAULT.withSourceMap(sourceMap)     // enable source maps
+EvalOptions.DEFAULT.withTracing(true)           // enable execution tracing
+EvalOptions.DEFAULT.withBuiltinTrace(false)     // disable builtin trace (zero-overhead)
+new EvalOptions(sourceMap, true, true)          // all three at once
 ```
 
 ### `ValidatorTest`
@@ -752,10 +768,10 @@ ValidatorTest.compileValidatorWithSourceMap(MyValidator.class, sourceRoot)
 ValidatorTest.compileWithSourceMap(javaSource)
 
 // Evaluate with execution tracing
-ValidatorTest.evaluateWithTrace(compiled, args...)  // → EvalWithTrace
+ValidatorTest.evaluateWithTrace(compiled, args...)  // → EvalResult (with traces)
 
 // Evaluate with builtin trace only (lightweight, no execution tracing)
-ValidatorTest.evaluateWithBuiltinTrace(compiled, args...)  // → EvalWithTrace
+ValidatorTest.evaluateWithBuiltinTrace(compiled, args...)  // → EvalResult (with builtin trace)
 
 // Diagnostics: builtin-only (lightweight) or full (with execution trace)
 ValidatorTest.evaluateWithBuiltinDiagnostics(compiled, args...)  // → FailureReport or null
@@ -770,18 +786,6 @@ ValidatorTest.assertRejectsWithSourceMap(compileResult, args...)
 
 // Assert with rich diagnostics (FailureReport) on failure
 ValidatorTest.assertValidatesWithDiagnostics(compiled, args...)
-```
-
-### `EvalWithTrace`
-
-```java
-record EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace,
-                     List<BuiltinExecution> builtinTrace)
-
-evalWithTrace.formatTrace()          // → formatted step-by-step trace
-evalWithTrace.formatBudgetSummary()  // → formatted per-location budget summary
-evalWithTrace.result()               // → the underlying EvalResult
-evalWithTrace.builtinTrace()         // → List<BuiltinExecution>
 ```
 
 ### `ContractTest`

--- a/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekJavaBenchmark.java
+++ b/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekJavaBenchmark.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.benchmark;
 
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.flat.UplcFlatDecoder;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 import com.bloxbean.cardano.julc.vm.java.JavaVmProvider;
@@ -65,19 +66,20 @@ public class CekJavaBenchmark {
     })
     String file;
 
+    private static final EvalOptions BENCH_OPTIONS = EvalOptions.DEFAULT.withBuiltinTrace(false);
+
     private Program program;
     private JavaVmProvider provider;
 
     @Setup(Level.Trial)
     public void setup() throws IOException {
         provider = new JavaVmProvider();
-        provider.setBuiltinTraceEnabled(false);
         program = UplcFlatDecoder.decodeProgram(loadFlatBytes(file));
     }
 
     @Benchmark
     public EvalResult bench() {
-        return provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        return provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, BENCH_OPTIONS);
     }
 
     static byte[] loadFlatBytes(String filename) throws IOException {

--- a/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekTruffleBenchmark.java
+++ b/julc-benchmark/src/jmh/java/com/bloxbean/cardano/julc/benchmark/CekTruffleBenchmark.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.benchmark;
 
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.flat.UplcFlatDecoder;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 import com.bloxbean.cardano.julc.vm.truffle.TruffleVmProvider;
@@ -62,18 +63,19 @@ public class CekTruffleBenchmark {
     })
     String file;
 
+    private static final EvalOptions BENCH_OPTIONS = EvalOptions.DEFAULT.withBuiltinTrace(false);
+
     private Program program;
     private TruffleVmProvider provider;
 
     @Setup(Level.Trial)
     public void setup() throws IOException {
         provider = new TruffleVmProvider();
-        provider.setBuiltinTraceEnabled(false);
         program = UplcFlatDecoder.decodeProgram(CekJavaBenchmark.loadFlatBytes(file));
     }
 
     @Benchmark
     public EvalResult bench() {
-        return provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        return provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, BENCH_OPTIONS);
     }
 }

--- a/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluator.java
+++ b/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluator.java
@@ -21,7 +21,6 @@ import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
 import com.bloxbean.cardano.julc.vm.JulcVm;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
-import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
@@ -253,41 +252,21 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
                         }
                     }
 
-                    // c. Configure source map and tracing on the provider
-                    var vmProvider = getProvider();
+                    // c. Build per-evaluation options
                     SourceMap activeSourceMap = scriptSourceMaps.get(scriptHash);
-                    if (activeSourceMap != null) {
-                        vmProvider.setSourceMap(activeSourceMap);
-                    }
-                    vmProvider.setBuiltinTraceEnabled(builtinTraceEnabled);
-                    if (executionTraceEnabled) {
-                        vmProvider.setTracingEnabled(true);
-                    }
+                    var evalOptions = new com.bloxbean.cardano.julc.vm.EvalOptions(
+                            activeSourceMap, executionTraceEnabled, builtinTraceEnabled);
 
                     // d. Use pre-registered program if available (preserves Term identity)
                     Program evalProgram = scriptPrograms.containsKey(scriptHash)
                             ? scriptPrograms.get(scriptHash) : resolved.program();
 
-                    // e. Evaluate with try-finally for provider state reset
-                    List<ExecutionTraceEntry> executionTrace;
-                    List<BuiltinExecution> builtinTrace;
-                    EvalResult evalResult;
-                    try {
-                        var langVm = JulcVm.withProvider(vmProvider, resolved.language());
-                        evalResult = langVm.evaluateWithArgs(
-                                evalProgram, args, maxBudget);
-                        executionTrace = executionTraceEnabled
-                                ? vmProvider.getLastExecutionTrace() : List.of();
-                        builtinTrace = builtinTraceEnabled
-                                ? vmProvider.getLastBuiltinTrace() : List.of();
-                    } finally {
-                        if (activeSourceMap != null) {
-                            vmProvider.setSourceMap(null);
-                        }
-                        if (executionTraceEnabled) {
-                            vmProvider.setTracingEnabled(false);
-                        }
-                    }
+                    // e. Evaluate — traces are captured in the EvalResult
+                    var langVm = JulcVm.withProvider(getProvider(), resolved.language());
+                    EvalResult evalResult = langVm.evaluateWithArgs(
+                            evalProgram, args, maxBudget, evalOptions);
+                    var executionTrace = evalResult.executionTrace();
+                    var builtinTrace = evalResult.builtinTrace();
 
                     // f. Capture trace (prints to stdout + stores in collectedTraces)
                     String key = redeemer.getTag() + "[" + redeemer.getIndex() + "]";
@@ -311,16 +290,14 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
                                     ? Collections.unmodifiableMap(collectedTraces) : Map.of();
                             return Result.error(formatEvalError(
                                     redeemer, "Script evaluation failed for", failure,
-                                    failure.error(), activeSourceMap,
-                                    executionTrace, builtinTrace));
+                                    failure.error(), activeSourceMap));
                         }
                         case EvalResult.BudgetExhausted exhausted -> {
                             lastTraces = collectedTraces != null
                                     ? Collections.unmodifiableMap(collectedTraces) : Map.of();
                             return Result.error(formatEvalError(
                                     redeemer, "Budget exhausted for", exhausted,
-                                    exhausted.consumed().toString(), activeSourceMap,
-                                    executionTrace, builtinTrace));
+                                    exhausted.consumed().toString(), activeSourceMap));
                         }
                     }
                 } catch (Exception e) {
@@ -597,11 +574,9 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
     // ---- Error formatting with source map support ----
 
     private String formatEvalError(Redeemer redeemer, String prefix, EvalResult result,
-                                    String fallbackDetail, SourceMap sourceMap,
-                                    List<ExecutionTraceEntry> executionTrace,
-                                    List<BuiltinExecution> builtinTrace) {
+                                    String fallbackDetail, SourceMap sourceMap) {
         var redeemerKey = redeemer.getTag() + "[" + redeemer.getIndex() + "]";
-        var report = FailureReportBuilder.build(result, sourceMap, executionTrace, builtinTrace);
+        var report = FailureReportBuilder.build(result, sourceMap);
         if (report != null) {
             return prefix + " " + redeemerKey + ":\n"
                     + FailureReportFormatter.format(report);

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/EvalCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/EvalCommand.java
@@ -15,7 +15,6 @@ import picocli.CommandLine.Parameters;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 @Command(name = "eval", description = "Evaluate a UPLC program")
 public class EvalCommand implements Runnable {
@@ -29,7 +28,6 @@ public class EvalCommand implements Runnable {
             Program program = loadProgram(file);
             JulcVm vm = JulcVm.create();
             EvalResult result = vm.evaluate(program);
-            var builtinTrace = vm.getLastBuiltinTrace();
 
             switch (result) {
                 case EvalResult.Success s -> {
@@ -43,7 +41,7 @@ public class EvalCommand implements Runnable {
                     }
                 }
                 case EvalResult.Failure f -> {
-                    var report = FailureReportBuilder.build(f, null, List.of(), builtinTrace);
+                    var report = FailureReportBuilder.build(f, null);
                     if (report != null) {
                         System.out.println(AnsiFailureReportFormatter.format(report));
                     } else {
@@ -52,7 +50,7 @@ public class EvalCommand implements Runnable {
                     System.exit(1);
                 }
                 case EvalResult.BudgetExhausted b -> {
-                    var report = FailureReportBuilder.build(b, null, List.of(), builtinTrace);
+                    var report = FailureReportBuilder.build(b, null);
                     if (report != null) {
                         System.out.println(AnsiFailureReportFormatter.format(report));
                     } else {

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/FailureReportIntegrationTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/FailureReportIntegrationTest.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import com.bloxbean.cardano.julc.testkit.ValidatorTest;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.JulcVm;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
@@ -71,14 +72,14 @@ class FailureReportIntegrationTest {
         assertTrue(compiled.hasSourceMap());
 
         var vm = JulcVm.create();
-        vm.setSourceMap(compiled.sourceMap());
+        var evalOptions = EvalOptions.DEFAULT.withSourceMap(compiled.sourceMap());
 
-        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()));
+        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()), evalOptions);
 
         assertInstanceOf(EvalResult.Failure.class, result, "Validator should fail: " + result);
 
         // Verify builtin trace contains comparison with actual values
-        var builtinTrace = vm.getLastBuiltinTrace();
+        var builtinTrace = result.builtinTrace();
         assertFalse(builtinTrace.isEmpty(), "BuiltinTrace should capture builtins");
 
         var compEntry = builtinTrace.stream()
@@ -93,8 +94,7 @@ class FailureReportIntegrationTest {
                 "Should contain amount value 5. Got: " + compEntry.argSummary());
 
         // Build and format FailureReport
-        var report = FailureReportBuilder.build(result, compiled.sourceMap(),
-                List.of(), builtinTrace);
+        var report = FailureReportBuilder.build(result, compiled.sourceMap());
         assertNotNull(report);
 
         var formatted = FailureReportFormatter.format(report);
@@ -102,8 +102,6 @@ class FailureReportIntegrationTest {
         assertTrue(formatted.contains("False"), "Report should contain → False");
         assertTrue(formatted.contains("Last builtins:"), "Report should show builtins section");
         assertTrue(formatted.contains("CPU="), "Report should show budget");
-
-        vm.setSourceMap(null);
     }
 
     @Test
@@ -114,13 +112,13 @@ class FailureReportIntegrationTest {
         assertFalse(compiled.hasErrors(), "Compilation should succeed: " + compiled.diagnostics());
 
         var vm = JulcVm.create();
-        vm.setSourceMap(compiled.sourceMap());
+        var evalOptions = EvalOptions.DEFAULT.withSourceMap(compiled.sourceMap());
 
-        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()));
+        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()), evalOptions);
 
         assertInstanceOf(EvalResult.Failure.class, result, "Validator should fail: " + result);
 
-        var builtinTrace = vm.getLastBuiltinTrace();
+        var builtinTrace = result.builtinTrace();
         var equalsEntry = builtinTrace.stream()
                 .filter(e -> e.fun() == DefaultFun.EqualsInteger
                         && "False".equals(e.resultSummary()))
@@ -131,8 +129,6 @@ class FailureReportIntegrationTest {
                 "Should contain value 99. Got: " + equalsEntry.argSummary());
         assertTrue(equalsEntry.argSummary().contains("42"),
                 "Should contain value 42. Got: " + equalsEntry.argSummary());
-
-        vm.setSourceMap(null);
     }
 
     @Test
@@ -142,13 +138,13 @@ class FailureReportIntegrationTest {
         var compiled = compiler.compile(ALWAYS_PASS_MINT);
 
         var vm = JulcVm.create();
-        vm.setSourceMap(compiled.sourceMap());
+        var evalOptions = EvalOptions.DEFAULT.withSourceMap(compiled.sourceMap());
 
-        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()));
+        var result = vm.evaluateWithArgs(compiled.program(), List.of(buildMintingCtx()), evalOptions);
         assertTrue(result.isSuccess(), "Validator should succeed: " + result);
 
         // BuiltinTrace is still active on success (ring buffer captured builtins from ScriptContext deconstruction)
-        var builtinTrace = vm.getLastBuiltinTrace();
+        var builtinTrace = result.builtinTrace();
         // Even a trivial validator that returns true will have some builtins from ScriptContext processing
         // (at minimum the IfThenElse guard). But an always-true may have zero if it's optimized away.
         // Just verify the API works without crashing.
@@ -156,8 +152,6 @@ class FailureReportIntegrationTest {
 
         // FailureReportBuilder returns null for success
         assertNull(FailureReportBuilder.build(result, compiled.sourceMap()));
-
-        vm.setSourceMap(null);
     }
 
     @Test

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/BudgetAssertions.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/BudgetAssertions.java
@@ -3,8 +3,6 @@ package com.bloxbean.cardano.julc.testkit;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.vm.EvalResult;
-import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
-import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 import com.bloxbean.cardano.julc.vm.trace.FailureReport;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
@@ -184,18 +182,8 @@ public final class BudgetAssertions {
      * Describe a result with source location info if a source map is available.
      */
     public static String describeResult(EvalResult result, SourceMap sourceMap) {
-        return describeResult(result, sourceMap, List.of(), List.of());
-    }
-
-    /**
-     * Describe a result with full diagnostic context.
-     */
-    public static String describeResult(EvalResult result, SourceMap sourceMap,
-                                         List<ExecutionTraceEntry> executionTrace,
-                                         List<BuiltinExecution> builtinTrace) {
         if (!result.isSuccess()) {
-            FailureReport report = FailureReportBuilder.build(
-                    result, sourceMap, executionTrace, builtinTrace);
+            FailureReport report = FailureReportBuilder.build(result, sourceMap);
             if (report != null) {
                 return FailureReportFormatter.format(report);
             }

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ContractTest.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ContractTest.java
@@ -46,6 +46,9 @@ public abstract class ContractTest {
      */
     private JulcVm vm;
 
+    /** The result from the most recent evaluation. */
+    private EvalResult lastResult;
+
     /**
      * Returns the shared JulcVm instance, creating it on first access.
      */
@@ -404,17 +407,17 @@ public abstract class ContractTest {
      */
     private EvalResult doEvaluate(CompileResult compiled, boolean tracing, PlutusData... args) {
         var v = vm();
-        v.setSourceMap(compiled.sourceMap());
-        if (tracing) v.setTracingEnabled(true);
-        try {
-            if (args.length == 0) {
-                return v.evaluate(compiled.program());
-            }
-            return v.evaluateWithArgs(compiled.program(), java.util.List.of(args));
-        } finally {
-            v.setTracingEnabled(false);
-            v.setSourceMap(null);
+        var options = com.bloxbean.cardano.julc.vm.EvalOptions.DEFAULT
+                .withSourceMap(compiled.sourceMap())
+                .withTracing(tracing);
+        EvalResult result;
+        if (args.length == 0) {
+            result = v.evaluate(compiled.program(), options);
+        } else {
+            result = v.evaluateWithArgs(compiled.program(), java.util.List.of(args), options);
         }
+        this.lastResult = result;
+        return result;
     }
 
     /**
@@ -422,7 +425,8 @@ public abstract class ContractTest {
      * Builtin tracing is always on by default — no opt-in required.
      */
     protected java.util.List<BuiltinExecution> getLastBuiltinTrace() {
-        return vm().getLastBuiltinTrace();
+        var r = lastResult;
+        return r != null ? r.builtinTrace() : java.util.List.of();
     }
 
     /**
@@ -430,7 +434,8 @@ public abstract class ContractTest {
      * Call after {@link #evaluateWithTrace}.
      */
     protected java.util.List<ExecutionTraceEntry> getLastExecutionTrace() {
-        return vm().getLastExecutionTrace();
+        var r = lastResult;
+        return r != null ? r.executionTrace() : java.util.List.of();
     }
 
     /**

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/JulcEval.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/JulcEval.java
@@ -296,32 +296,25 @@ public final class JulcEval {
         }
 
         var vm = com.bloxbean.cardano.julc.vm.JulcVm.create();
-        vm.setSourceMap(compiled.sourceMap());
-        if (tracingEnabled) {
-            vm.setTracingEnabled(true);
-        }
+        var evalOpts = com.bloxbean.cardano.julc.vm.EvalOptions.DEFAULT
+                .withSourceMap(compiled.sourceMap())
+                .withTracing(tracingEnabled);
         var allArgs = MethodEvaluator.buildAllArgs(params, args);
         EvalResult result;
-        try {
-            if (allArgs.isEmpty()) {
-                result = vm.evaluate(compiled.program());
-            } else {
-                result = vm.evaluateWithArgs(compiled.program(), allArgs);
-            }
-        } finally {
-            this.lastExecutionTrace = vm.getLastExecutionTrace();
-            this.lastBuiltinTrace = vm.getLastBuiltinTrace();
-            vm.setTracingEnabled(false);
-            vm.setSourceMap(null);
+        if (allArgs.isEmpty()) {
+            result = vm.evaluate(compiled.program(), evalOpts);
+        } else {
+            result = vm.evaluateWithArgs(compiled.program(), allArgs, evalOpts);
         }
+        this.lastExecutionTrace = result.executionTrace();
+        this.lastBuiltinTrace = result.builtinTrace();
 
         if (result instanceof EvalResult.Success s) {
             return s.resultTerm();
         }
 
         // Build rich error report (reuses FailureReportBuilder+FailureReportFormatter)
-        var report = FailureReportBuilder.build(result, compiled.sourceMap(),
-                lastExecutionTrace, lastBuiltinTrace);
+        var report = FailureReportBuilder.build(result, compiled.sourceMap());
         String errorMsg;
         if (report != null) {
             errorMsg = FailureReportFormatter.format(report);

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ValidatorTest.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ValidatorTest.java
@@ -8,11 +8,10 @@ import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
 import com.bloxbean.cardano.julc.vm.JulcVm;
-import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
-import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 import com.bloxbean.cardano.julc.vm.trace.FailureReport;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
@@ -535,25 +534,22 @@ public final class ValidatorTest {
 
     /**
      * Evaluate a compiled program with source map but WITHOUT execution tracing.
-     * Retrieves the builtin trace (always collected by the VM) for lightweight diagnostics.
+     * The result carries the builtin trace (always collected by the VM) for lightweight diagnostics.
      * <p>
      * This is cheaper than {@link #evaluateWithTrace} because it does not enable
      * per-step execution tracing.
      *
      * @param compiled the compile result (with source map)
      * @param args     the PlutusData arguments
-     * @return the result with empty execution trace and populated builtin trace
+     * @return the EvalResult (with builtin trace, empty execution trace)
      */
-    public static EvalWithTrace evaluateWithBuiltinTrace(CompileResult compiled, PlutusData... args) {
+    public static EvalResult evaluateWithBuiltinTrace(CompileResult compiled, PlutusData... args) {
         return doEvaluate(compiled, false, args);
     }
 
     /**
      * Evaluate a compiled program with builtin-only diagnostics (no execution tracing).
      * Returns a {@link FailureReport} if the evaluation fails, or null on success.
-     * <p>
-     * Lighter-weight alternative to {@link #evaluateWithDiagnostics} — useful for
-     * diagnosing validator failures without the overhead of full execution tracing.
      *
      * @param compiled the compile result (with source map)
      * @param args     the PlutusData arguments
@@ -567,35 +563,14 @@ public final class ValidatorTest {
 
     /**
      * Evaluate a compiled program with source map and execution tracing enabled.
-     * Returns an {@link EvalWithTrace} containing both the result and the trace.
+     * The result carries both the execution trace and builtin trace.
      *
      * @param compiled the compile result (with source map)
      * @param args     the PlutusData arguments
-     * @return the result and execution trace
+     * @return the EvalResult (with execution trace and builtin trace)
      */
-    public static EvalWithTrace evaluateWithTrace(CompileResult compiled, PlutusData... args) {
+    public static EvalResult evaluateWithTrace(CompileResult compiled, PlutusData... args) {
         return doEvaluate(compiled, true, args);
-    }
-
-    /**
-     * Holds an evaluation result together with its execution trace and builtin trace.
-     */
-    public record EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace,
-                                 List<BuiltinExecution> builtinTrace) {
-        /** Backward-compatible constructor (no builtin trace). */
-        public EvalWithTrace(EvalResult result, List<ExecutionTraceEntry> trace) {
-            this(result, trace, List.of());
-        }
-
-        /** Format the trace as a readable multi-line string. */
-        public String formatTrace() {
-            return ExecutionTraceEntry.format(trace);
-        }
-
-        /** Format a per-file/line budget summary with visit counts. */
-        public String formatBudgetSummary() {
-            return ExecutionTraceEntry.formatSummary(trace);
-        }
     }
 
     // --- Diagnostic evaluation ---
@@ -630,31 +605,26 @@ public final class ValidatorTest {
     }
 
     /**
-     * Shared evaluate helper — creates a VM, sets source map, optionally enables tracing,
-     * evaluates, and collects traces. The VM is throwaway (no cleanup needed).
+     * Shared evaluate helper — creates a VM, configures options, evaluates.
      */
-    private static EvalWithTrace doEvaluate(CompileResult compiled, boolean tracing, PlutusData... args) {
+    private static EvalResult doEvaluate(CompileResult compiled, boolean tracing, PlutusData... args) {
         var vm = JulcVm.create();
-        vm.setSourceMap(compiled.sourceMap());
-        if (tracing) vm.setTracingEnabled(true);
-        EvalResult result;
+        var options = EvalOptions.DEFAULT
+                .withSourceMap(compiled.sourceMap())
+                .withTracing(tracing);
         if (args.length == 0) {
-            result = vm.evaluate(compiled.program());
+            return vm.evaluate(compiled.program(), options);
         } else {
-            result = vm.evaluateWithArgs(compiled.program(), List.of(args));
+            return vm.evaluateWithArgs(compiled.program(), List.of(args), options);
         }
-        var executionTrace = tracing ? vm.getLastExecutionTrace() : List.<ExecutionTraceEntry>of();
-        var builtinTrace = vm.getLastBuiltinTrace();
-        return new EvalWithTrace(result, executionTrace, builtinTrace);
     }
 
     /**
      * Build a FailureReport if evaluation failed, null otherwise.
      */
-    private static FailureReport buildReportIfFailed(EvalWithTrace traced, SourceMap sourceMap) {
-        if (traced.result().isSuccess()) return null;
-        return FailureReportBuilder.build(traced.result(), sourceMap,
-                traced.trace(), traced.builtinTrace());
+    private static FailureReport buildReportIfFailed(EvalResult result, SourceMap sourceMap) {
+        if (result.isSuccess()) return null;
+        return FailureReportBuilder.build(result, sourceMap);
     }
 
     private static String formatResult(EvalResult result) {

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/JavaVmProvider.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/JavaVmProvider.java
@@ -7,8 +7,6 @@ import com.bloxbean.cardano.julc.core.Term;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.vm.*;
 import com.bloxbean.cardano.julc.vm.java.cost.*;
-import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
-import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.List;
 
@@ -25,11 +23,6 @@ public class JavaVmProvider implements JulcVmProvider {
     private volatile CostModelParser.ParsedCostModel customV1CostModel;
     private volatile CostModelParser.ParsedCostModel customV2CostModel;
     private volatile CostModelParser.ParsedCostModel customV3CostModel;
-    private volatile SourceMap sourceMap;
-    private volatile boolean tracingEnabled;
-    private volatile boolean builtinTraceEnabled = true;
-    private volatile List<ExecutionTraceEntry> lastExecutionTrace = List.of();
-    private volatile List<BuiltinExecution> lastBuiltinTrace = List.of();
 
     @Override
     public void setCostModelParams(long[] costModelValues, PlutusLanguage language,
@@ -43,22 +36,25 @@ public class JavaVmProvider implements JulcVmProvider {
     }
 
     @Override
-    public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget) {
-        return evaluateInternal(program.term(), language, budget);
+    public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget,
+                               EvalOptions options) {
+        return evaluateInternal(program.term(), language, budget, options);
     }
 
     @Override
     public EvalResult evaluateWithArgs(Program program, PlutusLanguage language,
-                                       List<PlutusData> args, ExBudget budget) {
+                                       List<PlutusData> args, ExBudget budget,
+                                       EvalOptions options) {
         // Apply each argument as a Data constant
         Term term = program.term();
         for (var arg : args) {
             term = new Term.Apply(term, new Term.Const(Constant.data(arg)));
         }
-        return evaluateInternal(term, language, budget);
+        return evaluateInternal(term, language, budget, options);
     }
 
-    private EvalResult evaluateInternal(Term term, PlutusLanguage language, ExBudget budget) {
+    private EvalResult evaluateInternal(Term term, PlutusLanguage language, ExBudget budget,
+                                        EvalOptions options) {
         MachineCosts mc;
         BuiltinCostModel bcm;
         var parsed = getCustomCostModel(language);
@@ -70,24 +66,24 @@ public class JavaVmProvider implements JulcVmProvider {
             bcm = DefaultCostModel.defaultBuiltinCostModel(language);
         }
         var costTracker = new CostTracker(mc, bcm, budget);
-        var machine = new CekMachine(costTracker, language, sourceMap, tracingEnabled, builtinTraceEnabled);
+        var machine = new CekMachine(costTracker, language,
+                options.sourceMap(), options.tracingEnabled(), options.builtinTraceEnabled());
         try {
             CekValue result = machine.evaluate(term);
             Term resultTerm = ValueConverter.toTerm(result);
-            return new EvalResult.Success(resultTerm, costTracker.consumed(), machine.getTraces());
+            return new EvalResult.Success(resultTerm, costTracker.consumed(), machine.getTraces(),
+                    machine.getExecutionTrace(), machine.getBuiltinTrace());
         } catch (BudgetExhaustedException e) {
             return new EvalResult.BudgetExhausted(costTracker.consumed(), machine.getTraces(),
-                    e.failedTerm());
+                    e.failedTerm(), machine.getExecutionTrace(), machine.getBuiltinTrace());
         } catch (CekEvaluationException e) {
             String errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             return new EvalResult.Failure(errorMsg, costTracker.consumed(), machine.getTraces(),
-                    e.failedTerm());
+                    e.failedTerm(), machine.getExecutionTrace(), machine.getBuiltinTrace());
         } catch (Exception e) {
             String errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-            return new EvalResult.Failure(errorMsg, costTracker.consumed(), machine.getTraces());
-        } finally {
-            lastExecutionTrace = machine.getExecutionTrace();
-            lastBuiltinTrace = machine.getBuiltinTrace();
+            return new EvalResult.Failure(errorMsg, costTracker.consumed(), machine.getTraces(),
+                    null, machine.getExecutionTrace(), machine.getBuiltinTrace());
         }
     }
 
@@ -97,31 +93,6 @@ public class JavaVmProvider implements JulcVmProvider {
             case PLUTUS_V2 -> customV2CostModel;
             case PLUTUS_V3 -> customV3CostModel;
         };
-    }
-
-    @Override
-    public void setSourceMap(SourceMap sourceMap) {
-        this.sourceMap = sourceMap;
-    }
-
-    @Override
-    public void setTracingEnabled(boolean enabled) {
-        this.tracingEnabled = enabled;
-    }
-
-    @Override
-    public void setBuiltinTraceEnabled(boolean enabled) {
-        this.builtinTraceEnabled = enabled;
-    }
-
-    @Override
-    public List<ExecutionTraceEntry> getLastExecutionTrace() {
-        return lastExecutionTrace;
-    }
-
-    @Override
-    public List<BuiltinExecution> getLastBuiltinTrace() {
-        return lastBuiltinTrace;
     }
 
     @Override

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/BuiltinTraceIntegrationTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/BuiltinTraceIntegrationTest.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.Term;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 import com.bloxbean.cardano.julc.vm.java.cost.*;
@@ -120,21 +121,19 @@ class BuiltinTraceIntegrationTest {
         var provider = new JavaVmProvider();
         var dummy = new Term.Const(Constant.integer(0));
         var sourceMap = createSourceMap(dummy, "Test.java", 1, "dummy");
-        provider.setSourceMap(sourceMap);
 
         var add = applyBuiltin(DefaultFun.AddInteger,
                 new Term.Const(Constant.integer(3)),
                 new Term.Const(Constant.integer(5)));
         var program = new com.bloxbean.cardano.julc.core.Program(1, 1, 0, add);
 
-        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, false, true);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
         assertInstanceOf(EvalResult.Success.class, result);
 
-        var builtinTrace = provider.getLastBuiltinTrace();
+        var builtinTrace = result.builtinTrace();
         assertFalse(builtinTrace.isEmpty());
         assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
-
-        provider.setSourceMap(null);
     }
 
     @Test
@@ -219,21 +218,20 @@ class BuiltinTraceIntegrationTest {
         // Default: builtin trace enabled
         var result1 = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
         assertInstanceOf(EvalResult.Success.class, result1);
-        assertFalse(provider.getLastBuiltinTrace().isEmpty(),
+        assertFalse(result1.builtinTrace().isEmpty(),
                 "Builtin trace should be on by default");
 
         // Disable builtin trace
-        provider.setBuiltinTraceEnabled(false);
-        var result2 = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        var result2 = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null,
+                EvalOptions.DEFAULT.withBuiltinTrace(false));
         assertInstanceOf(EvalResult.Success.class, result2);
-        assertTrue(provider.getLastBuiltinTrace().isEmpty(),
-                "Builtin trace should be empty when disabled via provider");
+        assertTrue(result2.builtinTrace().isEmpty(),
+                "Builtin trace should be empty when disabled via options");
 
-        // Re-enable
-        provider.setBuiltinTraceEnabled(true);
+        // Re-enable (default)
         var result3 = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
         assertInstanceOf(EvalResult.Success.class, result3);
-        assertFalse(provider.getLastBuiltinTrace().isEmpty(),
+        assertFalse(result3.builtinTrace().isEmpty(),
                 "Builtin trace should be captured again after re-enabling");
     }
 

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/JavaVmTracingTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/JavaVmTracingTest.java
@@ -3,9 +3,9 @@ package com.bloxbean.cardano.julc.vm.java;
 import com.bloxbean.cardano.julc.core.*;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
-import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
@@ -24,9 +24,9 @@ class JavaVmTracingTest {
     void tracingDisabledByDefault() {
         var program = new Program(1, 0, 0,
                 Term.const_(Constant.integer(BigInteger.ONE)));
-        provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
 
-        assertTrue(provider.getLastExecutionTrace().isEmpty(),
+        assertTrue(result.executionTrace().isEmpty(),
                 "Trace should be empty when tracing is disabled");
     }
 
@@ -41,13 +41,12 @@ class JavaVmTracingTest {
         positions.put(applyTerm, new SourceLocation("Test.java", 10, 1, "identity(42)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
+        var options = new EvalOptions(sourceMap, true, true);
         var result = provider.evaluate(
-                new Program(1, 0, 0, applyTerm), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, applyTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Success.class, result);
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         assertFalse(trace.isEmpty(), "Trace should have entries when enabled with source map");
 
         // Should contain an Apply entry for Test.java:10
@@ -69,11 +68,10 @@ class JavaVmTracingTest {
         positions.put(outerApply, new SourceLocation("Math.java", 6, 1, "3 + 4"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         assertFalse(trace.isEmpty());
         // At least one entry should have non-zero cpuDelta
         boolean hasNonZeroCpu = trace.stream().anyMatch(e -> e.cpuDelta() > 0);
@@ -95,11 +93,10 @@ class JavaVmTracingTest {
         positions.put(outerApply, new SourceLocation("Math.java", 5, 1, "3 + 4"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         // Should be deduped to 1 entry
         long line5Count = trace.stream()
                 .filter(e -> "Math.java".equals(e.fileName()) && e.line() == 5)
@@ -124,11 +121,10 @@ class JavaVmTracingTest {
         positions1.put(apply1, new SourceLocation("First.java", 1, 1, "first"));
         var sourceMap1 = SourceMap.of(positions1);
 
-        provider.setSourceMap(sourceMap1);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, apply1), PlutusLanguage.PLUTUS_V3, null);
+        var options1 = new EvalOptions(sourceMap1, true, true);
+        var result1 = provider.evaluate(new Program(1, 0, 0, apply1), PlutusLanguage.PLUTUS_V3, null, options1);
 
-        var trace1 = provider.getLastExecutionTrace();
+        var trace1 = result1.executionTrace();
         assertFalse(trace1.isEmpty());
         assertTrue(trace1.stream().anyMatch(e -> "First.java".equals(e.fileName())));
 
@@ -141,10 +137,10 @@ class JavaVmTracingTest {
         positions2.put(apply2, new SourceLocation("Second.java", 2, 1, "second"));
         var sourceMap2 = SourceMap.of(positions2);
 
-        provider.setSourceMap(sourceMap2);
-        provider.evaluate(new Program(1, 0, 0, apply2), PlutusLanguage.PLUTUS_V3, null);
+        var options2 = new EvalOptions(sourceMap2, true, true);
+        var result2 = provider.evaluate(new Program(1, 0, 0, apply2), PlutusLanguage.PLUTUS_V3, null, options2);
 
-        var trace2 = provider.getLastExecutionTrace();
+        var trace2 = result2.executionTrace();
         // Second trace should NOT contain First.java entries
         boolean hasFirst = trace2.stream().anyMatch(e -> "First.java".equals(e.fileName()));
         assertFalse(hasFirst, "Second trace should not contain entries from first evaluation");
@@ -153,16 +149,15 @@ class JavaVmTracingTest {
 
     @Test
     void tracingEnabledButNoSourceMap_emptyTrace() {
-        provider.setSourceMap(null);
-        provider.setTracingEnabled(true);
+        var options = new EvalOptions(null, true, true);
 
         var program = new Program(1, 0, 0,
                 Term.apply(
                         Term.lam("x", Term.var(new NamedDeBruijn("x", 1))),
                         Term.const_(Constant.integer(BigInteger.ONE))));
-        provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
-        assertTrue(provider.getLastExecutionTrace().isEmpty(),
+        assertTrue(result.executionTrace().isEmpty(),
                 "Trace should be empty when no source map");
     }
 
@@ -176,11 +171,10 @@ class JavaVmTracingTest {
         positions.put(forceTerm, new SourceLocation("Test.java", 3, 1, "force(delay(7))"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, forceTerm), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, forceTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         boolean hasForce = trace.stream().anyMatch(e -> "Force".equals(e.nodeType()));
         assertTrue(hasForce, "Should have a Force entry. Got: " + trace);
     }
@@ -196,11 +190,10 @@ class JavaVmTracingTest {
         positions.put(caseTerm, new SourceLocation("Test.java", 15, 1, "switch(x)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 1, 0, caseTerm), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 1, 0, caseTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         boolean hasCase = trace.stream().anyMatch(e -> "Case".equals(e.nodeType()));
         assertTrue(hasCase, "Should have a Case entry. Got: " + trace);
     }
@@ -213,13 +206,12 @@ class JavaVmTracingTest {
         positions.put(errorTerm, new SourceLocation("Test.java", 42, 1, "error()"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
+        var options = new EvalOptions(sourceMap, true, true);
         var result = provider.evaluate(
-                new Program(1, 0, 0, errorTerm), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, errorTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Failure.class, result);
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         boolean hasError = trace.stream().anyMatch(e ->
                 "Error".equals(e.nodeType()) && e.line() == 42);
         assertTrue(hasError, "Should have an Error entry at line 42. Got: " + trace);
@@ -239,15 +231,13 @@ class JavaVmTracingTest {
         var sourceMap = SourceMap.of(positions);
 
         // With tracing
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
+        var tracedOptions = new EvalOptions(sourceMap, true, true);
         var resultTraced = provider.evaluate(
-                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null, tracedOptions);
 
         // Without tracing
-        provider.setTracingEnabled(false);
         var resultUntraced = provider.evaluate(
-                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null, EvalOptions.DEFAULT);
 
         assertEquals(resultTraced.budgetConsumed().cpuSteps(),
                 resultUntraced.budgetConsumed().cpuSteps(),

--- a/julc-vm-scalus/src/main/java/com/bloxbean/cardano/julc/vm/scalus/ScalusVmProvider.java
+++ b/julc-vm-scalus/src/main/java/com/bloxbean/cardano/julc/vm/scalus/ScalusVmProvider.java
@@ -27,6 +27,10 @@ import java.util.List;
  * <p>
  * Discovered via {@link java.util.ServiceLoader} when {@code plutus-vm-scalus}
  * is on the classpath.
+ * <p>
+ * Note: This provider does not support source maps, execution tracing, or builtin
+ * trace collection. {@link EvalOptions} is accepted but ignored — traces in the
+ * returned {@link EvalResult} will always be empty.
  */
 public class ScalusVmProvider implements JulcVmProvider {
 
@@ -65,13 +69,15 @@ public class ScalusVmProvider implements JulcVmProvider {
     }
 
     @Override
-    public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget) {
+    public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget,
+                               EvalOptions options) {
         return evaluateInternal(program, language);
     }
 
     @Override
     public EvalResult evaluateWithArgs(Program program, PlutusLanguage language,
-                                       List<PlutusData> args, ExBudget budget) {
+                                       List<PlutusData> args, ExBudget budget,
+                                       EvalOptions options) {
         try {
             // FLAT-encode the base program (without args) to bridge to Scalus types
             byte[] flatBytes = UplcFlatEncoder.encodeProgram(program);

--- a/julc-vm-scalus/src/test/java/com/bloxbean/cardano/julc/vm/scalus/ScalusVmProviderTest.java
+++ b/julc-vm-scalus/src/test/java/com/bloxbean/cardano/julc/vm/scalus/ScalusVmProviderTest.java
@@ -702,9 +702,9 @@ class ScalusVmProviderTest {
             // The default JulcVmProvider.setCostModelParams should be a no-op.
             JulcVmProvider mockProvider = new JulcVmProvider() {
                 @Override
-                public EvalResult evaluate(Program p, PlutusLanguage l, ExBudget b) { return null; }
+                public EvalResult evaluate(Program p, PlutusLanguage l, ExBudget b, EvalOptions o) { return null; }
                 @Override
-                public EvalResult evaluateWithArgs(Program p, PlutusLanguage l, List<PlutusData> a, ExBudget b) { return null; }
+                public EvalResult evaluateWithArgs(Program p, PlutusLanguage l, List<PlutusData> a, ExBudget b, EvalOptions o) { return null; }
                 @Override
                 public String name() { return "test"; }
                 @Override

--- a/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/TruffleVmProvider.java
+++ b/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/TruffleVmProvider.java
@@ -4,7 +4,6 @@ import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.Term;
-import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.vm.*;
 import com.bloxbean.cardano.julc.vm.java.cost.*;
 import com.bloxbean.cardano.julc.vm.truffle.convert.NodeToTermConverter;
@@ -12,7 +11,6 @@ import com.bloxbean.cardano.julc.vm.truffle.convert.TermToNodeConverter;
 import com.bloxbean.cardano.julc.vm.truffle.node.UplcNode;
 import com.bloxbean.cardano.julc.vm.truffle.node.UplcRootNode;
 import com.bloxbean.cardano.julc.vm.truffle.runtime.UplcRuntimeException;
-import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 
 import java.util.List;
@@ -29,30 +27,13 @@ import java.util.List;
  * <p>
  * Cost model infrastructure is shared with julc-vm-java, guaranteeing
  * exact budget parity.
+ * <p>
  */
 public class TruffleVmProvider implements JulcVmProvider {
 
     private volatile CostModelParser.ParsedCostModel customV1CostModel;
     private volatile CostModelParser.ParsedCostModel customV2CostModel;
     private volatile CostModelParser.ParsedCostModel customV3CostModel;
-    private volatile SourceMap sourceMap;
-    private volatile boolean tracingEnabled;
-    private volatile List<ExecutionTraceEntry> lastExecutionTrace = List.of();
-
-    @Override
-    public void setSourceMap(SourceMap sourceMap) {
-        this.sourceMap = sourceMap;
-    }
-
-    @Override
-    public void setTracingEnabled(boolean enabled) {
-        this.tracingEnabled = enabled;
-    }
-
-    @Override
-    public List<ExecutionTraceEntry> getLastExecutionTrace() {
-        return lastExecutionTrace;
-    }
 
     @Override
     public void setCostModelParams(long[] costModelValues, PlutusLanguage language,
@@ -66,21 +47,24 @@ public class TruffleVmProvider implements JulcVmProvider {
     }
 
     @Override
-    public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget) {
-        return evaluateInternal(program.term(), language, budget);
+    public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget,
+                               EvalOptions options) {
+        return evaluateInternal(program.term(), language, budget, options);
     }
 
     @Override
     public EvalResult evaluateWithArgs(Program program, PlutusLanguage language,
-                                       List<PlutusData> args, ExBudget budget) {
+                                       List<PlutusData> args, ExBudget budget,
+                                       EvalOptions options) {
         Term term = program.term();
         for (var arg : args) {
             term = new Term.Apply(term, new Term.Const(Constant.data(arg)));
         }
-        return evaluateInternal(term, language, budget);
+        return evaluateInternal(term, language, budget, options);
     }
 
-    private EvalResult evaluateInternal(Term term, PlutusLanguage language, ExBudget budget) {
+    private EvalResult evaluateInternal(Term term, PlutusLanguage language, ExBudget budget,
+                                        EvalOptions options) {
         // Set up cost tracking (shared with julc-vm-java)
         MachineCosts mc;
         BuiltinCostModel bcm;
@@ -93,13 +77,14 @@ public class TruffleVmProvider implements JulcVmProvider {
             bcm = DefaultCostModel.defaultBuiltinCostModel(language);
         }
         var costTracker = new CostTracker(mc, bcm, budget);
-        var context = new UplcContext(costTracker, language, tracingEnabled);
+        var context = new UplcContext(costTracker, language,
+                options.tracingEnabled(), options.builtinTraceEnabled());
 
         try {
             // Charge startup cost (inside try for budget exhaustion handling)
             costTracker.chargeMachineStep(MachineCosts.StepKind.STARTUP);
             // Convert Term → Truffle AST
-            UplcNode bodyNode = TermToNodeConverter.convert(term, this.sourceMap);
+            UplcNode bodyNode = TermToNodeConverter.convert(term, options.sourceMap());
             var fd = FrameDescriptor.newBuilder().build();
             var rootNode = new UplcRootNode(fd, bodyNode);
 
@@ -108,16 +93,13 @@ public class TruffleVmProvider implements JulcVmProvider {
 
             // Convert result → Term
             Term resultTerm = NodeToTermConverter.toTerm(result);
-            this.lastExecutionTrace = context.getExecutionTrace();
-            return new EvalResult.Success(resultTerm, costTracker.consumed(), context.getTraces());
+            return new EvalResult.Success(resultTerm, costTracker.consumed(), context.getTraces(),
+                    context.getExecutionTrace(), context.getBuiltinTrace());
 
         } catch (BudgetExhaustedException e) {
-            this.lastExecutionTrace = context.getExecutionTrace();
-            Term failedTerm = e.failedTerm();
             return new EvalResult.BudgetExhausted(costTracker.consumed(), context.getTraces(),
-                    failedTerm);
+                    e.failedTerm(), context.getExecutionTrace(), context.getBuiltinTrace());
         } catch (UplcRuntimeException e) {
-            this.lastExecutionTrace = context.getExecutionTrace();
             String errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             // Enhance with source location if available
             if (e.getLocation() != null && e.getLocation().getSourceSection() != null) {
@@ -125,17 +107,16 @@ public class TruffleVmProvider implements JulcVmProvider {
                 errorMsg = errorMsg + " at " + ss.getSource().getName() + ":" + ss.getStartLine();
             }
             return new EvalResult.Failure(errorMsg, costTracker.consumed(), context.getTraces(),
-                    e.getFailedTerm());
+                    e.getFailedTerm(), context.getExecutionTrace(), context.getBuiltinTrace());
         } catch (com.bloxbean.cardano.julc.vm.java.CekEvaluationException e) {
             // Builtin errors from julc-vm-java implementations
-            this.lastExecutionTrace = context.getExecutionTrace();
             String errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             return new EvalResult.Failure(errorMsg, costTracker.consumed(), context.getTraces(),
-                    e.failedTerm());
+                    e.failedTerm(), context.getExecutionTrace(), context.getBuiltinTrace());
         } catch (Exception e) {
-            this.lastExecutionTrace = context.getExecutionTrace();
             String errorMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-            return new EvalResult.Failure(errorMsg, costTracker.consumed(), context.getTraces());
+            return new EvalResult.Failure(errorMsg, costTracker.consumed(), context.getTraces(),
+                    null, context.getExecutionTrace(), context.getBuiltinTrace());
         }
     }
 

--- a/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/UplcContext.java
+++ b/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/UplcContext.java
@@ -1,11 +1,15 @@
 package com.bloxbean.cardano.julc.vm.truffle;
 
+import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.java.CekValue;
 import com.bloxbean.cardano.julc.vm.java.builtins.BuiltinTable;
 import com.bloxbean.cardano.julc.vm.java.cost.CostTracker;
-import com.bloxbean.cardano.julc.vm.truffle.node.UplcNode;
+import com.bloxbean.cardano.julc.vm.java.trace.BuiltinTraceCollector;
 import com.bloxbean.cardano.julc.vm.java.trace.ExecutionTraceCollector;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
+import com.bloxbean.cardano.julc.vm.truffle.node.UplcNode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,16 +27,19 @@ public final class UplcContext {
     private final BuiltinTable.VersionedBuiltinTable builtinTable;
     private final List<String> traces = new ArrayList<>();
     private final ExecutionTraceCollector executionTraceCollector;
+    private final BuiltinTraceCollector builtinTraceCollector;
 
     public UplcContext(CostTracker costTracker, PlutusLanguage language) {
-        this(costTracker, language, false);
+        this(costTracker, language, false, true);
     }
 
-    public UplcContext(CostTracker costTracker, PlutusLanguage language, boolean tracingEnabled) {
+    public UplcContext(CostTracker costTracker, PlutusLanguage language,
+                       boolean tracingEnabled, boolean builtinTraceEnabled) {
         this.costTracker = costTracker;
         this.language = language;
         this.builtinTable = BuiltinTable.forLanguage(language);
         this.executionTraceCollector = tracingEnabled ? new ExecutionTraceCollector(costTracker) : null;
+        this.builtinTraceCollector = builtinTraceEnabled ? new BuiltinTraceCollector(20) : null;
     }
 
     public CostTracker getCostTracker() {
@@ -72,6 +79,35 @@ public final class UplcContext {
     public List<ExecutionTraceEntry> getExecutionTrace() {
         if (executionTraceCollector == null) return List.of();
         return executionTraceCollector.getEntries();
+    }
+
+    /**
+     * Record a successful builtin execution.
+     * No-op when builtin tracing is disabled.
+     */
+    public void recordBuiltin(DefaultFun fun, List<CekValue> args, CekValue result) {
+        if (builtinTraceCollector != null) {
+            builtinTraceCollector.record(fun, args, result);
+        }
+    }
+
+    /**
+     * Record a failed builtin execution.
+     * No-op when builtin tracing is disabled.
+     */
+    public void recordBuiltinError(DefaultFun fun, List<CekValue> args, Exception e) {
+        if (builtinTraceCollector != null) {
+            builtinTraceCollector.recordError(fun, args, e);
+        }
+    }
+
+    /**
+     * Returns the collected builtin trace entries.
+     * Empty list when builtin tracing is disabled.
+     */
+    public List<BuiltinExecution> getBuiltinTrace() {
+        if (builtinTraceCollector == null) return List.of();
+        return builtinTraceCollector.getEntries();
     }
 
     // --- Result capture (for debugger polyglot execution) ---

--- a/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/builtin/BuiltinDispatcher.java
+++ b/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/builtin/BuiltinDispatcher.java
@@ -69,13 +69,26 @@ public final class BuiltinDispatcher {
         // Charge builtin cost — exactly as CekMachine.executeBuiltin() does
         context.getCostTracker().chargeBuiltin(fun, cekArgs);
 
-        // Execute
+        // Execute and record builtin trace
         if (PASS_THROUGH_BUILTINS.contains(fun)) {
-            return executePassThrough(fun, truffleArgs, cekArgs);
+            try {
+                Object result = executePassThrough(fun, truffleArgs, cekArgs);
+                context.recordBuiltin(fun, cekArgs, toCekValue(result));
+                return result;
+            } catch (Exception e) {
+                context.recordBuiltinError(fun, cekArgs, e);
+                throw e;
+            }
         } else {
             BuiltinRuntime runtime = context.getBuiltinTable().getRuntime(fun);
-            CekValue result = runtime.execute(cekArgs);
-            return fromCekValue(result);
+            try {
+                CekValue result = runtime.execute(cekArgs);
+                context.recordBuiltin(fun, cekArgs, result);
+                return fromCekValue(result);
+            } catch (Exception e) {
+                context.recordBuiltinError(fun, cekArgs, e);
+                throw e;
+            }
         }
     }
 

--- a/julc-vm-truffle/src/test/java/com/bloxbean/cardano/julc/vm/truffle/ExecutionTraceTest.java
+++ b/julc-vm-truffle/src/test/java/com/bloxbean/cardano/julc/vm/truffle/ExecutionTraceTest.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.julc.vm.truffle;
 import com.bloxbean.cardano.julc.core.*;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
@@ -26,9 +27,9 @@ class ExecutionTraceTest {
     void tracingDisabledByDefault() {
         var program = new Program(1, 0, 0,
                 Term.const_(Constant.integer(BigInteger.ONE)));
-        provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
 
-        assertTrue(provider.getLastExecutionTrace().isEmpty(),
+        assertTrue(result.executionTrace().isEmpty(),
                 "Trace should be empty when tracing is disabled");
     }
 
@@ -43,13 +44,12 @@ class ExecutionTraceTest {
         positions.put(applyTerm, new SourceLocation("Test.java", 10, 1, "identity(42)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
+        var options = new EvalOptions(sourceMap, true, true);
         var result = provider.evaluate(
-                new Program(1, 0, 0, applyTerm), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, applyTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Success.class, result);
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         assertFalse(trace.isEmpty(), "Trace should have entries when enabled with source map");
 
         // Should contain an Apply entry for Test.java:10
@@ -60,16 +60,15 @@ class ExecutionTraceTest {
 
     @Test
     void tracingEnabledButNoSourceMap_emptyTrace() {
-        provider.setSourceMap(null);
-        provider.setTracingEnabled(true);
+        var options = new EvalOptions(null, true, true);
 
         var program = new Program(1, 0, 0,
                 Term.apply(
                         Term.lam("x", Term.var(new NamedDeBruijn("x", 1))),
                         Term.const_(Constant.integer(BigInteger.ONE))));
-        provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
-        assertTrue(provider.getLastExecutionTrace().isEmpty(),
+        assertTrue(result.executionTrace().isEmpty(),
                 "Trace should be empty when no source map");
     }
 
@@ -89,11 +88,10 @@ class ExecutionTraceTest {
         positions.put(outerApply, new SourceLocation("Math.java", 5, 1, "3 + 4"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         long line5Count = trace.stream()
                 .filter(e -> "Math.java".equals(e.fileName()) && e.line() == 5)
                 .count();
@@ -114,11 +112,10 @@ class ExecutionTraceTest {
         positions.put(outerApply, new SourceLocation("Math.java", 6, 1, "add(3, 4)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         assertTrue(trace.size() >= 2, "Different lines should produce separate entries. Got: " + trace);
     }
 
@@ -138,15 +135,13 @@ class ExecutionTraceTest {
         var sourceMap = SourceMap.of(positions);
 
         // With tracing
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
+        var tracedOptions = new EvalOptions(sourceMap, true, true);
         var resultTraced = provider.evaluate(
-                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null, tracedOptions);
 
         // Without tracing
-        provider.setTracingEnabled(false);
         var resultUntraced = provider.evaluate(
-                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, app), PlutusLanguage.PLUTUS_V3, null, EvalOptions.DEFAULT);
 
         assertEquals(resultTraced.budgetConsumed().cpuSteps(),
                 resultUntraced.budgetConsumed().cpuSteps(),
@@ -168,11 +163,10 @@ class ExecutionTraceTest {
         positions.put(forceTerm, new SourceLocation("Test.java", 3, 1, "force(delay(7))"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, forceTerm), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, forceTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         boolean hasForce = trace.stream().anyMatch(e -> "Force".equals(e.nodeType()));
         assertTrue(hasForce, "Should have a Force entry. Got: " + trace);
     }
@@ -188,11 +182,10 @@ class ExecutionTraceTest {
         positions.put(caseTerm, new SourceLocation("Test.java", 15, 1, "switch(x)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 1, 0, caseTerm), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 1, 0, caseTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         boolean hasCase = trace.stream().anyMatch(e -> "Case".equals(e.nodeType()));
         assertTrue(hasCase, "Should have a Case entry. Got: " + trace);
     }
@@ -205,13 +198,12 @@ class ExecutionTraceTest {
         positions.put(errorTerm, new SourceLocation("Test.java", 42, 1, "error()"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
+        var options = new EvalOptions(sourceMap, true, true);
         var result = provider.evaluate(
-                new Program(1, 0, 0, errorTerm), PlutusLanguage.PLUTUS_V3, null);
+                new Program(1, 0, 0, errorTerm), PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Failure.class, result);
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         boolean hasError = trace.stream().anyMatch(e ->
                 "Error".equals(e.nodeType()) && e.line() == 42);
         assertTrue(hasError, "Should have an Error entry at line 42. Got: " + trace);
@@ -229,11 +221,10 @@ class ExecutionTraceTest {
         positions1.put(apply1, new SourceLocation("First.java", 1, 1, "first"));
         var sourceMap1 = SourceMap.of(positions1);
 
-        provider.setSourceMap(sourceMap1);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, apply1), PlutusLanguage.PLUTUS_V3, null);
+        var options1 = new EvalOptions(sourceMap1, true, true);
+        var result1 = provider.evaluate(new Program(1, 0, 0, apply1), PlutusLanguage.PLUTUS_V3, null, options1);
 
-        var trace1 = provider.getLastExecutionTrace();
+        var trace1 = result1.executionTrace();
         assertFalse(trace1.isEmpty());
         assertTrue(trace1.stream().anyMatch(e -> "First.java".equals(e.fileName())));
 
@@ -246,10 +237,10 @@ class ExecutionTraceTest {
         positions2.put(apply2, new SourceLocation("Second.java", 2, 1, "second"));
         var sourceMap2 = SourceMap.of(positions2);
 
-        provider.setSourceMap(sourceMap2);
-        provider.evaluate(new Program(1, 0, 0, apply2), PlutusLanguage.PLUTUS_V3, null);
+        var options2 = new EvalOptions(sourceMap2, true, true);
+        var result2 = provider.evaluate(new Program(1, 0, 0, apply2), PlutusLanguage.PLUTUS_V3, null, options2);
 
-        var trace2 = provider.getLastExecutionTrace();
+        var trace2 = result2.executionTrace();
         // Second trace should NOT contain First.java entries
         boolean hasFirst = trace2.stream().anyMatch(e -> "First.java".equals(e.fileName()));
         assertFalse(hasFirst, "Second trace should not contain entries from first evaluation");
@@ -271,11 +262,10 @@ class ExecutionTraceTest {
         // innerApply is NOT mapped
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         // All entries should be from Test.java:10 (the mapped one)
         for (var entry : trace) {
             assertEquals("Test.java", entry.fileName());
@@ -298,11 +288,10 @@ class ExecutionTraceTest {
         positions.put(outerApply, new SourceLocation("Math.java", 6, 1, "3 + 4"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         assertFalse(trace.isEmpty());
         // At least one entry should have non-zero cpuDelta
         boolean hasNonZeroCpu = trace.stream().anyMatch(e -> e.cpuDelta() > 0);
@@ -324,11 +313,10 @@ class ExecutionTraceTest {
         positions.put(outerApply, new SourceLocation("Math.java", 5, 1, "3 + 4"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        provider.setTracingEnabled(true);
-        provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null);
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(new Program(1, 0, 0, outerApply), PlutusLanguage.PLUTUS_V3, null, options);
 
-        var trace = provider.getLastExecutionTrace();
+        var trace = result.executionTrace();
         // Should be deduped to 1 entry
         long line5Count = trace.stream()
                 .filter(e -> "Math.java".equals(e.fileName()) && e.line() == 5)

--- a/julc-vm-truffle/src/test/java/com/bloxbean/cardano/julc/vm/truffle/TruffleBuiltinTraceTest.java
+++ b/julc-vm-truffle/src/test/java/com/bloxbean/cardano/julc/vm/truffle/TruffleBuiltinTraceTest.java
@@ -1,0 +1,163 @@
+package com.bloxbean.cardano.julc.vm.truffle;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.Program;
+import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.core.source.SourceLocation;
+import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import org.junit.jupiter.api.Test;
+
+import java.util.IdentityHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for builtin trace collection in the Truffle VM backend.
+ */
+class TruffleBuiltinTraceTest {
+
+    private final TruffleVmProvider provider = new TruffleVmProvider();
+
+    @Test
+    void successfulEvaluation_capturesBuiltinTrace() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)),
+                new Term.Const(Constant.integer(5)));
+        var program = new Program(1, 1, 0, add);
+
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+
+        assertInstanceOf(EvalResult.Success.class, result);
+        var builtinTrace = result.builtinTrace();
+        assertEquals(1, builtinTrace.size());
+        assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
+        assertEquals("3, 5", builtinTrace.getFirst().argSummary());
+        assertEquals("8", builtinTrace.getFirst().resultSummary());
+    }
+
+    @Test
+    void failureCaptures_comparisonBuiltin() {
+        // IfThenElse(LessThanEqualsInteger(5, 3), True, Error)
+        var lessThanEquals = applyBuiltin(DefaultFun.LessThanEqualsInteger,
+                new Term.Const(Constant.integer(5)),
+                new Term.Const(Constant.integer(3)));
+        var ifThenElse = applyBuiltin(DefaultFun.IfThenElse,
+                lessThanEquals,
+                new Term.Const(Constant.bool(true)),
+                new Term.Error());
+        var program = new Program(1, 1, 0, ifThenElse);
+
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+
+        assertInstanceOf(EvalResult.Failure.class, result);
+        var builtinTrace = result.builtinTrace();
+        assertFalse(builtinTrace.isEmpty(), "Builtin trace should capture builtins before failure");
+
+        boolean foundComparison = builtinTrace.stream()
+                .anyMatch(e -> e.fun() == DefaultFun.LessThanEqualsInteger
+                        && "False".equals(e.resultSummary()));
+        assertTrue(foundComparison,
+                "Should capture LessThanEqualsInteger(5, 3) → False. Got: " + builtinTrace);
+    }
+
+    @Test
+    void builtinTraceDisabled_returnsEmpty() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(1)),
+                new Term.Const(Constant.integer(2)));
+        var program = new Program(1, 1, 0, add);
+
+        var options = EvalOptions.DEFAULT.withBuiltinTrace(false);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
+
+        assertInstanceOf(EvalResult.Success.class, result);
+        assertTrue(result.builtinTrace().isEmpty(),
+                "Builtin trace should be empty when disabled");
+    }
+
+    @Test
+    void noSourceMap_stillCapturesBuiltinTrace() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(1)),
+                new Term.Const(Constant.integer(2)));
+        var program = new Program(1, 1, 0, add);
+
+        // No source map, but builtin trace should still work
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+
+        var builtinTrace = result.builtinTrace();
+        assertFalse(builtinTrace.isEmpty());
+        assertEquals(DefaultFun.AddInteger, builtinTrace.getFirst().fun());
+    }
+
+    @Test
+    void multipleBuiltins_capturedInOrder() {
+        // ((1+2) + (3+4))
+        var a1 = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(1)), new Term.Const(Constant.integer(2)));
+        var a2 = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)), new Term.Const(Constant.integer(4)));
+        var a3 = applyBuiltin(DefaultFun.AddInteger, a1, a2);
+        var program = new Program(1, 1, 0, a3);
+
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+
+        var builtinTrace = result.builtinTrace();
+        assertEquals(3, builtinTrace.size());
+        assertEquals("3", builtinTrace.get(0).resultSummary());
+        assertEquals("7", builtinTrace.get(1).resultSummary());
+        assertEquals("10", builtinTrace.get(2).resultSummary());
+    }
+
+    @Test
+    void builtinTraceIndependentOfExecutionTrace() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)),
+                new Term.Const(Constant.integer(5)));
+        var program = new Program(1, 1, 0, add);
+
+        // Builtin trace ON, execution trace OFF (no source map)
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
+
+        assertFalse(result.builtinTrace().isEmpty(), "Builtin trace should be captured");
+        assertTrue(result.executionTrace().isEmpty(), "Execution trace should be empty (no source map)");
+    }
+
+    @Test
+    void builtinTraceWithSourceMap() {
+        var add = applyBuiltin(DefaultFun.AddInteger,
+                new Term.Const(Constant.integer(3)),
+                new Term.Const(Constant.integer(5)));
+        var program = new Program(1, 1, 0, add);
+
+        var positions = new IdentityHashMap<Term, SourceLocation>();
+        positions.put(add, new SourceLocation("Test.java", 1, 1, "3 + 5"));
+        var sourceMap = SourceMap.of(positions);
+
+        var options = new EvalOptions(sourceMap, true, true);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
+
+        // Both traces should be populated
+        assertFalse(result.builtinTrace().isEmpty(), "Builtin trace should be captured");
+        assertFalse(result.executionTrace().isEmpty(), "Execution trace should be captured with source map");
+    }
+
+    // --- helpers ---
+
+    private static Term applyBuiltin(DefaultFun fun, Term... args) {
+        var table = com.bloxbean.cardano.julc.vm.java.builtins.BuiltinTable.forLanguage(PlutusLanguage.PLUTUS_V3);
+        var sig = table.getSignature(fun);
+        Term t = new Term.Builtin(fun);
+        for (int i = 0; i < sig.forceCount(); i++) {
+            t = new Term.Force(t);
+        }
+        for (Term arg : args) {
+            t = new Term.Apply(t, arg);
+        }
+        return t;
+    }
+}

--- a/julc-vm-truffle/src/test/java/com/bloxbean/cardano/julc/vm/truffle/TruffleDebuggerTest.java
+++ b/julc-vm-truffle/src/test/java/com/bloxbean/cardano/julc/vm/truffle/TruffleDebuggerTest.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.julc.vm.truffle;
 import com.bloxbean.cardano.julc.core.*;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
 import com.bloxbean.cardano.julc.core.source.SourceMap;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
@@ -116,9 +117,8 @@ class TruffleDebuggerTest {
         positions.put(constTerm, new SourceLocation("Test.java", 1, 1, "42"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
-        provider.setSourceMap(null); // cleanup
+        var options = new EvalOptions(sourceMap, false, true);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Success.class, result);
         var success = (EvalResult.Success) result;
@@ -138,9 +138,8 @@ class TruffleDebuggerTest {
         positions.put(add, new SourceLocation("Test.java", 5, 1, "3 + 4"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
-        provider.setSourceMap(null);
+        var options = new EvalOptions(sourceMap, false, true);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Success.class, result);
         var constTerm = (Term.Const) ((EvalResult.Success) result).resultTerm();
@@ -158,9 +157,8 @@ class TruffleDebuggerTest {
         positions.put(errorTerm, new SourceLocation("Validator.java", 42, 10, "error()"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
-        provider.setSourceMap(null);
+        var options = new EvalOptions(sourceMap, false, true);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Failure.class, result);
         var failure = (EvalResult.Failure) result;
@@ -184,7 +182,6 @@ class TruffleDebuggerTest {
         var program = new Program(1, 0, 0, app);
 
         // Without source map
-        provider.setSourceMap(null);
         var resultNoMap = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
         assertInstanceOf(EvalResult.Success.class, resultNoMap);
 
@@ -193,9 +190,8 @@ class TruffleDebuggerTest {
         positions.put(app, new SourceLocation("Test.java", 1, 1, "addTen(5)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        var resultWithMap = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
-        provider.setSourceMap(null);
+        var options = new EvalOptions(sourceMap, false, true);
+        var resultWithMap = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Success.class, resultWithMap);
 
@@ -232,9 +228,8 @@ class TruffleDebuggerTest {
         positions.put(delayTerm, new SourceLocation("Test.java", 3, 7, "delay(7)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
-        provider.setSourceMap(null);
+        var options = new EvalOptions(sourceMap, false, true);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Success.class, result);
         var constTerm = (Term.Const) ((EvalResult.Success) result).resultTerm();
@@ -254,9 +249,8 @@ class TruffleDebuggerTest {
         positions.put(caseTerm, new SourceLocation("Test.java", 15, 1, "switch(constr)"));
         var sourceMap = SourceMap.of(positions);
 
-        provider.setSourceMap(sourceMap);
-        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null);
-        provider.setSourceMap(null);
+        var options = new EvalOptions(sourceMap, false, true);
+        var result = provider.evaluate(program, PlutusLanguage.PLUTUS_V3, null, options);
 
         assertInstanceOf(EvalResult.Success.class, result);
         var constTerm = (Term.Const) ((EvalResult.Success) result).resultTerm();

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/EvalOptions.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/EvalOptions.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.julc.vm;
+
+import com.bloxbean.cardano.julc.core.source.SourceMap;
+
+/**
+ * Per-evaluation configuration options.
+ * <p>
+ * Passed to {@link JulcVmProvider#evaluate} and {@link JulcVmProvider#evaluateWithArgs}
+ * to configure source maps, execution tracing, and builtin trace collection for a
+ * single evaluation. This makes each evaluation self-contained and thread-safe —
+ * no shared mutable state on the provider.
+ *
+ * @param sourceMap           the source map for debugging support (nullable — null disables)
+ * @param tracingEnabled      true to enable per-step execution tracing (requires source map)
+ * @param builtinTraceEnabled true to enable builtin execution trace collection (default: true)
+ */
+public record EvalOptions(SourceMap sourceMap, boolean tracingEnabled, boolean builtinTraceEnabled) {
+
+    /** Default options: no source map, no execution tracing, builtin trace enabled. */
+    public static final EvalOptions DEFAULT = new EvalOptions(null, false, true);
+
+    /** Return a copy with the given source map. */
+    public EvalOptions withSourceMap(SourceMap sourceMap) {
+        return new EvalOptions(sourceMap, this.tracingEnabled, this.builtinTraceEnabled);
+    }
+
+    /** Return a copy with execution tracing enabled or disabled. */
+    public EvalOptions withTracing(boolean enabled) {
+        return new EvalOptions(this.sourceMap, enabled, this.builtinTraceEnabled);
+    }
+
+    /** Return a copy with builtin trace collection enabled or disabled. */
+    public EvalOptions withBuiltinTrace(boolean enabled) {
+        return new EvalOptions(this.sourceMap, this.tracingEnabled, enabled);
+    }
+}

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/EvalResult.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/EvalResult.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.julc.vm;
 
 import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
+import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.List;
 import java.util.Objects;
@@ -14,61 +16,98 @@ import java.util.Objects;
  *   <li>{@link Failure} — evaluation failed (error term, type error, etc.)</li>
  *   <li>{@link BudgetExhausted} — evaluation exceeded the allowed budget</li>
  * </ul>
+ * <p>
+ * Each result variant carries execution and builtin traces captured during evaluation,
+ * making results self-contained and thread-safe. Traces are empty lists when tracing
+ * is disabled or the provider does not support tracing.
  */
 public sealed interface EvalResult {
 
     /**
      * Successful evaluation.
      *
-     * @param resultTerm the evaluated term
-     * @param consumed   the budget consumed during evaluation
-     * @param traces     trace messages emitted during evaluation
+     * @param resultTerm     the evaluated term
+     * @param consumed       the budget consumed during evaluation
+     * @param traces         trace messages emitted during evaluation
+     * @param executionTrace per-step execution trace entries (empty if tracing disabled)
+     * @param builtinTrace   last N builtin executions (empty if not supported)
      */
-    record Success(Term resultTerm, ExBudget consumed, List<String> traces) implements EvalResult {
+    record Success(Term resultTerm, ExBudget consumed, List<String> traces,
+                   List<ExecutionTraceEntry> executionTrace,
+                   List<BuiltinExecution> builtinTrace) implements EvalResult {
         public Success {
             Objects.requireNonNull(resultTerm);
             Objects.requireNonNull(consumed);
             traces = List.copyOf(traces);
+            executionTrace = List.copyOf(executionTrace);
+            builtinTrace = List.copyOf(builtinTrace);
+        }
+
+        /** Backward-compatible constructor (no trace fields). */
+        public Success(Term resultTerm, ExBudget consumed, List<String> traces) {
+            this(resultTerm, consumed, traces, List.of(), List.of());
         }
     }
 
     /**
      * Failed evaluation.
      *
-     * @param error      description of the failure
-     * @param consumed   the budget consumed before failure
-     * @param traces     trace messages emitted before failure
-     * @param failedTerm the UPLC term that was being evaluated when the error occurred (nullable)
+     * @param error          description of the failure
+     * @param consumed       the budget consumed before failure
+     * @param traces         trace messages emitted before failure
+     * @param failedTerm     the UPLC term that was being evaluated when the error occurred (nullable)
+     * @param executionTrace per-step execution trace entries (empty if tracing disabled)
+     * @param builtinTrace   last N builtin executions (empty if not supported)
      */
-    record Failure(String error, ExBudget consumed, List<String> traces, Term failedTerm) implements EvalResult {
+    record Failure(String error, ExBudget consumed, List<String> traces, Term failedTerm,
+                   List<ExecutionTraceEntry> executionTrace,
+                   List<BuiltinExecution> builtinTrace) implements EvalResult {
         public Failure {
             Objects.requireNonNull(error);
             Objects.requireNonNull(consumed);
             traces = List.copyOf(traces);
+            executionTrace = List.copyOf(executionTrace);
+            builtinTrace = List.copyOf(builtinTrace);
         }
 
-        /** Backward-compatible constructor (no failedTerm). */
+        /** Backward-compatible constructor (no failedTerm or trace fields). */
         public Failure(String error, ExBudget consumed, List<String> traces) {
-            this(error, consumed, traces, null);
+            this(error, consumed, traces, null, List.of(), List.of());
+        }
+
+        /** Backward-compatible constructor (no trace fields). */
+        public Failure(String error, ExBudget consumed, List<String> traces, Term failedTerm) {
+            this(error, consumed, traces, failedTerm, List.of(), List.of());
         }
     }
 
     /**
      * Budget exhausted — evaluation exceeded the allowed budget.
      *
-     * @param consumed   the budget consumed before exhaustion
-     * @param traces     trace messages emitted before exhaustion
-     * @param failedTerm the UPLC term that was being evaluated when the budget was exhausted (nullable)
+     * @param consumed       the budget consumed before exhaustion
+     * @param traces         trace messages emitted before exhaustion
+     * @param failedTerm     the UPLC term that was being evaluated when the budget was exhausted (nullable)
+     * @param executionTrace per-step execution trace entries (empty if tracing disabled)
+     * @param builtinTrace   last N builtin executions (empty if not supported)
      */
-    record BudgetExhausted(ExBudget consumed, List<String> traces, Term failedTerm) implements EvalResult {
+    record BudgetExhausted(ExBudget consumed, List<String> traces, Term failedTerm,
+                           List<ExecutionTraceEntry> executionTrace,
+                           List<BuiltinExecution> builtinTrace) implements EvalResult {
         public BudgetExhausted {
             Objects.requireNonNull(consumed);
             traces = List.copyOf(traces);
+            executionTrace = List.copyOf(executionTrace);
+            builtinTrace = List.copyOf(builtinTrace);
         }
 
-        /** Backward-compatible constructor (no failedTerm). */
+        /** Backward-compatible constructor (no failedTerm or trace fields). */
         public BudgetExhausted(ExBudget consumed, List<String> traces) {
-            this(consumed, traces, null);
+            this(consumed, traces, null, List.of(), List.of());
+        }
+
+        /** Backward-compatible constructor (no trace fields). */
+        public BudgetExhausted(ExBudget consumed, List<String> traces, Term failedTerm) {
+            this(consumed, traces, failedTerm, List.of(), List.of());
         }
     }
 
@@ -92,6 +131,24 @@ public sealed interface EvalResult {
             case Success s -> s.traces();
             case Failure f -> f.traces();
             case BudgetExhausted b -> b.traces();
+        };
+    }
+
+    /** Get the execution trace from this evaluation (empty if tracing was disabled). */
+    default List<ExecutionTraceEntry> executionTrace() {
+        return switch (this) {
+            case Success s -> s.executionTrace();
+            case Failure f -> f.executionTrace();
+            case BudgetExhausted b -> b.executionTrace();
+        };
+    }
+
+    /** Get the builtin trace from this evaluation (empty if not supported by provider). */
+    default List<BuiltinExecution> builtinTrace() {
+        return switch (this) {
+            case Success s -> s.builtinTrace();
+            case Failure f -> f.builtinTrace();
+            case BudgetExhausted b -> b.builtinTrace();
         };
     }
 }

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVm.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVm.java
@@ -2,9 +2,6 @@ package com.bloxbean.cardano.julc.vm;
 
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
-import com.bloxbean.cardano.julc.core.source.SourceMap;
-import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
-import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.Comparator;
 import java.util.List;
@@ -22,9 +19,10 @@ import java.util.ServiceLoader;
  * // Evaluate a program
  * EvalResult result = vm.evaluate(program);
  *
- * // Evaluate with arguments
- * EvalResult result = vm.evaluateWithArgs(program,
- *     List.of(datum, redeemer, scriptContext));
+ * // Evaluate with arguments and options
+ * var options = EvalOptions.DEFAULT.withSourceMap(sourceMap).withTracing(true);
+ * EvalResult result = vm.evaluateWithArgs(program, List.of(ctx), options);
+ * // Traces are in the result: result.executionTrace(), result.builtinTrace()
  * }</pre>
  *
  * @see JulcVmProvider
@@ -124,117 +122,62 @@ public final class JulcVm {
         return new JulcVm(provider, language);
     }
 
-    /**
-     * Evaluate a UPLC program with unlimited budget.
-     */
+    // --- Evaluate with default options ---
+
+    /** Evaluate a UPLC program with unlimited budget and default options. */
     public EvalResult evaluate(Program program) {
         return provider.evaluate(program, language, null);
     }
 
-    /**
-     * Evaluate a UPLC program with a maximum budget.
-     */
+    /** Evaluate a UPLC program with a maximum budget and default options. */
     public EvalResult evaluate(Program program, ExBudget budget) {
         return provider.evaluate(program, language, budget);
     }
 
-    /**
-     * Evaluate a UPLC program applied to the given arguments, with unlimited budget.
-     * <p>
-     * Arguments are applied as PlutusData constants.
-     */
+    /** Evaluate with arguments, unlimited budget, default options. */
     public EvalResult evaluateWithArgs(Program program, List<PlutusData> args) {
         return provider.evaluateWithArgs(program, language, args, null);
     }
 
-    /**
-     * Evaluate a UPLC program applied to the given arguments, with a maximum budget.
-     */
+    /** Evaluate with arguments, maximum budget, default options. */
     public EvalResult evaluateWithArgs(Program program, List<PlutusData> args, ExBudget budget) {
         return provider.evaluateWithArgs(program, language, args, budget);
     }
+
+    // --- Evaluate with explicit options ---
+
+    /** Evaluate a UPLC program with per-evaluation options and unlimited budget. */
+    public EvalResult evaluate(Program program, EvalOptions options) {
+        return provider.evaluate(program, language, null, options);
+    }
+
+    /** Evaluate a UPLC program with per-evaluation options and a maximum budget. */
+    public EvalResult evaluate(Program program, ExBudget budget, EvalOptions options) {
+        return provider.evaluate(program, language, budget, options);
+    }
+
+    /** Evaluate with arguments, per-evaluation options, and unlimited budget. */
+    public EvalResult evaluateWithArgs(Program program, List<PlutusData> args, EvalOptions options) {
+        return provider.evaluateWithArgs(program, language, args, null, options);
+    }
+
+    /** Evaluate with arguments, per-evaluation options, and a maximum budget. */
+    public EvalResult evaluateWithArgs(Program program, List<PlutusData> args,
+                                       ExBudget budget, EvalOptions options) {
+        return provider.evaluateWithArgs(program, language, args, budget, options);
+    }
+
+    // --- Configuration ---
 
     /**
      * Set the cost model parameter values for a specific Plutus language version.
      * Values must be in the canonical order (matching the on-chain costModels array).
      * <p>
-     * Mixed-version transactions require calling this once per language version
-     * present in the transaction (V1, V2, and/or V3).
-     * <p>
-     * The protocol version determines which builtins are available and therefore
-     * the expected parameter count. New builtins are added to all language versions
-     * (V1/V2/V3) in each protocol version, so V1/V2 arrays grow over time too.
-     *
-     * @param costModelValues       ordered array of cost model parameter values
-     * @param language              the Plutus language version these parameters are for
-     * @param protocolMajorVersion  the protocol major version (e.g. 9 for Chang, 10 for Plomin)
-     * @param protocolMinorVersion  the protocol minor version
+     * This is shared/global configuration set once at startup — not per-evaluation.
      */
     public void setCostModelParams(long[] costModelValues, PlutusLanguage language,
                                    int protocolMajorVersion, int protocolMinorVersion) {
         provider.setCostModelParams(costModelValues, language, protocolMajorVersion, protocolMinorVersion);
-    }
-
-    /**
-     * Set the source map for debugging support.
-     * When set, evaluation errors can include the originating Java source location,
-     * and execution tracing can map CEK steps back to Java source lines.
-     * <p>
-     * No-op if the active provider does not support source maps.
-     *
-     * @param sourceMap the source map from compilation (nullable — pass null to disable)
-     */
-    public void setSourceMap(SourceMap sourceMap) {
-        provider.setSourceMap(sourceMap);
-    }
-
-    /**
-     * Enable or disable execution tracing.
-     * When enabled (and a source map is set), each statement-level CEK step
-     * is recorded with its Java source location.
-     * <p>
-     * This is the heavier tracing option — for lightweight diagnostics, use
-     * {@link #setBuiltinTraceEnabled(boolean)} instead.
-     * <p>
-     * No-op if the active provider does not support tracing.
-     *
-     * @param enabled true to enable execution tracing, false to disable
-     */
-    public void setTracingEnabled(boolean enabled) {
-        provider.setTracingEnabled(enabled);
-    }
-
-    /**
-     * Enable or disable builtin trace collection.
-     * When enabled, the last N builtin executions (function name, argument values,
-     * result value) are recorded. This is lightweight and useful for showing
-     * <em>what values</em> caused a validator failure.
-     * <p>
-     * Enabled by default. Disable for zero-overhead production evaluation.
-     * <p>
-     * No-op if the active provider does not support builtin tracing.
-     *
-     * @param enabled true to enable builtin tracing, false to disable
-     */
-    public void setBuiltinTraceEnabled(boolean enabled) {
-        provider.setBuiltinTraceEnabled(enabled);
-    }
-
-    /**
-     * Returns the execution trace from the most recent evaluation.
-     * Empty list if tracing was disabled, no source map was set, or
-     * the active provider does not support tracing.
-     */
-    public List<ExecutionTraceEntry> getLastExecutionTrace() {
-        return provider.getLastExecutionTrace();
-    }
-
-    /**
-     * Returns the last N builtin executions from the most recent evaluation.
-     * Empty list if builtin tracing was disabled or the active provider does not support this.
-     */
-    public List<BuiltinExecution> getLastBuiltinTrace() {
-        return provider.getLastBuiltinTrace();
     }
 
     /** The name of the active VM provider. */

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVmProvider.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/JulcVmProvider.java
@@ -2,10 +2,6 @@ package com.bloxbean.cardano.julc.vm;
 
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
-import com.bloxbean.cardano.julc.core.Term;
-import com.bloxbean.cardano.julc.core.source.SourceMap;
-import com.bloxbean.cardano.julc.vm.trace.BuiltinExecution;
-import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 
 import java.util.List;
 
@@ -16,40 +12,51 @@ import java.util.List;
  * backends can coexist; the one with the highest {@link #priority()} is selected
  * by default.
  * <p>
- * Current implementations:
- * <ul>
- *   <li>{@code plutus-vm-scalus} — wraps the Scalus CEK machine (priority 50)</li>
- *   <li>{@code plutus-vm-java} — pure Java CEK machine (future, priority 100)</li>
- * </ul>
+ * Per-evaluation configuration (source maps, tracing) is passed via {@link EvalOptions}
+ * — providers hold no mutable per-evaluation state.
  *
  * @see JulcVm
  */
 public interface JulcVmProvider {
 
     /**
-     * Evaluate a UPLC program.
+     * Evaluate a UPLC program with per-evaluation options.
      *
      * @param program  the UPLC program to evaluate
      * @param language the Plutus language version
      * @param budget   the maximum allowed budget (null for unlimited)
-     * @return the evaluation result
+     * @param options  per-evaluation configuration (source map, tracing flags)
+     * @return the evaluation result (including traces)
      */
-    EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget);
+    EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget, EvalOptions options);
 
     /**
-     * Evaluate a UPLC program applied to the given arguments.
-     * <p>
-     * Arguments are applied as {@code PlutusData} constants. For V1/V2 scripts,
-     * this is typically [datum, redeemer, scriptContext]. For V3, it's [scriptContext].
+     * Evaluate a UPLC program applied to the given arguments, with per-evaluation options.
      *
      * @param program  the UPLC program to evaluate
      * @param language the Plutus language version
      * @param args     the arguments to apply (as PlutusData)
      * @param budget   the maximum allowed budget (null for unlimited)
-     * @return the evaluation result
+     * @param options  per-evaluation configuration (source map, tracing flags)
+     * @return the evaluation result (including traces)
      */
     EvalResult evaluateWithArgs(Program program, PlutusLanguage language,
-                                List<PlutusData> args, ExBudget budget);
+                                List<PlutusData> args, ExBudget budget, EvalOptions options);
+
+    /**
+     * Evaluate a UPLC program with default options.
+     */
+    default EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget) {
+        return evaluate(program, language, budget, EvalOptions.DEFAULT);
+    }
+
+    /**
+     * Evaluate a UPLC program applied to the given arguments, with default options.
+     */
+    default EvalResult evaluateWithArgs(Program program, PlutusLanguage language,
+                                        List<PlutusData> args, ExBudget budget) {
+        return evaluateWithArgs(program, language, args, budget, EvalOptions.DEFAULT);
+    }
 
     /**
      * Set the cost model parameter values for a specific Plutus language version.
@@ -59,10 +66,6 @@ public interface JulcVmProvider {
      * <p>
      * Mixed-version transactions require calling this once per language version
      * present in the transaction (V1, V2, and/or V3).
-     * <p>
-     * The protocol version determines which builtins are available and therefore
-     * the expected parameter count. New builtins are added to all language versions
-     * (V1/V2/V3) in each protocol version, so V1/V2 arrays grow over time too.
      *
      * @param costModelValues       ordered array of cost model parameter values
      * @param language              the Plutus language version these parameters are for
@@ -72,68 +75,6 @@ public interface JulcVmProvider {
     default void setCostModelParams(long[] costModelValues, PlutusLanguage language,
                                     int protocolMajorVersion, int protocolMinorVersion) {
         // Default: ignore (use built-in defaults)
-    }
-
-    /**
-     * Set the source map for debugging support.
-     * When set, evaluation errors can include the originating Java source location,
-     * and execution tracing can map CEK steps back to Java source lines.
-     * <p>
-     * Providers that do not support source maps ignore this call.
-     *
-     * @param sourceMap the source map from compilation (nullable — pass null to disable)
-     */
-    default void setSourceMap(SourceMap sourceMap) {
-        // Default: ignore (provider does not support source maps)
-    }
-
-    /**
-     * Enable or disable execution tracing.
-     * When enabled (and a source map is set), each statement-level CEK step
-     * is recorded with its Java source location.
-     * <p>
-     * This is the heavier tracing option — for lightweight diagnostics, use
-     * {@link #setBuiltinTraceEnabled(boolean)} instead.
-     * <p>
-     * Providers that do not support tracing ignore this call.
-     *
-     * @param enabled true to enable execution tracing, false to disable
-     */
-    default void setTracingEnabled(boolean enabled) {
-        // Default: ignore (provider does not support tracing)
-    }
-
-    /**
-     * Enable or disable builtin trace collection.
-     * When enabled, the last N builtin executions (function name, argument values,
-     * result value) are recorded in a ring buffer. This is lightweight and useful
-     * for showing <em>what values</em> caused a validator failure.
-     * <p>
-     * Enabled by default. Disable for zero-overhead production evaluation.
-     * <p>
-     * Providers that do not support builtin tracing ignore this call.
-     *
-     * @param enabled true to enable builtin tracing, false to disable
-     */
-    default void setBuiltinTraceEnabled(boolean enabled) {
-        // Default: ignore (provider does not support builtin tracing)
-    }
-
-    /**
-     * Returns the execution trace from the most recent evaluation.
-     * Empty list if execution tracing was disabled, no source map was set, or
-     * the provider does not support tracing.
-     */
-    default List<ExecutionTraceEntry> getLastExecutionTrace() {
-        return List.of();
-    }
-
-    /**
-     * Returns the last N builtin executions from the most recent evaluation.
-     * Empty list if builtin tracing was disabled or the provider does not support this.
-     */
-    default List<BuiltinExecution> getLastBuiltinTrace() {
-        return List.of();
     }
 
     /** The name of this provider (for logging/debugging). */

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReportBuilder.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/trace/FailureReportBuilder.java
@@ -7,7 +7,10 @@ import com.bloxbean.cardano.julc.vm.EvalResult;
 import java.util.List;
 
 /**
- * Builds a {@link FailureReport} from an {@link EvalResult} and optional diagnostic traces.
+ * Builds a {@link FailureReport} from an {@link EvalResult}.
+ * <p>
+ * Traces (execution trace and builtin trace) are read directly from the
+ * {@code EvalResult}, which carries them as part of the evaluation output.
  */
 public final class FailureReportBuilder {
 
@@ -16,15 +19,11 @@ public final class FailureReportBuilder {
     /**
      * Build a FailureReport from a failed evaluation result.
      *
-     * @param result         the failed EvalResult (Failure or BudgetExhausted)
-     * @param sourceMap      the source map for resolving error locations (nullable)
-     * @param executionTrace the execution trace entries (nullable or empty)
-     * @param builtinTrace   the last N builtin executions (nullable or empty)
+     * @param result    the failed EvalResult (Failure or BudgetExhausted)
+     * @param sourceMap the source map for resolving error locations (nullable)
      * @return the structured failure report, or null if the result is a Success
      */
-    public static FailureReport build(EvalResult result, SourceMap sourceMap,
-                                       List<ExecutionTraceEntry> executionTrace,
-                                       List<BuiltinExecution> builtinTrace) {
+    public static FailureReport build(EvalResult result, SourceMap sourceMap) {
         if (result instanceof EvalResult.Success) return null;
 
         String errorMessage = switch (result) {
@@ -49,24 +48,17 @@ public final class FailureReportBuilder {
         return new FailureReport(
                 errorMessage,
                 location,
-                builtinTrace != null ? builtinTrace : List.of(),
-                executionTrace != null ? executionTrace : List.of(),
+                result.builtinTrace(),
+                result.executionTrace(),
                 result.budgetConsumed(),
                 result.traces()
         );
     }
 
     /**
-     * Build a FailureReport with only a source map (no builtin/execution traces).
-     */
-    public static FailureReport build(EvalResult result, SourceMap sourceMap) {
-        return build(result, sourceMap, List.of(), List.of());
-    }
-
-    /**
-     * Build a FailureReport with no source map or traces.
+     * Build a FailureReport with no source map.
      */
     public static FailureReport build(EvalResult result) {
-        return build(result, null, List.of(), List.of());
+        return build(result, null);
     }
 }

--- a/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/JulcVmTest.java
+++ b/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/JulcVmTest.java
@@ -23,7 +23,8 @@ class JulcVmTest {
         List<PlutusData> lastArgs;
 
         @Override
-        public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget) {
+        public EvalResult evaluate(Program program, PlutusLanguage language, ExBudget budget,
+                                   EvalOptions options) {
             evaluateCallCount++;
             lastLanguage = language;
             lastBudget = budget;
@@ -35,7 +36,8 @@ class JulcVmTest {
 
         @Override
         public EvalResult evaluateWithArgs(Program program, PlutusLanguage language,
-                                           List<PlutusData> args, ExBudget budget) {
+                                           List<PlutusData> args, ExBudget budget,
+                                           EvalOptions options) {
             evaluateWithArgsCallCount++;
             lastLanguage = language;
             lastArgs = args;


### PR DESCRIPTION
# Summary

 - Make VM evaluation thread-safe by eliminating all per-evaluation mutable state from providers                                                                                                                                                                 
  - Move trace outputs (executionTrace, builtinTrace) into `EvalResult` so each evaluation returns a self-contained, immutable result
  - Replace mutable provider config (sourceMap, tracingEnabled, builtinTraceEnabled) with immutable per-evaluation `EvalOptions` record                                                                                                                           
  - Add builtin trace support to TruffleVmProvider (previously only supported execution tracing)                                                                                                                                                                  
  - Remove redundant `EvalWithTrace` wrapper and 4-arg `FailureReportBuilder.build()` overload     
  
   ## Key Changes                                        

  **`EvalResult`** — now carries `executionTrace` and `builtinTrace` as record fields on all 3 variants (Success, Failure, BudgetExhausted). Backward-compatible constructors preserved.                                                                          
   
  **`EvalOptions`** — new immutable record replacing setter-based config. Passed per `evaluate()`/`evaluateWithArgs()` call:                                                                                                                                      
  ```java                                               
  var options = EvalOptions.DEFAULT                                                                                                                                                                                                                               
          .withSourceMap(sourceMap)                                                                                                                                                                                                                               
          .withTracing(true);
  EvalResult result = vm.evaluateWithArgs(program, args, options);                                                                                                                                                                                                
  // Traces in the result — no shared state                                                                                                                                                                                                                       
  List<BuiltinExecution> trace = result.builtinTrace();                  
```                                                                                                                                                                                         
                                                                                                                                                                                                                                                                  
  Providers — zero per-evaluation mutable state. Only shared state is cost models (set once at startup via setCostModelParams).                                                                                                                                   
                                                                                                                                                                                                                                                                  
  TruffleVmProvider — now supports builtin trace collection (ring buffer of last 20 builtin executions), matching Java VM parity.     