### PR TITLE
Add diagnostic catalog codegen slice

### DIFF
--- a/adr/021-diagnostic-catalog-codegen.md
+++ b/adr/021-diagnostic-catalog-codegen.md
@@ -1,0 +1,398 @@
+# ADR-021: Diagnostic Catalog, Generated Constants, and Full Compiler Coverage
+
+**Date**: 2026-05-14
+**Status**: Proposed
+
+---
+
+## Context
+
+ADR-020 introduced `julc-compiler/src/main/resources/diagnostics.json` as a structured catalog of compiler diagnostic codes (currently 30 entries, `JULC0001`-`JULC0030`) plus a parallel hand-written `DiagnosticCodes.java` file (currently 9 string constants). The two have already drifted: only 9 of the 30 catalog codes have a Java constant, and many compiler failures still have no stable code at all.
+
+The current state has two separate coverage problems:
+
+1. **Catalog/codegen drift.** A code added to JSON can lack a Java handle, and a Java constant can lack a catalog entry. The existing `DiagnosticCatalogConsistencyTest` only catches Java references that do not exist in JSON.
+2. **Partial compiler diagnostic coverage.** The 9 active coded diagnostics are not the whole compiler surface. `julc-compiler/src/main/java` still contains many user-visible `CompilerException`, `CompilerDiagnostic`, `collectError(...)`, and `enrichedError(...)` paths across parsing, subset validation, type registration/resolution, PIR generation, stdlib method lowering, UPLC generation, and compiler resource loading.
+3. **CLI message/docs drift.** A user can see `[JULC0015] try/catch not supported` in CLI output and then find different wording in `/ai/diagnostics.json`.
+4. **Inline string literals.** Existing call sites use string-valued constants or raw strings. Typos are silent; refactoring is by search/replace; there is no type-level handle for the message template, severity, category, or fix.
+
+The previous narrow plan only migrated the currently coded subset. That would make the generated catalog safer but would not solve the larger product problem: AI agents and users still need stable explanations for every compiler failure. This ADR therefore combines code generation with a full compiler diagnostic coverage migration.
+
+---
+
+## Goals
+
+1. **One authoritative catalog.** Every compiler diagnostic code lives in `diagnostics.json`; generated Java constants derive from it.
+2. **Full compiler coverage.** Every user-visible compiler error/warning produced by `julc-compiler` has a stable `JULC####` code, template, severity, category, and fix guidance.
+3. **Compile-time safety.** Compiler call sites reference generated `DiagnosticInfo` constants, not raw `JULC####` string literals.
+4. **No CLI/docs drift.** The message emitted by the compiler comes from the same catalog template published to MCP/docs/AI consumers.
+5. **IDE-friendly checkout.** Generated `DiagnosticCodes.java` is checked in so a fresh checkout has no missing symbols.
+6. **JVM-independent docs build.** The docs pipeline continues to read JSON directly and does not need to run Gradle.
+7. **No blind spots after migration.** CI fails when a new compiler error path is added without an explicit catalog-backed diagnostic.
+
+---
+
+## Decision
+
+### Source of truth
+
+**JSON remains the source of truth at `julc-compiler/src/main/resources/diagnostics.json`.** No move; no format change.
+
+- YAML was considered and rejected. The public contract is already `julc.dev/ai/diagnostics.json`; AI/LLM consumers are JSON-fluent; Java and Node both already parse JSON without extra dependencies.
+- Java-first authoring was considered and rejected for this project. JuLC publishes a public JSON catalog from a Node-based docs site, so Java-first would couple docs deploys to Gradle.
+
+### Generated Java constants
+
+`DiagnosticCodes.java` is generated from JSON and checked into git at the existing FQN:
+
+`com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes`
+
+The generated file contains one `DiagnosticInfo` constant per catalog entry, sorted by constant name, plus `all()` and `find(String)` helpers. A `verifyDiagnosticCodes` Gradle task regenerates into a temporary location and fails if the checked-in source differs.
+
+Checking in the generated file is intentional. It keeps IntelliJ usable before any Gradle task has run. The cost is an extra generated diff whenever diagnostics change.
+
+### Catalog owns emitted templates
+
+The catalog gains a `template` field. For compiler-emitted diagnostics, this is the exact emitted message template. Call sites supply contextual parameters; `DiagnosticInfo.format(...)` renders the final text.
+
+Keep the existing `summary` field for docs/MCP compatibility:
+
+- `title`: short label
+- `summary`: human/AI explanation
+- `template`: exact compiler-emitted message
+- `fix`: canonical remediation
+- `constant`: Java constant name
+- `status`: coverage state
+
+`summary` is not removed or repurposed.
+
+### Coverage states
+
+Each catalog entry gets:
+
+```json
+"constant": "TRY_CATCH_UNSUPPORTED",
+"status": "emitted"
+```
+
+Allowed `status` values:
+
+| Status | Meaning |
+|---|---|
+| `emitted` | `julc-compiler` currently emits this code from at least one production path. |
+| `planned` | Catalog/docs entry exists, but no compiler path emits it yet. This is temporary during migration only. |
+| `lintOnly` | The issue is reported by CLI/MCP lint, not by compiler runtime diagnostics. |
+| `internal` | Compiler/environment/resource failure. Still coded, but not generally actionable user source guidance. |
+
+After this ADR is implemented, user-source compiler failures should be `emitted`, not `planned`. Any remaining `planned` entries need an explicit rationale in the catalog entry, such as `"notes": "Reserved for future lint-to-compiler migration"`.
+
+### Placeholder style
+
+Use indexed `{0}`, `{1}`, `{2}` placeholders rendered with `java.text.MessageFormat`.
+
+Authoring rule: apostrophes in templates must be doubled (`can''t`) because `MessageFormat` treats `'` as an escape character. CI parses every template and verifies placeholders.
+
+### Typed API
+
+Add a hand-written record:
+
+```java
+package com.bloxbean.cardano.julc.compiler.error;
+
+import java.text.MessageFormat;
+
+public record DiagnosticInfo(
+        String code,
+        String constant,
+        CompilerDiagnostic.Level level,
+        String category,
+        String template,
+        String fix) {
+
+    public String format(Object... args) {
+        return (args == null || args.length == 0)
+                ? template
+                : MessageFormat.format(template, args);
+    }
+}
+```
+
+Use the existing `CompilerDiagnostic.Level` for now. A separate top-level `Severity` enum is unnecessary churn for this refactor.
+
+Diagnostic emission helpers should cover every production path:
+
+```java
+public void errorWithCode(Node node, DiagnosticInfo info, Object... args);
+public void errorWithCode(Node node, DiagnosticInfo info, String suggestionOverride, Object... args);
+public void warningWithCode(Node node, DiagnosticInfo info, Object... args);
+public CompilerException validationError(DiagnosticInfo info, Node node, Object... args);
+public CompilerException validationError(DiagnosticInfo info, String suggestionOverride, Node node, Object... args);
+```
+
+The default suggestion is `info.fix()`. Callers may override it when the existing source-specific hint is more precise.
+
+---
+
+## Full Coverage Plan
+
+### Coverage inventory
+
+Audit every diagnostic/error creation point in `julc-compiler/src/main/java`, including:
+
+| Area | Current creation patterns |
+|---|---|
+| Compiler facade | `validationError(...)`, direct `new CompilerDiagnostic(...)`, direct `new CompilerException(String)` |
+| Subset validation | private `error(...)` / `warning(...)` helpers |
+| PIR generation | `collectError(...)`, `enrichedError(...)`, direct `CompilerException` |
+| Loop PIR helpers | `gen.enrichedError(...)` |
+| Type registration | `errorAt(...)`, `CompilerException`, duplicate/circular/newtype paths |
+| Type resolution/imports | `CompilerException` for duplicate, unknown, ambiguous, unsupported type paths |
+| Stdlib/type method registry | wrong-arity `CompilerException` paths |
+| UPLC generation | unsupported/unbound/mutual recursion paths |
+| Compiler resources | ledger source index/resource failures |
+
+The inventory output should be committed as a test fixture or markdown table, for example:
+
+`julc-compiler/src/test/resources/diagnostic-coverage.txt`
+
+Each row maps:
+
+```text
+source file | line/pattern | current message family | catalog constant | status | notes
+```
+
+This gives reviewers a concrete checklist and prevents "we think we covered it" from becoming the acceptance criterion.
+
+### Initial code mapping
+
+The 9 currently coded diagnostics become typed `status: "emitted"` entries:
+
+| Code | Constant |
+|---|---|
+| `JULC0008` | `ENTRYPOINT_WRONG_PARAMETER_COUNT` |
+| `JULC0009` | `ENTRYPOINT_MISSING` |
+| `JULC0010` | `VALIDATOR_ANNOTATION_MISSING` |
+| `JULC0013` | `PARAM_RAW_PLUTUS_DATA` |
+| `JULC0015` | `TRY_CATCH_UNSUPPORTED` |
+| `JULC0016` | `THROW_UNSUPPORTED` |
+| `JULC0017` | `NULL_UNSUPPORTED` |
+| `JULC0018` | `C_STYLE_FOR_UNSUPPORTED` |
+| `JULC0019` | `DO_WHILE_UNSUPPORTED` |
+
+Existing catalog entries that already match real compiler failures should also be migrated during this ADR, not deferred:
+
+| Existing code | Error family |
+|---|---|
+| `JULC0001` | method must have body |
+| `JULC0004` | break outside loop |
+| `JULC0005` | non-exhaustive switch |
+| `JULC0006` | method may not return on all paths |
+| `JULC0007` | switch requires sealed interface |
+| `JULC0011` | undefined variable |
+| `JULC0012` | cannot resolve/unknown/ambiguous type |
+| `JULC0014` | arrays unsupported |
+| `JULC0020` | floating-point unsupported |
+| `JULC0023` | more than 2 mutually recursive bindings |
+| `JULC0024` | unknown method |
+| `JULC0025` | stdlib method wrong arity |
+| `JULC0026` | `@NewType` wrong field count |
+| `JULC0027` | unsupported `@NewType` field type |
+| `JULC0028` | parse failure |
+| `JULC0029` | duplicate type |
+| `JULC0030` | circular type dependency |
+
+If an actual compiler error does not fit an existing code, add a new code after `JULC0030`. Do not overload a vague existing code to avoid growing the catalog.
+
+### Internal/environment diagnostics
+
+Some compiler failures are not source-code mistakes, for example missing bundled ledger source resources or inconsistent compiler internals. These should still get stable codes so support/debug output is searchable, but they should be categorized separately:
+
+- `INTERNAL`
+- `RESOURCE`
+- `CONFIG`
+
+Examples likely needing new codes:
+
+- ledger source index missing
+- ledger source listed but not bundled
+- failed to read bundled source
+- ambiguous on-chain library class
+- unsupported bare field accessor / unbound variable in UPLC generation
+- unsupported statement/expression families that are internal fallthroughs
+
+These codes can use fixes like "This is likely a JuLC compiler bug or packaging issue; report the diagnostic code and source snippet."
+
+### Do not hide grouped errors
+
+Some paths already collect multiple diagnostics and then throw `new CompilerException(diagnostics)`. Those wrapper throws do not need their own code. The individual diagnostics inside the list do.
+
+The consistency tests should distinguish:
+
+- allowed wrapper throws: `new CompilerException(diagnostics)`
+- not allowed after migration: `new CompilerException("...")` for user-visible compiler failures unless routed through a coded helper
+
+---
+
+## Implementation
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `julc-compiler/src/main/resources/diagnostics.json` | Add `constant`, `status`, and `template` fields. Mark all migrated compiler diagnostics as `status: "emitted"`. Add new codes beyond `JULC0030` for uncovered compiler/resource/internal failures. Keep `summary` for docs/MCP compatibility. |
+| `julc-compiler/build.gradle` | Add `generateDiagnosticCodes` and `verifyDiagnosticCodes` tasks using Groovy `JsonSlurper`. Wire `check.dependsOn verifyDiagnosticCodes`. |
+| `julc-compiler/src/main/java/.../error/DiagnosticCodes.java` | Generated and checked in. Contains one `DiagnosticInfo` per catalog entry, sorted by constant, plus `all()` and `find(String)`. |
+| `julc-compiler/src/main/java/.../error/DiagnosticInfo.java` | New hand-written record. |
+| `julc-compiler/src/main/java/.../error/DiagnosticCollector.java` | Add typed error/warning overloads. Existing string overloads may remain temporarily but are not used by migrated production code. |
+| `julc-compiler/src/main/java/.../JulcCompiler.java` | Migrate `validationError(...)`, parse errors, param errors, multi-validator validation errors, and other direct compiler-facade errors to typed diagnostics. |
+| `julc-compiler/src/main/java/.../validate/SubsetValidator.java` | Migrate all subset errors/warnings, not only `JULC0015`-`JULC0019`. |
+| `julc-compiler/src/main/java/.../pir/*.java` | Migrate `collectError(...)`, `enrichedError(...)`, loop helper errors, unknown method, wrong arity, unsupported statement/expression, switch, lambda, newtype constructor, and return-in-loop errors. |
+| `julc-compiler/src/main/java/.../resolve/*.java` | Migrate type registration, type resolution, import ambiguity, ledger resource, and library method registry errors. |
+| `julc-compiler/src/main/java/.../uplc/*.java` | Migrate UPLC generator errors. |
+| `julc-compiler/src/test/java/.../error/DiagnosticCatalogConsistencyTest.java` | Replace the one-way drift check with schema, generated-source, template, and full production coverage checks. |
+| `julc-compiler/src/test/resources/diagnostic-coverage.txt` | Add the audited map from compiler error families to catalog constants. |
+| `CONTRIBUTING.md` or `julc-compiler/README.md` | Document how to edit diagnostics and require running `generateDiagnosticCodes`. |
+
+### Files not modified
+
+- `docs/scripts/generate-catalog.mjs` remains JSON-based. It may pass through the new fields without logic changes.
+- `docs/.gitignore` remains unchanged.
+- `processResources` version filtering for `@julcVersion@` remains unchanged.
+- `ExplainDiagnosticTool`, `JulcResources`, `DiagnosticFormatter`, `ReplEngine`, and `DiagnosticDto` should not require API changes if `summary` is preserved and fields are additive.
+
+### Generated file shape
+
+```java
+// GENERATED FROM julc-compiler/src/main/resources/diagnostics.json
+// DO NOT EDIT - run `./gradlew :julc-compiler:generateDiagnosticCodes` and commit.
+package com.bloxbean.cardano.julc.compiler.error;
+
+public final class DiagnosticCodes {
+    private DiagnosticCodes() {}
+
+    public static final DiagnosticInfo ENTRYPOINT_WRONG_PARAMETER_COUNT = new DiagnosticInfo(
+            "JULC0008",
+            "ENTRYPOINT_WRONG_PARAMETER_COUNT",
+            CompilerDiagnostic.Level.ERROR,
+            "VALIDATOR",
+            "@Entrypoint method has wrong parameter count: expected {0}, found {1}",
+            "Adjust the entrypoint signature to match the validator annotation.");
+
+    public static java.util.List<DiagnosticInfo> all() { ... }
+    public static java.util.Optional<DiagnosticInfo> find(String code) { ... }
+}
+```
+
+### Migration sequence
+
+1. **Audit coverage first.** Generate the coverage inventory for every compiler error/diagnostic creation point.
+2. **Normalize schema.** Add `constant`, `status`, and `template` to existing catalog entries while preserving `summary`.
+3. **Add missing codes.** Add new catalog entries for any real compiler error family not covered by `JULC0001`-`JULC0030`.
+4. **Add `DiagnosticInfo`.**
+5. **Add Gradle codegen/verify tasks.**
+6. **Generate and commit `DiagnosticCodes.java`.**
+7. **Add typed emission helpers.**
+8. **Migrate current active coded paths.** Convert the 9 already-coded diagnostics to `DiagnosticInfo`.
+9. **Migrate high-value user-source paths.** Parse, validator shape, subset validation, type resolution, type registration, PIR generation, stdlib arity, switch/lambda/newtype/loop errors.
+10. **Migrate internal/resource paths.** Ledger resource loading, ambiguous library class, UPLC/internal fallthrough errors.
+11. **Tighten tests.** Only after migration, enable full production-source checks that prevent uncoded compiler errors from reappearing.
+12. **Update contributor docs.**
+
+This can be one PR if the migration is manageable. If it becomes too large, split it into two PRs with a hard rule: PR 1 may add codegen and `status`, but PR 2 must complete coverage before ADR-021 is considered accepted. Do not leave `planned` entries for compiler paths indefinitely.
+
+---
+
+## Consistency and Coverage Tests
+
+Extend `DiagnosticCatalogConsistencyTest` to assert:
+
+1. Every catalog entry has valid `code`, `constant`, `status`, `severity`, `category`, `title`, `summary`, `template`, and `fix`.
+2. `code` matches `JULC\\d{4}` and is unique.
+3. `constant` matches `[A-Z][A-Z0-9_]*` and is unique.
+4. `severity` maps to `CompilerDiagnostic.Level`.
+5. `category` exists in the top-level `categories` object.
+6. Every catalog entry appears in generated `DiagnosticCodes.java`.
+7. Every generated constant exactly matches its catalog entry.
+8. Every `status: "emitted"` entry is referenced from production compiler source.
+9. No raw `"JULC####"` string literals appear in `julc-compiler/src/main/java` except generated `DiagnosticCodes.java`.
+10. Every `template` parses with `MessageFormat`.
+11. Template placeholder indexes are contiguous from `{0}` to max placeholder, unless a template intentionally reuses an index and documents it.
+12. Production source does not add user-visible `new CompilerException("...")`, `new CompilerDiagnostic(...)`, `collectError("...")`, or `enrichedError("...")` paths unless they flow through a `DiagnosticInfo`.
+13. The coverage inventory file references only constants that exist in generated `DiagnosticCodes.java`.
+14. Every non-wrapper production error creation point appears in the coverage inventory.
+
+The source scan should ignore comments and generated files. It should also support static imports, or the coding convention should require qualified `DiagnosticCodes.CONSTANT` references. Prefer qualified references in migrated code because they are easier to scan reliably.
+
+---
+
+## Verification
+
+- `./gradlew :julc-compiler:generateDiagnosticCodes` regenerates `DiagnosticCodes.java`; `git diff` is empty afterward.
+- `./gradlew :julc-compiler:verifyDiagnosticCodes` passes; deliberate manual edits to `DiagnosticCodes.java` fail with a clear message.
+- `./gradlew :julc-compiler:test` passes, including full diagnostic coverage tests.
+- `./gradlew :julc-cli:test` passes, especially `ExplainDiagnosticToolTest`, `JulcResourcesTest`, `DiagnosticFormatterTest`, and MCP compile/lint tests.
+- `./gradlew test` passes.
+- `(cd docs && npm run build)` succeeds and `docs/dist/ai/diagnostics.json` contains the additive fields.
+- Manual smoke: compile representative failures for parser, subset, validator annotation, type resolution, stdlib wrong arity, switch exhaustiveness, newtype, and internal/resource cases. Each should include a stable `[JULC####]` code.
+- Negative checks:
+  - Add a raw `"JULC0099"` literal in compiler production source: test fails.
+  - Add `new CompilerException("new uncoded failure")` in production source: test fails.
+  - Add `status: "emitted"` without a production reference: test fails.
+  - Add a catalog template with a malformed apostrophe/placeholder: test fails.
+
+---
+
+## Current Implementation Status
+
+The first implementation slice is intentionally limited to diagnostic catalog code generation and migration of the 9 diagnostics that already emitted stable `JULC####` codes before this ADR. The full coverage model described above is the desired end state, not fully implemented yet.
+
+Not done yet:
+
+- Full diagnostic coverage is not implemented yet. Many compiler error paths still do not emit stable `JULC####` codes.
+- The strict CI rule for "no uncoded compiler errors" is intentionally not enabled yet. It should be enabled only after the full compiler diagnostic coverage migration is complete.
+- The working tree currently contains unrelated AI/docs/assets changes alongside the diagnostic work, so review/merge should use careful PR splitting rather than treating the entire local diff as one diagnostic PR.
+
+---
+
+## Consequences
+
+### Positive
+
+- The catalog becomes a real compiler contract, not just partial docs.
+- Every compiler failure shown to users/agents can be looked up by stable code.
+- CLI output and `/ai/diagnostics.json` share the exact emitted template.
+- Generated typed constants remove typo-prone raw code strings.
+- CI blocks future uncoded compiler errors.
+- Docs CI remains JVM-free.
+- IntelliJ works from a fresh checkout because generated Java is checked in.
+
+### Negative
+
+- This is a larger migration than the original codegen-only plan.
+- PR diffs may touch many compiler files plus JSON and generated Java.
+- Some internal error families need new catalog codes and wording decisions.
+- Contributors must run `generateDiagnosticCodes` after changing the catalog.
+- `MessageFormat` apostrophe escaping is an authoring footgun, mitigated by tests.
+
+### Neutral
+
+- Lint-only diagnostics remain outside the compiler catalog unless they correspond to a real compiler diagnostic. Lint rules may continue to carry `JULC-LINT-*` IDs and optionally point to a `JULC####` diagnostic.
+- `summary` remains a docs/MCP field even when `template` becomes the compiler-emitted field.
+
+---
+
+## Open Questions
+
+1. **Exact number of new codes.** The audit should decide whether broad families like "unsupported expression" get one parameterized code or several specific codes. Prefer specific codes for common user mistakes; use broader internal codes for impossible/fallthrough paths.
+2. **Strict qualified references.** The tests are simpler if production code references `DiagnosticCodes.X` instead of static imports. This ADR leans toward qualified references for diagnostics.
+3. **Coverage inventory format.** A markdown table is review-friendly; a machine-readable JSON/CSV fixture is easier to test. Prefer machine-readable if the test will consume it.
+4. **Internal/resource codes in public docs.** They should remain in `/ai/diagnostics.json`, but fixes should clearly say when the issue is likely a JuLC bug or packaging problem.
+
+---
+
+## Out of Scope
+
+- Localisation/i18n.
+- Splitting the catalog into multiple files. Revisit when the catalog becomes large enough to be painful.
+- Migrating CLI/MCP lint rule IDs into the compiler diagnostic namespace.
+- Changing the public shape of `CompilerDiagnostic` beyond attaching catalog-backed messages through existing fields.

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/output/DiagnosticFormatter.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/output/DiagnosticFormatter.java
@@ -19,7 +19,13 @@ public final class DiagnosticFormatter {
             case INFO -> AnsiColors.blue("info");
         };
         sb.append("./").append(d.fileName()).append(':').append(d.line()).append(':').append(d.column())
-                .append(": ").append(levelStr).append(": ").append(d.message());
+                .append(": ").append(levelStr).append(": ");
+        if (d.hasCode()) {
+            // Show the JULC#### code so users / AI agents can look up the
+            // canonical fix in /ai/diagnostics.json or the troubleshooting docs.
+            sb.append('[').append(d.code()).append("] ");
+        }
+        sb.append(d.message());
         if (d.hasSuggestion()) {
             sb.append("\n  ").append(AnsiColors.dim("suggestion: " + d.suggestion()));
         }

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/output/DiagnosticFormatterTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/output/DiagnosticFormatterTest.java
@@ -31,6 +31,37 @@ class DiagnosticFormatterTest {
     }
 
     @Test
+    void formatShowsCodeWhenPresent() {
+        // When a diagnostic carries a stable JULC#### code, the formatter
+        // must surface it inline so users / AI agents can look up the
+        // canonical fix in /ai/diagnostics.json.
+        var diag = new CompilerDiagnostic(
+                CompilerDiagnostic.Level.ERROR,
+                "try/catch is not supported on-chain",
+                "T.java", 5, 9, "Use if/else instead", "JULC0015");
+        String formatted = DiagnosticFormatter.format(diag);
+        assertTrue(formatted.contains("[JULC0015]"),
+                "formatter must surface the diagnostic code");
+        assertTrue(formatted.contains("try/catch is not supported"),
+                "formatter must still include the message");
+    }
+
+    @Test
+    void formatOmitsCodeBracketsWhenAbsent() {
+        // Backwards compat: legacy code-less diagnostics must not render
+        // a stray `[null]` in the output.
+        var diag = new CompilerDiagnostic(
+                CompilerDiagnostic.Level.ERROR,
+                "legacy error",
+                "T.java", 1, 1);
+        String formatted = DiagnosticFormatter.format(diag);
+        assertFalse(formatted.contains("[null]"),
+                "code-less diagnostics must not render '[null]'");
+        assertFalse(formatted.contains("[]"),
+                "code-less diagnostics must not render empty brackets");
+    }
+
+    @Test
     void formatAllShowsSummary() {
         var diags = List.of(
                 new CompilerDiagnostic(CompilerDiagnostic.Level.ERROR, "e1", "a.java", 1, 1),

--- a/julc-compiler/build.gradle
+++ b/julc-compiler/build.gradle
@@ -23,6 +23,150 @@ dependencies {
     testRuntimeOnly project(':julc-vm-scalus')
 }
 
+def diagnosticCatalogFile = layout.projectDirectory.file('src/main/resources/diagnostics.json')
+def diagnosticCodesFile = layout.projectDirectory.file(
+        'src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java')
+
+def renderDiagnosticCodes = { File catalogFile, File outputFile ->
+    def root = new groovy.json.JsonSlurper().parse(catalogFile)
+    def entries = root.diagnostics ?: []
+    if (entries.isEmpty()) {
+        throw new GradleException("${catalogFile} contains no diagnostics")
+    }
+
+    def required = ['code', 'constant', 'severity', 'category', 'template', 'fix']
+    def codes = new LinkedHashSet<String>()
+    def constants = new LinkedHashSet<String>()
+    entries.each { entry ->
+        required.each { field ->
+            if (!entry.containsKey(field) || entry[field] == null || entry[field].toString().isBlank()) {
+                throw new GradleException("Diagnostic entry ${entry.code ?: '<unknown>'} is missing '${field}'")
+            }
+        }
+        if (!(entry.code ==~ /JULC\d{4}/)) {
+            throw new GradleException("Invalid diagnostic code '${entry.code}'")
+        }
+        if (!(entry.constant ==~ /[A-Z][A-Z0-9_]*/)) {
+            throw new GradleException("Invalid diagnostic constant '${entry.constant}'")
+        }
+        if (!codes.add(entry.code.toString())) {
+            throw new GradleException("Duplicate diagnostic code '${entry.code}'")
+        }
+        if (!constants.add(entry.constant.toString())) {
+            throw new GradleException("Duplicate diagnostic constant '${entry.constant}'")
+        }
+    }
+
+    def javaString = { Object raw ->
+        def value = raw == null ? '' : raw.toString()
+        def sb = new StringBuilder('"')
+        value.each { ch ->
+            if (ch == '\\') {
+                sb.append('\\\\')
+            } else if (ch == '"') {
+                sb.append('\\"')
+            } else if (ch == '\n') {
+                sb.append('\\n')
+            } else if (ch == '\r') {
+                sb.append('\\r')
+            } else if (ch == '\t') {
+                sb.append('\\t')
+            } else {
+                int c = ch.charAt(0)
+                if (c < 0x20 || c > 0x7e) {
+                    sb.append(String.format('\\u%04x', c))
+                } else {
+                    sb.append(ch)
+                }
+            }
+        }
+        sb.append('"')
+        sb.toString()
+    }
+
+    def sorted = entries.toSorted { a, b -> a.constant.toString() <=> b.constant.toString() }
+    def out = new StringBuilder()
+    out.append('// GENERATED FROM julc-compiler/src/main/resources/diagnostics.json\n')
+    out.append('// DO NOT EDIT - run `./gradlew :julc-compiler:generateDiagnosticCodes` and commit.\n')
+    out.append('package com.bloxbean.cardano.julc.compiler.error;\n\n')
+    out.append('public final class DiagnosticCodes {\n')
+    out.append('    private DiagnosticCodes() {}\n\n')
+
+    sorted.eachWithIndex { entry, idx ->
+        def level = entry.severity.toString().toUpperCase(java.util.Locale.ROOT)
+        out.append("    public static final DiagnosticInfo ${entry.constant} = new DiagnosticInfo(\n")
+        out.append("            ${javaString(entry.code)},\n")
+        out.append("            ${javaString(entry.constant)},\n")
+        out.append("            CompilerDiagnostic.Level.${level},\n")
+        out.append("            ${javaString(entry.category)},\n")
+        out.append("            ${javaString(entry.template)},\n")
+        out.append("            ${javaString(entry.fix)});\n")
+        if (idx < sorted.size() - 1) {
+            out.append('\n')
+        }
+    }
+
+    out.append('\n\n')
+    out.append('    private static final java.util.List<DiagnosticInfo> ALL = java.util.List.of(\n')
+    sorted.eachWithIndex { entry, idx ->
+        out.append("            ${entry.constant}")
+        out.append(idx < sorted.size() - 1 ? ',\n' : '\n')
+    }
+    out.append('    );\n\n')
+    out.append('    private static final java.util.Map<String, DiagnosticInfo> BY_CODE = ALL.stream()\n')
+    out.append('            .collect(java.util.stream.Collectors.toUnmodifiableMap(\n')
+    out.append('                    DiagnosticInfo::code,\n')
+    out.append('                    info -> info));\n\n')
+    out.append('    public static java.util.List<DiagnosticInfo> all() {\n')
+    out.append('        return ALL;\n')
+    out.append('    }\n\n')
+    out.append('    public static java.util.Optional<DiagnosticInfo> find(String code) {\n')
+    out.append('        return java.util.Optional.ofNullable(BY_CODE.get(code));\n')
+    out.append('    }\n')
+    out.append('}\n')
+
+    outputFile.parentFile.mkdirs()
+    outputFile.text = out.toString()
+}
+
+tasks.register('generateDiagnosticCodes') {
+    description = 'Generate DiagnosticCodes.java from diagnostics.json.'
+    group = 'build'
+    inputs.file(diagnosticCatalogFile)
+    outputs.file(diagnosticCodesFile)
+    doLast {
+        renderDiagnosticCodes(diagnosticCatalogFile.asFile, diagnosticCodesFile.asFile)
+    }
+}
+
+tasks.register('verifyDiagnosticCodes') {
+    description = 'Verify checked-in DiagnosticCodes.java matches diagnostics.json.'
+    group = 'verification'
+    inputs.file(diagnosticCatalogFile)
+    inputs.file(diagnosticCodesFile)
+    doLast {
+        def expected = new File(temporaryDir, 'DiagnosticCodes.java')
+        renderDiagnosticCodes(diagnosticCatalogFile.asFile, expected)
+        def actual = diagnosticCodesFile.asFile
+        if (!actual.exists() || expected.text != actual.text) {
+            throw new GradleException(
+                    'DiagnosticCodes.java is out of date. Run ./gradlew :julc-compiler:generateDiagnosticCodes and commit the result.')
+        }
+    }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('verifyDiagnosticCodes')
+}
+
+tasks.named('processResources') {
+    filteringCharset = 'UTF-8'
+    inputs.property('julcVersion', project.version)
+    filesMatching('diagnostics.json') {
+        filter { line -> line.replace('@julcVersion@', project.version.toString()) }
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerException.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerException.java
@@ -16,6 +16,11 @@ public class CompilerException extends RuntimeException {
         this.diagnostics = List.copyOf(diagnostics);
     }
 
+    public CompilerException(String message, CompilerDiagnostic diagnostic) {
+        super(message);
+        this.diagnostics = List.of(diagnostic);
+    }
+
     public CompilerException(String message) {
         super(message);
         this.diagnostics = List.of();

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.compiler;
 
 import com.bloxbean.cardano.julc.compiler.codegen.ValidatorWrapper;
 import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
+import com.bloxbean.cardano.julc.compiler.error.DiagnosticInfo;
 import com.bloxbean.cardano.julc.compiler.pir.*;
 import com.bloxbean.cardano.julc.compiler.resolve.ImportResolver;
 import com.bloxbean.cardano.julc.compiler.resolve.LedgerSourceLoader;
@@ -20,6 +21,7 @@ import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
@@ -31,6 +33,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.ENTRYPOINT_MISSING;
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.ENTRYPOINT_WRONG_PARAMETER_COUNT;
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.PARAM_RAW_PLUTUS_DATA;
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.VALIDATOR_ANNOTATION_MISSING;
 
 /**
  * Main compiler facade. Orchestrates the pipeline:
@@ -79,10 +86,20 @@ public class JulcCompiler {
     /** Typed Data subtypes that must not be used with @Param. */
     private static final Set<String> BANNED_PARAM_TYPES = Set.of(
             "PlutusData.BytesData", "BytesData",
+            "com.bloxbean.cardano.julc.core.PlutusData.BytesData",
             "PlutusData.MapData", "MapData",
+            "com.bloxbean.cardano.julc.core.PlutusData.MapData",
             "PlutusData.ListData", "ListData",
-            "PlutusData.IntData", "IntData"
+            "com.bloxbean.cardano.julc.core.PlutusData.ListData",
+            "PlutusData.IntData", "IntData",
+            "com.bloxbean.cardano.julc.core.PlutusData.IntData"
     );
+
+    private static final String SPENDING_ENTRYPOINT_PARAMS_SUGGESTION =
+            "Use (Redeemer, ScriptContext) for no-datum spending validators, or " +
+                    "(Datum, Redeemer, ScriptContext) when the script receives an inline datum.";
+    private static final String NON_SPENDING_ENTRYPOINT_PARAMS_SUGGESTION =
+            "Use exactly (Redeemer, ScriptContext) for non-spending validator entrypoints.";
 
     private final StdlibLookup stdlibLookup;
     private final CompilerOptions options;
@@ -962,7 +979,12 @@ public class JulcCompiler {
                 }
             }
         }
-        throw new CompilerException("No validator annotation found (e.g. @SpendingValidator, @MintingValidator)");
+        throw validationError(VALIDATOR_ANNOTATION_MISSING,
+                "Add exactly one validator annotation at the class level, such as " +
+                        "@SpendingValidator, @MintingValidator, @WithdrawValidator, " +
+                        "@CertifyingValidator, @VotingValidator, @ProposingValidator, or @MultiValidator.",
+                null,
+                " (e.g. @SpendingValidator, @MintingValidator)");
     }
 
     private ScriptPurpose getScriptPurpose(ClassOrInterfaceDeclaration cls) {
@@ -1002,7 +1024,10 @@ public class JulcCompiler {
         if (cls.getAnnotationByName("MultiValidator").isPresent()) {
             return ScriptPurpose.MULTI;
         }
-        throw new CompilerException("No validator annotation found on " + cls.getNameAsString());
+        throw validationError(VALIDATOR_ANNOTATION_MISSING,
+                "Add the appropriate validator annotation at the class level.",
+                cls,
+                " on " + cls.getNameAsString());
     }
 
     private MethodDeclaration findEntrypoint(ClassOrInterfaceDeclaration cls) {
@@ -1011,7 +1036,10 @@ public class JulcCompiler {
                 return method;
             }
         }
-        throw new CompilerException("No @Entrypoint method found in " + cls.getNameAsString());
+        throw validationError(ENTRYPOINT_MISSING,
+                "Annotate exactly one public static validator method with @Entrypoint.",
+                cls,
+                cls.getNameAsString());
     }
 
     /** Map Purpose enum name to ScriptInfo tag. */
@@ -1078,7 +1106,10 @@ public class JulcCompiler {
         }
 
         if (entrypoints.isEmpty()) {
-            throw new CompilerException("No @Entrypoint method found in @MultiValidator " + cls.getNameAsString());
+            throw validationError(ENTRYPOINT_MISSING,
+                    "Add a public static @Entrypoint method. For auto-dispatch, annotate each entrypoint with purpose=Purpose.<KIND>.",
+                    cls,
+                    "@MultiValidator " + cls.getNameAsString());
         }
 
         // Check for mixing DEFAULT and explicit purposes
@@ -1101,9 +1132,16 @@ public class JulcCompiler {
             }
             int paramCount = entrypoints.get(0).method.getParameters().size();
             if (paramCount != 2) {
-                throw new CompilerException("@MultiValidator manual dispatch entrypoint must have 2 parameters "
-                        + "(redeemer, scriptContext), found " + paramCount
-                        + " in " + cls.getNameAsString() + "." + entrypoints.get(0).method.getNameAsString() + "()");
+                throw validationError(ENTRYPOINT_WRONG_PARAMETER_COUNT,
+                        "Use exactly (Redeemer, ScriptContext) for manual @MultiValidator dispatch.",
+                        entrypoints.get(0).method,
+                        "@MultiValidator manual dispatch",
+                        "2",
+                        " (redeemer, scriptContext)",
+                        paramCount,
+                        cls.getNameAsString(),
+                        entrypoints.get(0).method.getNameAsString(),
+                        "");
             }
         } else {
             // Mode 1: auto-dispatch — check for duplicates and param counts
@@ -1116,14 +1154,29 @@ public class JulcCompiler {
                 int paramCount = ep.method.getParameters().size();
                 if (ep.purposeName.equals("SPEND")) {
                     if (paramCount < 2 || paramCount > 3) {
-                        throw new CompilerException("@Entrypoint(purpose=Purpose.SPEND) must have 2 or 3 parameters, "
-                                + "found " + paramCount + " in " + cls.getNameAsString() + "." + ep.method.getNameAsString() + "()");
+                        throw validationError(ENTRYPOINT_WRONG_PARAMETER_COUNT,
+                                SPENDING_ENTRYPOINT_PARAMS_SUGGESTION,
+                                ep.method,
+                                "@Entrypoint(purpose=Purpose.SPEND)",
+                                "2 or 3",
+                                "",
+                                paramCount,
+                                cls.getNameAsString(),
+                                ep.method.getNameAsString(),
+                                "");
                     }
                 } else {
                     if (paramCount != 2) {
-                        throw new CompilerException("@Entrypoint(purpose=Purpose." + ep.purposeName + ") must have 2 parameters "
-                                + "(redeemer, scriptContext), found " + paramCount
-                                + " in " + cls.getNameAsString() + "." + ep.method.getNameAsString() + "()");
+                        throw validationError(ENTRYPOINT_WRONG_PARAMETER_COUNT,
+                                NON_SPENDING_ENTRYPOINT_PARAMS_SUGGESTION,
+                                ep.method,
+                                "@Entrypoint(purpose=Purpose." + ep.purposeName + ")",
+                                "2",
+                                " (redeemer, scriptContext)",
+                                paramCount,
+                                cls.getNameAsString(),
+                                ep.method.getNameAsString(),
+                                "");
                     }
                 }
             }
@@ -1138,9 +1191,16 @@ public class JulcCompiler {
         if (purpose == ScriptPurpose.SPENDING) {
             // Spending validators: 2 params (redeemer, ctx) or 3 params (datum, redeemer, ctx)
             if (paramCount < 2 || paramCount > 3) {
-                throw new CompilerException("@SpendingValidator entrypoint must have 2 or 3 parameters "
-                        + "(datum, redeemer, scriptContext), found " + paramCount
-                        + " in " + cls.getNameAsString() + "." + entrypoint.getNameAsString() + "()");
+                throw validationError(ENTRYPOINT_WRONG_PARAMETER_COUNT,
+                        SPENDING_ENTRYPOINT_PARAMS_SUGGESTION,
+                        entrypoint,
+                        "@SpendingValidator",
+                        "2 or 3",
+                        " (datum, redeemer, scriptContext)",
+                        paramCount,
+                        cls.getNameAsString(),
+                        entrypoint.getNameAsString(),
+                        "");
             }
         } else {
             // Non-spending validators: 2 params (redeemer, scriptContext)
@@ -1154,12 +1214,39 @@ public class JulcCompiler {
                     default -> "@" + purpose.name();
                 };
                 String hint = paramCount == 3 ? " Did you mean @SpendingValidator?" : "";
-                throw new CompilerException(annotation + " entrypoint must have 2 parameters "
-                        + "(redeemer, scriptContext), found " + paramCount
-                        + " in " + cls.getNameAsString() + "." + entrypoint.getNameAsString() + "()."
-                        + hint);
+                throw validationError(ENTRYPOINT_WRONG_PARAMETER_COUNT,
+                        NON_SPENDING_ENTRYPOINT_PARAMS_SUGGESTION,
+                        entrypoint,
+                        annotation,
+                        "2",
+                        " (redeemer, scriptContext)",
+                        paramCount,
+                        cls.getNameAsString(),
+                        entrypoint.getNameAsString(),
+                        "." + hint);
             }
         }
+    }
+
+    private static CompilerException validationError(DiagnosticInfo info, String suggestion,
+                                                     Node node, Object... args) {
+        String message = info.format(args);
+        int line = 0;
+        int column = 0;
+        if (node != null && node.getBegin().isPresent()) {
+            var pos = node.getBegin().get();
+            line = pos.line;
+            column = pos.column;
+        }
+        var diagnostic = new CompilerDiagnostic(
+                CompilerDiagnostic.Level.ERROR,
+                message,
+                "<source>",
+                line,
+                column,
+                suggestion,
+                info.code());
+        return new CompilerException(message, diagnostic);
     }
 
     private List<ParamField> findParamFields(ClassOrInterfaceDeclaration cls, TypeResolver typeResolver,
@@ -1177,11 +1264,10 @@ public class JulcCompiler {
                     }
                     diagnostics.add(new CompilerDiagnostic(
                             CompilerDiagnostic.Level.ERROR,
-                            "@Param type '" + javaType + "' is not allowed. "
-                                    + "@Param values are always raw Data at runtime; using a typed Data subtype "
-                                    + "causes the compiler to misinterpret the runtime representation.",
+                            PARAM_RAW_PLUTUS_DATA.format(javaType),
                             "<source>", line, col,
-                            "Use @Param PlutusData instead of @Param " + javaType));
+                            PARAM_RAW_PLUTUS_DATA.fix(),
+                            PARAM_RAW_PLUTUS_DATA.code()));
                     continue;
                 }
                 for (var variable : field.getVariables()) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/CompilerDiagnostic.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/CompilerDiagnostic.java
@@ -2,23 +2,46 @@ package com.bloxbean.cardano.julc.compiler.error;
 
 /**
  * A compiler diagnostic message with source location and optional suggestion.
+ *
+ * <p>The {@code code} field is a stable identifier (e.g. {@code "JULC0001"}) that
+ * downstream tools (the MCP server's {@code julc_explain_diagnostic} tool, the
+ * AI starter pack's error-table, the {@code julc lint} command) use to look up
+ * the canonical root-cause + fix for the error. The catalog of known codes is
+ * authored at {@code julc-compiler/src/main/resources/diagnostics.json}.
+ *
+ * <p>The field is nullable for backwards compatibility — existing call sites
+ * that have not yet been migrated to use a code continue to work, they simply
+ * carry no code in their diagnostic. New error sites should always supply a
+ * code.
  */
-public record CompilerDiagnostic(Level level, String message, String fileName, int line, int column, String suggestion) {
+public record CompilerDiagnostic(Level level, String message, String fileName,
+                                 int line, int column, String suggestion, String code) {
 
     public enum Level { ERROR, WARNING, INFO }
 
     public CompilerDiagnostic(Level level, String message, String fileName, int line, int column) {
-        this(level, message, fileName, line, column, null);
+        this(level, message, fileName, line, column, null, null);
+    }
+
+    public CompilerDiagnostic(Level level, String message, String fileName,
+                              int line, int column, String suggestion) {
+        this(level, message, fileName, line, column, suggestion, null);
     }
 
     public boolean isError() { return level == Level.ERROR; }
 
     public boolean hasSuggestion() { return suggestion != null && !suggestion.isEmpty(); }
 
+    public boolean hasCode() { return code != null && !code.isEmpty(); }
+
     @Override
     public String toString() {
         var sb = new StringBuilder();
-        sb.append(level).append(" at .(").append(fileName).append(":").append(line).append(")");
+        sb.append(level);
+        if (hasCode()) {
+            sb.append("[").append(code).append("]");
+        }
+        sb.append(" at .(").append(fileName).append(":").append(line).append(")");
         sb.append(":").append(column);
         sb.append(" - ").append(message);
         if (hasSuggestion()) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
@@ -1,0 +1,294 @@
+// GENERATED FROM julc-compiler/src/main/resources/diagnostics.json
+// DO NOT EDIT - run `./gradlew :julc-compiler:generateDiagnosticCodes` and commit.
+package com.bloxbean.cardano.julc.compiler.error;
+
+public final class DiagnosticCodes {
+    private DiagnosticCodes() {}
+
+    public static final DiagnosticInfo ARRAY_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0014",
+            "ARRAY_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "arrays are not supported on-chain",
+            "Use `JulcList<T>` or `List<T>` instead of `T[]`.");
+
+    public static final DiagnosticInfo BREAK_OUTSIDE_LOOP = new DiagnosticInfo(
+            "JULC0004",
+            "BREAK_OUTSIDE_LOOP",
+            CompilerDiagnostic.Level.ERROR,
+            "CONTROL_FLOW",
+            "break statement outside of a loop",
+            "Place the `break` inside a loop, or refactor to use early `return` from a helper method.");
+
+    public static final DiagnosticInfo CIRCULAR_TYPE_DEPENDENCY = new DiagnosticInfo(
+            "JULC0030",
+            "CIRCULAR_TYPE_DEPENDENCY",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "Circular type dependency detected among: {0}",
+            "Break the cycle by introducing a parameterized record or refactoring the involved types.");
+
+    public static final DiagnosticInfo C_STYLE_FOR_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0018",
+            "C_STYLE_FOR_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "C-style for loops are not supported on-chain",
+            "Use for-each over a list or while loops instead");
+
+    public static final DiagnosticInfo DO_WHILE_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0019",
+            "DO_WHILE_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "do-while loops are not supported on-chain",
+            "Use while loops or for-each instead");
+
+    public static final DiagnosticInfo DUPLICATE_TYPE_DECLARATION = new DiagnosticInfo(
+            "JULC0029",
+            "DUPLICATE_TYPE_DECLARATION",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "Duplicate type declaration: {0}",
+            "Rename one of the types, or ensure they are not both on the compilation classpath.");
+
+    public static final DiagnosticInfo ENTRYPOINT_MISSING = new DiagnosticInfo(
+            "JULC0009",
+            "ENTRYPOINT_MISSING",
+            CompilerDiagnostic.Level.ERROR,
+            "VALIDATOR",
+            "No @Entrypoint method found in {0}",
+            "Annotate exactly one `public static` method with `@Entrypoint`. The method must return `boolean` (or `void` for newer signature shapes).");
+
+    public static final DiagnosticInfo ENTRYPOINT_WRONG_PARAMETER_COUNT = new DiagnosticInfo(
+            "JULC0008",
+            "ENTRYPOINT_WRONG_PARAMETER_COUNT",
+            CompilerDiagnostic.Level.ERROR,
+            "VALIDATOR",
+            "{0} entrypoint must have {1} parameters{2}, found {3} in {4}.{5}(){6}",
+            "Adjust the entrypoint signature to match the validator annotation. Spending: `(Datum, Redeemer, ScriptContext)`. Others: `(Redeemer, ScriptContext)`.");
+
+    public static final DiagnosticInfo FLOATING_POINT_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0020",
+            "FLOATING_POINT_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "floating point types (float/double) are not supported on-chain",
+            "Use `BigInteger` for integer math. For fractional values, scale up (e.g. parts-per-million) and do integer math, or use `Rational` from the ledger types when modelling protocol params.");
+
+    public static final DiagnosticInfo LAMBDA_STORED_IN_VARIABLE_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0022",
+            "LAMBDA_STORED_IN_VARIABLE_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "Lambda cannot be stored in a variable",
+            "Pass the lambda directly: `list.map(x -> ...)`, `list.filter(p -> ...)`. If you need to share lambda logic, extract it as a regular static method (not as a lambda).");
+
+    public static final DiagnosticInfo METHOD_BODY_MISSING = new DiagnosticInfo(
+            "JULC0001",
+            "METHOD_BODY_MISSING",
+            CompilerDiagnostic.Level.ERROR,
+            "VALIDATOR",
+            "Method must have a body: {0}",
+            "Provide a body for every method in your validator class.");
+
+    public static final DiagnosticInfo METHOD_MISSING_RETURN = new DiagnosticInfo(
+            "JULC0006",
+            "METHOD_MISSING_RETURN",
+            CompilerDiagnostic.Level.ERROR,
+            "CONTROL_FLOW",
+            "Method {0} may not return a value on all execution paths",
+            "Ensure every if/else branch returns, or add a fallthrough return at the end of the method.");
+
+    public static final DiagnosticInfo MUTUAL_RECURSION_TOO_LARGE = new DiagnosticInfo(
+            "JULC0023",
+            "MUTUAL_RECURSION_TOO_LARGE",
+            CompilerDiagnostic.Level.ERROR,
+            "PIR",
+            "Mutually recursive bindings with more than 2 participants not yet supported: {0}",
+            "Refactor: combine the helpers into a single function with an accumulator, or break the recursion via an explicit dispatch on a sealed interface.");
+
+    public static final DiagnosticInfo NEWTYPE_UNSUPPORTED_FIELD_TYPE = new DiagnosticInfo(
+            "JULC0027",
+            "NEWTYPE_UNSUPPORTED_FIELD_TYPE",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "Unsupported @NewType field type: {0}",
+            "Change the underlying field to a supported primitive, or remove @NewType.");
+
+    public static final DiagnosticInfo NEWTYPE_WRONG_FIELD_COUNT = new DiagnosticInfo(
+            "JULC0026",
+            "NEWTYPE_WRONG_FIELD_COUNT",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "@NewType record {0} must have exactly one field",
+            "Reduce to one field, or remove @NewType and use a plain record (which compiles to ConstrData).");
+
+    public static final DiagnosticInfo NULL_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0017",
+            "NULL_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "null is not supported on-chain",
+            "Use Optional<T> (Optional.of(x) / Optional.empty()) to represent absence of a value");
+
+    public static final DiagnosticInfo PARAM_RAW_PLUTUS_DATA = new DiagnosticInfo(
+            "JULC0013",
+            "PARAM_RAW_PLUTUS_DATA",
+            CompilerDiagnostic.Level.ERROR,
+            "LIBRARY",
+            "@Param type ''{0}'' is not allowed. @Param values are always raw Data at runtime; using a typed Data subtype causes the compiler to misinterpret the runtime representation.",
+            "Use byte[], BigInteger, typed records, redeemers, or @Param PlutusData only for opaque data.");
+
+    public static final DiagnosticInfo RETURN_INSIDE_WHILE = new DiagnosticInfo(
+            "JULC0003",
+            "RETURN_INSIDE_WHILE",
+            CompilerDiagnostic.Level.ERROR,
+            "CONTROL_FLOW",
+            "Cannot return inside while loop",
+            "Use a boolean accumulator and return after the loop. `break` works inside `for-each` if you only need early termination.");
+
+    public static final DiagnosticInfo SOURCE_PARSE_FAILED = new DiagnosticInfo(
+            "JULC0028",
+            "SOURCE_PARSE_FAILED",
+            CompilerDiagnostic.Level.ERROR,
+            "PIR",
+            "Failed to parse {0} source: {1}",
+            "Check the file with a Java IDE or `javac` \u2014 the JuLC compiler relies on JavaParser to produce a clean AST.");
+
+    public static final DiagnosticInfo STDLIB_METHOD_WRONG_ARITY = new DiagnosticInfo(
+            "JULC0025",
+            "STDLIB_METHOD_WRONG_ARITY",
+            CompilerDiagnostic.Level.ERROR,
+            "STDLIB",
+            "Stdlib method called with wrong number of arguments: {0}",
+            "See the message itself \u2014 it includes a `Usage:` hint with the correct signature.");
+
+    public static final DiagnosticInfo SWITCH_FIELD_SHADOWS_PARAMETER = new DiagnosticInfo(
+            "JULC0021",
+            "SWITCH_FIELD_SHADOWS_PARAMETER",
+            CompilerDiagnostic.Level.WARNING,
+            "CONTROL_FLOW",
+            "Switch case binding name shadows a method parameter",
+            "Always use distinct names. Example: rename `time` parameter to `point` when switching on `IntervalBoundType.Finite(time)`.");
+
+    public static final DiagnosticInfo SWITCH_NOT_EXHAUSTIVE = new DiagnosticInfo(
+            "JULC0005",
+            "SWITCH_NOT_EXHAUSTIVE",
+            CompilerDiagnostic.Level.ERROR,
+            "CONTROL_FLOW",
+            "Switch on sealed interface {0} is not exhaustive. Missing cases: {1}",
+            "Add the missing case branches or include a `default ->` branch to handle all remaining variants.");
+
+    public static final DiagnosticInfo SWITCH_REQUIRES_SEALED_INTERFACE = new DiagnosticInfo(
+            "JULC0007",
+            "SWITCH_REQUIRES_SEALED_INTERFACE",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "switch expression requires a sealed interface type, got: {0}",
+            "Use field access (`pair.first()`, `pair.second()`) for records. Reserve `switch` for sealed interfaces with permitted record variants.");
+
+    public static final DiagnosticInfo THROW_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0016",
+            "THROW_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "throw is not supported on-chain",
+            "Return false from the validator to reject a transaction");
+
+    public static final DiagnosticInfo TRY_CATCH_UNSUPPORTED = new DiagnosticInfo(
+            "JULC0015",
+            "TRY_CATCH_UNSUPPORTED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "try/catch is not supported on-chain",
+            "Use if/else checks instead of exception handling");
+
+    public static final DiagnosticInfo TYPE_RESOLUTION_FAILED = new DiagnosticInfo(
+            "JULC0012",
+            "TYPE_RESOLUTION_FAILED",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "Cannot resolve type: {0}",
+            "Ensure the type is imported and is one of: a record, sealed interface, ledger type, JulcList/JulcMap/Optional/Tuple, or primitive (BigInteger, byte[], boolean, String).");
+
+    public static final DiagnosticInfo UNDEFINED_VARIABLE = new DiagnosticInfo(
+            "JULC0011",
+            "UNDEFINED_VARIABLE",
+            CompilerDiagnostic.Level.ERROR,
+            "TYPE",
+            "Undefined variable: {0}",
+            "Check spelling and declaration order. If a switch case binds a field with the same name as your method parameter, rename one of them \u2014 the field shadows the parameter inside the case body (see JULC0021).");
+
+    public static final DiagnosticInfo UNKNOWN_METHOD_ON_TYPE = new DiagnosticInfo(
+            "JULC0024",
+            "UNKNOWN_METHOD_ON_TYPE",
+            CompilerDiagnostic.Level.ERROR,
+            "STDLIB",
+            "Unknown method: {0}",
+            "Check the stdlib catalog at https://julc.dev/ai/catalog.json or the stdlib reference at https://julc.dev/stdlib/stdlib-guide/. Common: `JulcList<T>` has `head/tail/get/size/isEmpty/contains/prepend/reverse/concat/take/drop/map/filter/any/all/find`.");
+
+    public static final DiagnosticInfo VALIDATOR_ANNOTATION_MISSING = new DiagnosticInfo(
+            "JULC0010",
+            "VALIDATOR_ANNOTATION_MISSING",
+            CompilerDiagnostic.Level.ERROR,
+            "VALIDATOR",
+            "No validator annotation found{0}",
+            "Add the appropriate validator annotation at the class level.");
+
+    public static final DiagnosticInfo VARIABLE_UNINITIALIZED = new DiagnosticInfo(
+            "JULC0002",
+            "VARIABLE_UNINITIALIZED",
+            CompilerDiagnostic.Level.ERROR,
+            "SYNTAX",
+            "Variable must be initialized: {0}",
+            "Initialize at declaration, e.g. `var x = BigInteger.ZERO;`. Re-bind via a new `var` if you need a different value later (UPLC is single-assignment).");
+
+
+    private static final java.util.List<DiagnosticInfo> ALL = java.util.List.of(
+            ARRAY_UNSUPPORTED,
+            BREAK_OUTSIDE_LOOP,
+            CIRCULAR_TYPE_DEPENDENCY,
+            C_STYLE_FOR_UNSUPPORTED,
+            DO_WHILE_UNSUPPORTED,
+            DUPLICATE_TYPE_DECLARATION,
+            ENTRYPOINT_MISSING,
+            ENTRYPOINT_WRONG_PARAMETER_COUNT,
+            FLOATING_POINT_UNSUPPORTED,
+            LAMBDA_STORED_IN_VARIABLE_UNSUPPORTED,
+            METHOD_BODY_MISSING,
+            METHOD_MISSING_RETURN,
+            MUTUAL_RECURSION_TOO_LARGE,
+            NEWTYPE_UNSUPPORTED_FIELD_TYPE,
+            NEWTYPE_WRONG_FIELD_COUNT,
+            NULL_UNSUPPORTED,
+            PARAM_RAW_PLUTUS_DATA,
+            RETURN_INSIDE_WHILE,
+            SOURCE_PARSE_FAILED,
+            STDLIB_METHOD_WRONG_ARITY,
+            SWITCH_FIELD_SHADOWS_PARAMETER,
+            SWITCH_NOT_EXHAUSTIVE,
+            SWITCH_REQUIRES_SEALED_INTERFACE,
+            THROW_UNSUPPORTED,
+            TRY_CATCH_UNSUPPORTED,
+            TYPE_RESOLUTION_FAILED,
+            UNDEFINED_VARIABLE,
+            UNKNOWN_METHOD_ON_TYPE,
+            VALIDATOR_ANNOTATION_MISSING,
+            VARIABLE_UNINITIALIZED
+    );
+
+    private static final java.util.Map<String, DiagnosticInfo> BY_CODE = ALL.stream()
+            .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                    DiagnosticInfo::code,
+                    info -> info));
+
+    public static java.util.List<DiagnosticInfo> all() {
+        return ALL;
+    }
+
+    public static java.util.Optional<DiagnosticInfo> find(String code) {
+        return java.util.Optional.ofNullable(BY_CODE.get(code));
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollector.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollector.java
@@ -57,16 +57,32 @@ public class DiagnosticCollector {
      * Record an error with source position and a suggestion.
      */
     public void error(Node node, String message, String suggestion) {
-        int line = 0, col = 0;
-        if (node != null) {
-            var begin = node.getBegin();
-            if (begin.isPresent()) {
-                line = begin.get().line;
-                col = begin.get().column;
-            }
-        }
-        diagnostics.add(new CompilerDiagnostic(
-                CompilerDiagnostic.Level.ERROR, message, fileName, line, col, suggestion));
+        errorWithCode(node, null, message, suggestion);
+    }
+
+    /**
+     * Record an error with a stable code (e.g. {@code "JULC0001"}), source
+     * position, message, and an optional fix suggestion. The code is looked
+     * up in the diagnostics catalog by downstream tooling (MCP, lint, docs).
+     */
+    public void errorWithCode(Node node, String code, String message, String suggestion) {
+        add(CompilerDiagnostic.Level.ERROR, node, code, message, suggestion);
+    }
+
+    /**
+     * Record an error from the generated diagnostics catalog.
+     */
+    public void errorWithCode(Node node, DiagnosticInfo info, Object... args) {
+        errorWithCodeWithSuggestion(node, info, info.fix(), args);
+    }
+
+    /**
+     * Record an error from the generated diagnostics catalog with a
+     * source-specific suggestion override.
+     */
+    public void errorWithCodeWithSuggestion(Node node, DiagnosticInfo info,
+                                            String suggestionOverride, Object... args) {
+        add(info.level(), node, info.code(), info.format(args), suggestionOverride);
     }
 
     /**
@@ -85,6 +101,14 @@ public class DiagnosticCollector {
     }
 
     /**
+     * Record an error without a source node but with a stable code + suggestion.
+     */
+    public void errorWithCode(String code, String message, String suggestion) {
+        diagnostics.add(new CompilerDiagnostic(
+                CompilerDiagnostic.Level.ERROR, message, fileName, 0, 0, suggestion, code));
+    }
+
+    /**
      * Record a warning with source position.
      */
     public void warning(Node node, String message) {
@@ -95,6 +119,35 @@ public class DiagnosticCollector {
      * Record a warning with source position and a suggestion.
      */
     public void warning(Node node, String message, String suggestion) {
+        warningWithCode(node, null, message, suggestion);
+    }
+
+    /**
+     * Record a warning with a stable code (e.g. {@code "JULC0021"}), source
+     * position, message, and an optional fix suggestion.
+     */
+    public void warningWithCode(Node node, String code, String message, String suggestion) {
+        add(CompilerDiagnostic.Level.WARNING, node, code, message, suggestion);
+    }
+
+    /**
+     * Record a warning from the generated diagnostics catalog.
+     */
+    public void warningWithCode(Node node, DiagnosticInfo info, Object... args) {
+        warningWithCodeWithSuggestion(node, info, info.fix(), args);
+    }
+
+    /**
+     * Record a warning from the generated diagnostics catalog with a
+     * source-specific suggestion override.
+     */
+    public void warningWithCodeWithSuggestion(Node node, DiagnosticInfo info,
+                                              String suggestionOverride, Object... args) {
+        add(info.level(), node, info.code(), info.format(args), suggestionOverride);
+    }
+
+    private void add(CompilerDiagnostic.Level level, Node node, String code,
+                     String message, String suggestion) {
         int line = 0, col = 0;
         if (node != null) {
             var begin = node.getBegin();
@@ -104,7 +157,7 @@ public class DiagnosticCollector {
             }
         }
         diagnostics.add(new CompilerDiagnostic(
-                CompilerDiagnostic.Level.WARNING, message, fileName, line, col, suggestion));
+                level, message, fileName, line, col, suggestion, code));
     }
 
     /**

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticInfo.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticInfo.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.julc.compiler.error;
+
+import java.text.MessageFormat;
+
+/**
+ * Catalog-backed diagnostic metadata generated into {@link DiagnosticCodes}.
+ *
+ * @param code     stable public diagnostic code, e.g. {@code JULC0015}
+ * @param constant generated Java constant name
+ * @param level    diagnostic severity
+ * @param category catalog category
+ * @param template exact compiler-emitted message template
+ * @param fix      canonical fix guidance
+ */
+public record DiagnosticInfo(String code, String constant, CompilerDiagnostic.Level level,
+                             String category, String template, String fix) {
+
+    public String format(Object... args) {
+        if (args == null || args.length == 0) {
+            return template;
+        }
+        return MessageFormat.format(template, args);
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/validate/SubsetValidator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/validate/SubsetValidator.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.compiler.validate;
 
 import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
+import com.bloxbean.cardano.julc.compiler.error.DiagnosticInfo;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -13,6 +14,12 @@ import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.C_STYLE_FOR_UNSUPPORTED;
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.DO_WHILE_UNSUPPORTED;
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.NULL_UNSUPPORTED;
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.THROW_UNSUPPORTED;
+import static com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes.TRY_CATCH_UNSUPPORTED;
 
 /**
  * Validates that Java source uses only the supported subset for on-chain compilation.
@@ -33,14 +40,32 @@ public class SubsetValidator extends VoidVisitorAdapter<Void> {
     }
 
     private void error(com.github.javaparser.ast.Node node, String message) {
-        error(node, message, null);
+        error(node, (String) null, message, null);
     }
 
     private void error(com.github.javaparser.ast.Node node, String message, String suggestion) {
+        error(node, (String) null, message, suggestion);
+    }
+
+    /**
+     * Emit an error with a stable diagnostics catalog code (e.g. JULC0015).
+     * The code is consumed by the AI tooling (MCP `julc_explain_diagnostic`,
+     * starter pack §7) to surface the canonical root cause and fix.
+     */
+    private void error(com.github.javaparser.ast.Node node, String code,
+                       String message, String suggestion) {
         int line = node.getBegin().map(p -> p.line).orElse(0);
         int col = node.getBegin().map(p -> p.column).orElse(0);
         diagnostics.add(new CompilerDiagnostic(
-                CompilerDiagnostic.Level.ERROR, message, fileName, line, col, suggestion));
+                CompilerDiagnostic.Level.ERROR, message, fileName, line, col, suggestion, code));
+    }
+
+    private void error(com.github.javaparser.ast.Node node, DiagnosticInfo info,
+                       String suggestion, Object... args) {
+        int line = node.getBegin().map(p -> p.line).orElse(0);
+        int col = node.getBegin().map(p -> p.column).orElse(0);
+        diagnostics.add(new CompilerDiagnostic(
+                info.level(), info.format(args), fileName, line, col, suggestion, info.code()));
     }
 
     private void warning(com.github.javaparser.ast.Node node, String message) {
@@ -63,15 +88,13 @@ public class SubsetValidator extends VoidVisitorAdapter<Void> {
 
     @Override
     public void visit(TryStmt n, Void arg) {
-        error(n, "try/catch is not supported on-chain",
-                "Use if/else checks instead of exception handling");
+        error(n, TRY_CATCH_UNSUPPORTED, TRY_CATCH_UNSUPPORTED.fix());
         super.visit(n, arg);
     }
 
     @Override
     public void visit(ThrowStmt n, Void arg) {
-        error(n, "throw is not supported on-chain",
-                "Return false from the validator to reject a transaction");
+        error(n, THROW_UNSUPPORTED, THROW_UNSUPPORTED.fix());
         super.visit(n, arg);
     }
 
@@ -84,8 +107,7 @@ public class SubsetValidator extends VoidVisitorAdapter<Void> {
 
     @Override
     public void visit(ForStmt n, Void arg) {
-        error(n, "C-style for loops are not supported on-chain",
-                "Use for-each over a list or while loops instead");
+        error(n, C_STYLE_FOR_UNSUPPORTED, C_STYLE_FOR_UNSUPPORTED.fix());
         super.visit(n, arg);
     }
 
@@ -116,8 +138,7 @@ public class SubsetValidator extends VoidVisitorAdapter<Void> {
 
     @Override
     public void visit(DoStmt n, Void arg) {
-        error(n, "do-while loops are not supported on-chain",
-                "Use while loops or for-each instead");
+        error(n, DO_WHILE_UNSUPPORTED, DO_WHILE_UNSUPPORTED.fix());
         super.visit(n, arg);
     }
 
@@ -167,8 +188,7 @@ public class SubsetValidator extends VoidVisitorAdapter<Void> {
 
     @Override
     public void visit(NullLiteralExpr n, Void arg) {
-        error(n, "null is not supported on-chain",
-                "Use Optional<T> to represent absence of a value");
+        error(n, NULL_UNSUPPORTED, NULL_UNSUPPORTED.fix());
         super.visit(n, arg);
     }
 

--- a/julc-compiler/src/main/resources/diagnostics.json
+++ b/julc-compiler/src/main/resources/diagnostics.json
@@ -1,0 +1,366 @@
+{
+  "schemaVersion": 1,
+  "julcVersion": "@julcVersion@",
+  "$comment": "Authoritative catalog of JuLC compiler diagnostics. Each entry has a stable JULC#### code, a generated Java constant, an emitted-message template, a one-line root cause, a canonical fix snippet, and optionally example bad/good code. Consumed by: (1) generated DiagnosticCodes.java, (2) the MCP julc_explain_diagnostic tool, (3) docs/AI catalog resources, (4) future full compiler diagnostic coverage tests.",
+  "categories": {
+    "SYNTAX": "Java syntax forms not supported in the on-chain subset",
+    "TYPE": "Type system errors (resolution, mismatches, generics)",
+    "VALIDATOR": "Validator class / @Entrypoint structure",
+    "CONTROL_FLOW": "Control-flow restrictions (return, break, while, switch)",
+    "LIBRARY": "@OnchainLibrary and @Param errors",
+    "STDLIB": "Stdlib method usage errors (wrong arity, missing args)",
+    "PIR": "PIR generation errors (internal pipeline)"
+  },
+  "diagnostics": [
+    {
+      "code": "JULC0001",
+      "constant": "METHOD_BODY_MISSING",
+      "status": "planned",
+      "title": "Method must have a body",
+      "category": "VALIDATOR",
+      "severity": "error",
+      "template": "Method must have a body: {0}",
+      "summary": "An abstract or interface method was found where the compiler expects a concrete method body. On-chain code cannot contain abstract methods.",
+      "fix": "Provide a body for every method in your validator class.",
+      "example": {
+        "bad": "@SpendingValidator\npublic class MyValidator {\n    @Entrypoint\n    public abstract boolean validate(Data redeemer, ScriptContext ctx);\n}",
+        "good": "@SpendingValidator\npublic class MyValidator {\n    @Entrypoint\n    public static boolean validate(Data redeemer, ScriptContext ctx) {\n        return true;\n    }\n}"
+      }
+    },
+    {
+      "code": "JULC0002",
+      "constant": "VARIABLE_UNINITIALIZED",
+      "status": "planned",
+      "title": "Variable must be initialized",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "Variable must be initialized: {0}",
+      "summary": "A local variable was declared without an initializer. UPLC has no notion of uninitialized state.",
+      "fix": "Initialize at declaration, e.g. `var x = BigInteger.ZERO;`. Re-bind via a new `var` if you need a different value later (UPLC is single-assignment).",
+      "example": {
+        "bad": "var x;\nx = 5;",
+        "good": "var x = BigInteger.valueOf(5);"
+      }
+    },
+    {
+      "code": "JULC0003",
+      "constant": "RETURN_INSIDE_WHILE",
+      "status": "planned",
+      "title": "Cannot return inside while loop",
+      "category": "CONTROL_FLOW",
+      "severity": "error",
+      "template": "Cannot return inside while loop",
+      "summary": "`return` statements are not allowed inside `while` loops. UPLC `while` is desugared to a fixed-point `LetRec` that needs an explicit accumulator.",
+      "fix": "Use a boolean accumulator and return after the loop. `break` works inside `for-each` if you only need early termination.",
+      "example": {
+        "bad": "while (i.compareTo(n) < 0) {\n    if (matches(i)) return true;\n    i = i.add(BigInteger.ONE);\n}\nreturn false;",
+        "good": "boolean found = false;\nvar i = BigInteger.ZERO;\nwhile (i.compareTo(n) < 0 && !found) {\n    if (matches(i)) found = true;\n    i = i.add(BigInteger.ONE);\n}\nreturn found;"
+      }
+    },
+    {
+      "code": "JULC0004",
+      "constant": "BREAK_OUTSIDE_LOOP",
+      "status": "planned",
+      "title": "break statement outside of a loop",
+      "category": "CONTROL_FLOW",
+      "severity": "error",
+      "template": "break statement outside of a loop",
+      "summary": "`break` was used outside of a `for-each` or `while` loop body.",
+      "fix": "Place the `break` inside a loop, or refactor to use early `return` from a helper method."
+    },
+    {
+      "code": "JULC0005",
+      "constant": "SWITCH_NOT_EXHAUSTIVE",
+      "status": "planned",
+      "title": "Switch is not exhaustive on sealed interface",
+      "category": "CONTROL_FLOW",
+      "severity": "error",
+      "template": "Switch on sealed interface {0} is not exhaustive. Missing cases: {1}",
+      "summary": "A `switch` expression on a sealed interface is missing one or more permitted variants.",
+      "fix": "Add the missing case branches or include a `default ->` branch to handle all remaining variants.",
+      "example": {
+        "bad": "sealed interface Action permits A, B, C {}\n// ...\nreturn switch (action) {\n    case A a -> ...;\n    case B b -> ...;\n    // missing C\n};",
+        "good": "return switch (action) {\n    case A a -> ...;\n    case B b -> ...;\n    case C c -> ...;\n};"
+      }
+    },
+    {
+      "code": "JULC0006",
+      "constant": "METHOD_MISSING_RETURN",
+      "status": "planned",
+      "title": "Method does not return on all paths",
+      "category": "CONTROL_FLOW",
+      "severity": "error",
+      "template": "Method {0} may not return a value on all execution paths",
+      "summary": "A non-void method has at least one execution path that does not return a value.",
+      "fix": "Ensure every if/else branch returns, or add a fallthrough return at the end of the method."
+    },
+    {
+      "code": "JULC0007",
+      "constant": "SWITCH_REQUIRES_SEALED_INTERFACE",
+      "status": "planned",
+      "title": "Switch expression requires a sealed interface type",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "switch expression requires a sealed interface type, got: {0}",
+      "summary": "`switch` was used on a non-sealed type. Records (including `Tuple2`/`Tuple3`) cannot be switched on.",
+      "fix": "Use field access (`pair.first()`, `pair.second()`) for records. Reserve `switch` for sealed interfaces with permitted record variants."
+    },
+    {
+      "code": "JULC0008",
+      "constant": "ENTRYPOINT_WRONG_PARAMETER_COUNT",
+      "status": "emitted",
+      "title": "@Entrypoint method has wrong parameter count",
+      "category": "VALIDATOR",
+      "severity": "error",
+      "template": "{0} entrypoint must have {1} parameters{2}, found {3} in {4}.{5}(){6}",
+      "summary": "The @Entrypoint method's parameter count doesn't match the validator kind. SpendingValidator entrypoints take 2 or 3 params (datum, redeemer, ctx); other validators take 2 (redeemer, ctx).",
+      "fix": "Adjust the entrypoint signature to match the validator annotation. Spending: `(Datum, Redeemer, ScriptContext)`. Others: `(Redeemer, ScriptContext)`."
+    },
+    {
+      "code": "JULC0009",
+      "constant": "ENTRYPOINT_MISSING",
+      "status": "emitted",
+      "title": "No @Entrypoint method found",
+      "category": "VALIDATOR",
+      "severity": "error",
+      "template": "No @Entrypoint method found in {0}",
+      "summary": "The validator class has no method annotated `@Entrypoint`.",
+      "fix": "Annotate exactly one `public static` method with `@Entrypoint`. The method must return `boolean` (or `void` for newer signature shapes)."
+    },
+    {
+      "code": "JULC0010",
+      "constant": "VALIDATOR_ANNOTATION_MISSING",
+      "status": "emitted",
+      "title": "No validator annotation found",
+      "category": "VALIDATOR",
+      "severity": "error",
+      "template": "No validator annotation found{0}",
+      "summary": "The class has no validator annotation. Expected one of @SpendingValidator, @MintingValidator, @CertifyingValidator, @WithdrawValidator, @VotingValidator, @ProposingValidator (or @MultiValidator).",
+      "fix": "Add the appropriate validator annotation at the class level."
+    },
+    {
+      "code": "JULC0011",
+      "constant": "UNDEFINED_VARIABLE",
+      "status": "planned",
+      "title": "Undefined variable",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "Undefined variable: {0}",
+      "summary": "A variable was referenced that is not in scope. Most commonly: typo, used before declared, or shadowed inside a switch case binding.",
+      "fix": "Check spelling and declaration order. If a switch case binds a field with the same name as your method parameter, rename one of them — the field shadows the parameter inside the case body (see JULC0021)."
+    },
+    {
+      "code": "JULC0012",
+      "constant": "TYPE_RESOLUTION_FAILED",
+      "status": "planned",
+      "title": "Cannot resolve type",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "Cannot resolve type: {0}",
+      "summary": "The compiler could not resolve a type reference. The class may not be on the classpath, may not be a registered ledger/stdlib type, or may not be a valid on-chain type.",
+      "fix": "Ensure the type is imported and is one of: a record, sealed interface, ledger type, JulcList/JulcMap/Optional/Tuple, or primitive (BigInteger, byte[], boolean, String)."
+    },
+    {
+      "code": "JULC0013",
+      "constant": "PARAM_RAW_PLUTUS_DATA",
+      "status": "emitted",
+      "title": "Banned @Param type",
+      "category": "LIBRARY",
+      "severity": "error",
+      "template": "@Param type ''{0}'' is not allowed. @Param values are always raw Data at runtime; using a typed Data subtype causes the compiler to misinterpret the runtime representation.",
+      "summary": "@Param fields cannot be raw `PlutusData` subtypes (`PlutusData.BytesData`, `PlutusData.MapData`, `PlutusData.ListData`, `PlutusData.IntData`) — these confuse the parameter wrapping pipeline.",
+      "fix": "Use byte[], BigInteger, typed records, redeemers, or @Param PlutusData only for opaque data."
+    },
+    {
+      "code": "JULC0014",
+      "constant": "ARRAY_UNSUPPORTED",
+      "status": "planned",
+      "title": "Arrays are not supported (except byte[])",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "arrays are not supported on-chain",
+      "summary": "Java arrays other than `byte[]` are not supported on-chain.",
+      "fix": "Use `JulcList<T>` or `List<T>` instead of `T[]`."
+    },
+    {
+      "code": "JULC0015",
+      "constant": "TRY_CATCH_UNSUPPORTED",
+      "status": "emitted",
+      "title": "try/catch is not supported on-chain",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "try/catch is not supported on-chain",
+      "summary": "UPLC has no exception model — only `error` (immediate script failure).",
+      "fix": "Use if/else checks instead of exception handling"
+    },
+    {
+      "code": "JULC0016",
+      "constant": "THROW_UNSUPPORTED",
+      "status": "emitted",
+      "title": "throw is not supported on-chain",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "throw is not supported on-chain",
+      "summary": "There is no exception machinery in UPLC.",
+      "fix": "Return false from the validator to reject a transaction"
+    },
+    {
+      "code": "JULC0017",
+      "constant": "NULL_UNSUPPORTED",
+      "status": "emitted",
+      "title": "null is not supported on-chain",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "null is not supported on-chain",
+      "summary": "There is no `null` value in the on-chain type system.",
+      "fix": "Use Optional<T> (Optional.of(x) / Optional.empty()) to represent absence of a value"
+    },
+    {
+      "code": "JULC0018",
+      "constant": "C_STYLE_FOR_UNSUPPORTED",
+      "status": "emitted",
+      "title": "C-style for loops are not supported",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "C-style for loops are not supported on-chain",
+      "summary": "Only `for-each` (`for (var x : list)`) and `while` loops are supported on-chain.",
+      "fix": "Use for-each over a list or while loops instead"
+    },
+    {
+      "code": "JULC0019",
+      "constant": "DO_WHILE_UNSUPPORTED",
+      "status": "emitted",
+      "title": "do-while loops are not supported",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "do-while loops are not supported on-chain",
+      "summary": "Do-while is not supported on-chain.",
+      "fix": "Use while loops or for-each instead"
+    },
+    {
+      "code": "JULC0020",
+      "constant": "FLOATING_POINT_UNSUPPORTED",
+      "status": "planned",
+      "title": "Floating-point types are not supported",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "floating point types (float/double) are not supported on-chain",
+      "summary": "`float` and `double` have no UPLC equivalent.",
+      "fix": "Use `BigInteger` for integer math. For fractional values, scale up (e.g. parts-per-million) and do integer math, or use `Rational` from the ledger types when modelling protocol params."
+    },
+    {
+      "code": "JULC0021",
+      "constant": "SWITCH_FIELD_SHADOWS_PARAMETER",
+      "status": "lintOnly",
+      "title": "Switch case field name shadows method parameter",
+      "category": "CONTROL_FLOW",
+      "severity": "warning",
+      "template": "Switch case binding name shadows a method parameter",
+      "summary": "When a sealed-interface variant has a field with the same name as a method parameter, the field binding silently shadows the parameter inside the switch case body. The compiler may not always catch this — be vigilant.",
+      "fix": "Always use distinct names. Example: rename `time` parameter to `point` when switching on `IntervalBoundType.Finite(time)`.",
+      "example": {
+        "bad": "boolean check(IntervalBound bound, BigInteger time) {\n    return switch (bound) {\n        case Finite f -> f.time().compareTo(time) > 0; // 'time' = field, NOT param\n    };\n}",
+        "good": "boolean check(IntervalBound bound, BigInteger point) {\n    return switch (bound) {\n        case Finite f -> f.time().compareTo(point) > 0;\n    };\n}"
+      }
+    },
+    {
+      "code": "JULC0022",
+      "constant": "LAMBDA_STORED_IN_VARIABLE_UNSUPPORTED",
+      "status": "planned",
+      "title": "Lambda cannot be stored in a variable",
+      "category": "SYNTAX",
+      "severity": "error",
+      "template": "Lambda cannot be stored in a variable",
+      "summary": "Lambdas must be passed inline as arguments to higher-order functions. Storing a lambda in a `Function<X,Y>` variable and calling `.apply(...)` is not supported.",
+      "fix": "Pass the lambda directly: `list.map(x -> ...)`, `list.filter(p -> ...)`. If you need to share lambda logic, extract it as a regular static method (not as a lambda)."
+    },
+    {
+      "code": "JULC0023",
+      "constant": "MUTUAL_RECURSION_TOO_LARGE",
+      "status": "planned",
+      "title": "Mutually recursive bindings with more than 2 participants not supported",
+      "category": "PIR",
+      "severity": "error",
+      "template": "Mutually recursive bindings with more than 2 participants not yet supported: {0}",
+      "summary": "JuLC supports self-recursion and mutual recursion between exactly 2 helpers (via Bekic's theorem). Three or more mutually recursive functions are not supported.",
+      "fix": "Refactor: combine the helpers into a single function with an accumulator, or break the recursion via an explicit dispatch on a sealed interface."
+    },
+    {
+      "code": "JULC0024",
+      "constant": "UNKNOWN_METHOD_ON_TYPE",
+      "status": "planned",
+      "title": "Unknown method on type",
+      "category": "STDLIB",
+      "severity": "error",
+      "template": "Unknown method: {0}",
+      "summary": "A method was called that doesn't exist on the receiver type. Likely the AI invented a method that isn't in the stdlib.",
+      "fix": "Check the stdlib catalog at https://julc.dev/ai/catalog.json or the stdlib reference at https://julc.dev/stdlib/stdlib-guide/. Common: `JulcList<T>` has `head/tail/get/size/isEmpty/contains/prepend/reverse/concat/take/drop/map/filter/any/all/find`."
+    },
+    {
+      "code": "JULC0025",
+      "constant": "STDLIB_METHOD_WRONG_ARITY",
+      "status": "planned",
+      "title": "Stdlib method called with wrong number of arguments",
+      "category": "STDLIB",
+      "severity": "error",
+      "template": "Stdlib method called with wrong number of arguments: {0}",
+      "summary": "A stdlib method was called with the wrong arity. Examples: `list.map()` requires a function argument, `list.contains()` requires an element argument, `map.insert()` requires (key, value).",
+      "fix": "See the message itself — it includes a `Usage:` hint with the correct signature."
+    },
+    {
+      "code": "JULC0026",
+      "constant": "NEWTYPE_WRONG_FIELD_COUNT",
+      "status": "planned",
+      "title": "@NewType requires exactly one field",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "@NewType record {0} must have exactly one field",
+      "summary": "@NewType is a single-field record wrapper around a primitive (byte[], BigInteger, String, boolean). Multi-field @NewType records are not allowed.",
+      "fix": "Reduce to one field, or remove @NewType and use a plain record (which compiles to ConstrData)."
+    },
+    {
+      "code": "JULC0027",
+      "constant": "NEWTYPE_UNSUPPORTED_FIELD_TYPE",
+      "status": "planned",
+      "title": "Unsupported @NewType field type",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "Unsupported @NewType field type: {0}",
+      "summary": "@NewType's underlying field must be a primitive: `byte[]`, `BigInteger`, `String`, or `boolean`.",
+      "fix": "Change the underlying field to a supported primitive, or remove @NewType."
+    },
+    {
+      "code": "JULC0028",
+      "constant": "SOURCE_PARSE_FAILED",
+      "status": "planned",
+      "title": "Failed to parse source",
+      "category": "PIR",
+      "severity": "error",
+      "template": "Failed to parse {0} source: {1}",
+      "summary": "The Java source could not be parsed. Usually a syntax error in the source file.",
+      "fix": "Check the file with a Java IDE or `javac` — the JuLC compiler relies on JavaParser to produce a clean AST."
+    },
+    {
+      "code": "JULC0029",
+      "constant": "DUPLICATE_TYPE_DECLARATION",
+      "status": "planned",
+      "title": "Duplicate record / sealed interface type",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "Duplicate type declaration: {0}",
+      "summary": "Two different declarations registered the same type name.",
+      "fix": "Rename one of the types, or ensure they are not both on the compilation classpath."
+    },
+    {
+      "code": "JULC0030",
+      "constant": "CIRCULAR_TYPE_DEPENDENCY",
+      "status": "planned",
+      "title": "Circular type dependency detected",
+      "category": "TYPE",
+      "severity": "error",
+      "template": "Circular type dependency detected among: {0}",
+      "summary": "Type registration found a cycle that cannot be resolved.",
+      "fix": "Break the cycle by introducing a parameterized record or refactoring the involved types."
+    }
+  ]
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ParamTypeValidationTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ParamTypeValidationTest.java
@@ -64,6 +64,13 @@ class ParamTypeValidationTest {
     }
 
     @Test
+    void testParamFullyQualifiedBytesDataRejected() {
+        var ex = expectCompileError("com.bloxbean.cardano.julc.core.PlutusData.BytesData");
+        assertTrue(ex.diagnostics().stream().anyMatch(CompilerDiagnostic::isError));
+        assertTrue(ex.getMessage().contains("BytesData"));
+    }
+
+    @Test
     void testParamPlutusDataAccepted() {
         var source = VALIDATOR_TEMPLATE.formatted("PlutusData");
         var result = new JulcCompiler().compile(source);
@@ -106,6 +113,7 @@ class ParamTypeValidationTest {
                 .filter(CompilerDiagnostic::isError)
                 .findFirst()
                 .orElseThrow();
+        assertEquals("JULC0013", errorDiag.code());
         assertTrue(errorDiag.hasSuggestion());
         assertTrue(errorDiag.suggestion().contains("PlutusData"));
     }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCatalogConsistencyTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCatalogConsistencyTest.java
@@ -1,0 +1,202 @@
+package com.bloxbean.cardano.julc.compiler.error;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.MessageFormat;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Drift detection: every JULC#### code referenced in compiler source must
+ * have a matching entry in {@code diagnostics.json}.
+ *
+ * <p>This test was added in response to Phase B review feedback: without it,
+ * removing or renumbering a catalog entry silently breaks the link between
+ * runtime diagnostics and the AI-facing catalog at {@code /ai/diagnostics.json}.
+ */
+class DiagnosticCatalogConsistencyTest {
+
+    private static final Pattern JULC_CODE = Pattern.compile("\"(JULC\\d{4})\"");
+    private static final Pattern CODE_FIELD = Pattern.compile("\"code\"\\s*:\\s*\"(JULC\\d{4})\"");
+    private static final Pattern CONSTANT_FIELD = Pattern.compile("\"constant\"\\s*:\\s*\"([A-Z][A-Z0-9_]*)\"");
+    private static final Pattern STATUS_FIELD = Pattern.compile("\"status\"\\s*:\\s*\"([A-Za-z]+)\"");
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{(\\d+)(?:,[^}]*)?}");
+    private static final Set<String> VALID_STATUS = Set.of("emitted", "planned", "lintOnly", "internal");
+
+    @Test
+    void everyProductionCodeIsInCatalog() throws IOException {
+        Set<String> catalogCodes = loadCatalogCodes();
+        assertFalse(catalogCodes.isEmpty(),
+                "diagnostics.json must contain at least one entry; loader returned empty");
+
+        Set<String> productionCodes = scanProductionForCodes();
+        Set<String> missing = new HashSet<>(productionCodes);
+        missing.removeAll(catalogCodes);
+        assertTrue(missing.isEmpty(),
+                "Compiler source references codes missing from diagnostics.json: " + missing);
+    }
+
+    @Test
+    void generatedConstantsMatchCatalog() throws IOException {
+        Set<String> catalogCodes = loadCatalogFields(CODE_FIELD);
+        Set<String> catalogConstants = loadCatalogFields(CONSTANT_FIELD);
+
+        Set<String> generatedCodes = new HashSet<>();
+        Set<String> generatedConstants = new HashSet<>();
+        for (var info : DiagnosticCodes.all()) {
+            generatedCodes.add(info.code());
+            generatedConstants.add(info.constant());
+            assertSame(info, DiagnosticCodes.find(info.code()).orElseThrow(),
+                    "find(code) must return the generated singleton for " + info.code());
+        }
+
+        assertEquals(catalogCodes, generatedCodes,
+                "Generated DiagnosticCodes must cover exactly the catalog codes");
+        assertEquals(catalogConstants, generatedConstants,
+                "Generated DiagnosticCodes must cover exactly the catalog constants");
+        assertEquals(catalogCodes.size(), DiagnosticCodes.all().size(),
+                "Generated all() must not contain duplicate codes");
+    }
+
+    @Test
+    void catalogHasPr1SchemaFields() throws IOException {
+        String body = loadCatalogBody();
+        int count = countMatches(CODE_FIELD, body);
+        assertTrue(count >= 30, "Expected the JULC0001-JULC0030 seed catalog");
+
+        Map<String, Pattern> required = Map.of(
+                "constant", Pattern.compile("\"constant\"\\s*:"),
+                "status", Pattern.compile("\"status\"\\s*:"),
+                "title", Pattern.compile("\"title\"\\s*:"),
+                "category", Pattern.compile("\"category\"\\s*:"),
+                "severity", Pattern.compile("\"severity\"\\s*:"),
+                "template", Pattern.compile("\"template\"\\s*:"),
+                "summary", Pattern.compile("\"summary\"\\s*:"),
+                "fix", Pattern.compile("\"fix\"\\s*:")
+        );
+        required.forEach((field, pattern) ->
+                assertEquals(count, countMatches(pattern, body),
+                        "Every diagnostic entry must have field '" + field + "'"));
+
+        Set<String> statuses = loadCatalogFields(STATUS_FIELD);
+        assertTrue(VALID_STATUS.containsAll(statuses),
+                "Unknown diagnostic status values: " + statuses);
+    }
+
+    @Test
+    void generatedTemplatesParseAndFormat() {
+        for (var info : DiagnosticCodes.all()) {
+            assertDoesNotThrow(() -> new MessageFormat(info.template()),
+                    "Template must parse under MessageFormat for " + info.code());
+            int maxPlaceholder = maxPlaceholder(info.template());
+            if (maxPlaceholder >= 0) {
+                Object[] args = new Object[maxPlaceholder + 1];
+                for (int i = 0; i < args.length; i++) {
+                    args[i] = "arg" + i;
+                }
+                assertDoesNotThrow(() -> info.format(args),
+                        "Template must format with dummy args for " + info.code());
+            }
+        }
+    }
+
+    @Test
+    void catalogIsLoadable() throws IOException {
+        // Smoke check that the resource is on the classpath and is non-trivial.
+        try (InputStream in = getClass().getResourceAsStream("/diagnostics.json")) {
+            assertNotNull(in, "diagnostics.json must be on the classpath");
+            byte[] bytes = in.readAllBytes();
+            assertTrue(bytes.length > 1000,
+                    "diagnostics.json appears truncated (<1KB)");
+            String body = new String(bytes);
+            assertTrue(body.contains("\"diagnostics\""),
+                    "diagnostics.json must have a 'diagnostics' top-level key");
+            assertTrue(body.contains("JULC0001"),
+                    "diagnostics.json must contain at least the seed code JULC0001");
+        }
+    }
+
+    private String loadCatalogBody() throws IOException {
+        try (InputStream in = getClass().getResourceAsStream("/diagnostics.json")) {
+            assertNotNull(in, "diagnostics.json must be on the classpath");
+            return new String(in.readAllBytes());
+        }
+    }
+
+    private Set<String> loadCatalogCodes() throws IOException {
+        return loadCatalogFields(JULC_CODE);
+    }
+
+    private Set<String> loadCatalogFields(Pattern pattern) throws IOException {
+        Set<String> codes = new HashSet<>();
+        String body = loadCatalogBody();
+        Matcher m = pattern.matcher(body);
+        while (m.find()) codes.add(m.group(1));
+        return codes;
+    }
+
+    private static int countMatches(Pattern pattern, String body) {
+        int count = 0;
+        Matcher m = pattern.matcher(body);
+        while (m.find()) count++;
+        return count;
+    }
+
+    private static int maxPlaceholder(String template) {
+        int max = -1;
+        Matcher m = PLACEHOLDER.matcher(template);
+        while (m.find()) {
+            max = Math.max(max, Integer.parseInt(m.group(1)));
+        }
+        return max;
+    }
+
+    /** Walk julc-compiler/src/main/java looking for "JULCnnnn" string literals. */
+    private Set<String> scanProductionForCodes() throws IOException {
+        Set<String> codes = new HashSet<>();
+        Path src = locateCompilerMainJava();
+        if (src == null) {
+            // Running from a packaged jar where the source tree isn't present
+            // (e.g. on CI with --no-source). In that case we can only verify
+            // catalog loadability, not drift. Skip silently.
+            return codes;
+        }
+        try (Stream<Path> files = Files.walk(src)) {
+            files.filter(p -> p.toString().endsWith(".java"))
+                 .forEach(p -> {
+                     try {
+                         String content = Files.readString(p);
+                         Matcher m = JULC_CODE.matcher(content);
+                         while (m.find()) codes.add(m.group(1));
+                     } catch (IOException e) {
+                         // Don't fail the whole test on a single read error;
+                         // missing-codes assertion will still cover real gaps.
+                     }
+                 });
+        }
+        return codes;
+    }
+
+    /**
+     * Best-effort path resolution. The Gradle test task runs with the module
+     * root as cwd, so {@code src/main/java} resolves directly. Falls back to
+     * walking up from the test class location.
+     */
+    private static Path locateCompilerMainJava() {
+        Path cwd = Path.of("src/main/java");
+        if (Files.isDirectory(cwd)) return cwd;
+        Path repoRel = Path.of("julc-compiler/src/main/java");
+        if (Files.isDirectory(repoRel)) return repoRel;
+        return null;
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollectorTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCollectorTest.java
@@ -91,4 +91,60 @@ class DiagnosticCollectorTest {
         assertEquals(0, diag.line());
         assertEquals(0, diag.column());
     }
+
+    @Test
+    void errorWithCode_attachesStableCode() {
+        var collector = new DiagnosticCollector("test.java");
+        var cu = StaticJavaParser.parse("class A { void m() { int x = 42; } }");
+        var literal = cu.findFirst(IntegerLiteralExpr.class).orElseThrow();
+
+        collector.errorWithCode(literal, "JULC0003", "Cannot return inside while loop",
+                "Use a boolean accumulator and return after the loop");
+
+        var diag = collector.getDiagnostics().get(0);
+        assertEquals("JULC0003", diag.code());
+        assertTrue(diag.hasCode());
+        assertTrue(diag.toString().contains("[JULC0003]"),
+                "toString should surface the code for log readability");
+    }
+
+    @Test
+    void errorWithGeneratedCode_formatsTemplateAndUsesCatalogFix() {
+        var collector = new DiagnosticCollector("test.java");
+        var cu = StaticJavaParser.parse("class A { void m() { int x = 42; } }");
+        var literal = cu.findFirst(IntegerLiteralExpr.class).orElseThrow();
+
+        collector.errorWithCode(literal, DiagnosticCodes.PARAM_RAW_PLUTUS_DATA,
+                "PlutusData.BytesData");
+
+        var diag = collector.getDiagnostics().get(0);
+        assertEquals("JULC0013", diag.code());
+        assertEquals("@Param type 'PlutusData.BytesData' is not allowed. "
+                + "@Param values are always raw Data at runtime; using a typed Data subtype "
+                + "causes the compiler to misinterpret the runtime representation.", diag.message());
+        assertEquals(DiagnosticCodes.PARAM_RAW_PLUTUS_DATA.fix(), diag.suggestion());
+    }
+
+    @Test
+    void errorWithCode_withoutNode_isStillStructured() {
+        var collector = new DiagnosticCollector("test.java");
+        collector.errorWithCode("JULC0010", "No validator annotation found",
+                "Add @SpendingValidator / @MintingValidator / etc.");
+
+        var diag = collector.getDiagnostics().get(0);
+        assertEquals("JULC0010", diag.code());
+        assertEquals(0, diag.line());
+    }
+
+    @Test
+    void diagnosticsWithoutCode_remainBackwardsCompatible() {
+        var collector = new DiagnosticCollector("test.java");
+        collector.error("Legacy error without code");
+
+        var diag = collector.getDiagnostics().get(0);
+        assertNull(diag.code());
+        assertFalse(diag.hasCode());
+        assertFalse(diag.toString().contains("[null]"),
+                "toString must not embed [null] for code-less diagnostics");
+    }
 }

--- a/julc-playground/src/main/java/com/bloxbean/julc/playground/model/DiagnosticDto.java
+++ b/julc-playground/src/main/java/com/bloxbean/julc/playground/model/DiagnosticDto.java
@@ -15,7 +15,7 @@ public record DiagnosticDto(
     public static DiagnosticDto from(CompilerDiagnostic d) {
         return new DiagnosticDto(
                 d.level().name(),
-                null,
+                d.code(),
                 d.message(),
                 d.line() > 0 ? d.line() : null,
                 d.column() > 0 ? d.column() : null,


### PR DESCRIPTION
Introduce diagnostics.json as the catalog source of truth, generate DiagnosticCodes constants, and wire the currently emitted compiler diagnostics to stable JULC#### metadata.

Keep strict full-coverage enforcement documented but intentionally out of this slice.