### PR TITLE
fix:  JuLC library source index generation and multi-JAR discovery

### DIFF
--- a/adr/022-plutus-source-index-discovery.md
+++ b/adr/022-plutus-source-index-discovery.md
@@ -1,0 +1,48 @@
+# ADR-022: Plutus Source Index Discovery
+
+**Date**: 2026-05-18
+**Status**: Accepted
+
+---
+
+## Context
+
+JuLC libraries distribute `@OnchainLibrary` Java sources in dependency JARs under:
+
+```text
+META-INF/plutus-sources/
+```
+
+The compiler resolver needs those sources during annotation processing and direct compiler usage. JAR directory listing is not portable through `ClassLoader` APIs, so reliable JAR discovery requires a manifest:
+
+```text
+META-INF/plutus-sources/index.txt
+```
+
+The Gradle plugin previously copied source files but did not generate this index. The resolver also used `getResourceAsStream(...)`, which only reads the first matching `index.txt` on the classpath.
+
+## Decision
+
+1. `bundleJulcSources` generates `META-INF/plutus-sources/index.txt`.
+2. Each index entry is a path relative to `META-INF/plutus-sources/`, for example:
+
+```text
+com/example/Groth16BLS12381.java
+```
+
+3. The resolver reads every `META-INF/plutus-sources/index.txt` via `ClassLoader.getResources(...)`.
+4. JARs must ship `index.txt` for reliable source discovery.
+5. Loose file-system `META-INF/plutus-sources/` directories are still scanned without an index for IDE, test, and development classpaths.
+6. Indexed entries are loaded before loose file-system fallback entries. Existing `putIfAbsent` behavior means indexed entries win and loose directories fill gaps.
+
+## Consequences
+
+- Multiple dependency JARs can each contribute on-chain library sources.
+- The Gradle plugin now produces JARs that satisfy the resolver contract.
+- Hand-built JARs without `index.txt` remain unsupported for reliable discovery.
+- Existing development workflows that use exploded file-system resources continue to work.
+- The resolver still keys discovered libraries by simple class name. That can collide when two packages contain the same class name.
+
+## Follow-Up
+
+The simple-name collision issue should be fixed in a separate Phase 2 PR. That PR should migrate resolver internals and all call sites to an FQCN-aware `LibrarySource` model, remove the simple-name scan API, reject or fully support wildcard imports explicitly, and route ambiguity errors through the compiler diagnostic pipeline.

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.compiler;
 
 import java.io.*;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -22,6 +23,9 @@ import java.util.regex.Pattern;
  * {@code SourceDiscovery} (test-time) to avoid duplicating resolution logic.
  */
 public final class LibrarySourceResolver {
+
+    private static final String PLUTUS_SOURCES_DIR = "META-INF/plutus-sources/";
+    private static final String PLUTUS_SOURCES_INDEX = PLUTUS_SOURCES_DIR + "index.txt";
 
     /**
      * Regex matching Java import statements.
@@ -114,24 +118,15 @@ public final class LibrarySourceResolver {
      */
     public static Map<String, String> scanClasspathSources(ClassLoader classLoader) {
         var result = new LinkedHashMap<String, String>();
-        // Primary: use index.txt manifest (works with both file: and jar: protocols)
-        try (var indexStream = classLoader.getResourceAsStream("META-INF/plutus-sources/index.txt")) {
-            if (indexStream != null) {
-                var indexContent = new String(indexStream.readAllBytes(), StandardCharsets.UTF_8);
-                for (String entry : indexContent.split("\n")) {
-                    entry = entry.strip();
-                    if (entry.isEmpty() || !entry.endsWith(".java")) continue;
-                    var resourcePath = "META-INF/plutus-sources/" + entry;
-                    try (var sourceStream = classLoader.getResourceAsStream(resourcePath)) {
-                        if (sourceStream != null) {
-                            var source = new String(sourceStream.readAllBytes(), StandardCharsets.UTF_8);
-                            var fileName = entry.contains("/")
-                                    ? entry.substring(entry.lastIndexOf('/') + 1) : entry;
-                            var simpleName = fileName.replace(".java", "");
-                            result.putIfAbsent(simpleName, source);
-                        }
-                    }
-                }
+        // Primary: use every index.txt manifest (works with both file: and jar: protocols)
+        boolean foundIndex = false;
+        try {
+            var indexes = classLoader.getResources(PLUTUS_SOURCES_INDEX);
+            while (indexes.hasMoreElements()) {
+                foundIndex = true;
+                scanIndexedSources(indexes.nextElement(), result);
+            }
+            if (foundIndex) {
                 return result;
             }
         } catch (IOException e) {
@@ -139,7 +134,7 @@ public final class LibrarySourceResolver {
         }
         // Fallback: file-system directory scan (for development/IDE usage)
         try {
-            var resources = classLoader.getResources("META-INF/plutus-sources/");
+            var resources = classLoader.getResources(PLUTUS_SOURCES_DIR);
             while (resources.hasMoreElements()) {
                 URL resourceUrl = resources.nextElement();
                 if ("file".equals(resourceUrl.getProtocol())) {
@@ -150,6 +145,32 @@ public final class LibrarySourceResolver {
             // Silently ignore
         }
         return result;
+    }
+
+    private static void scanIndexedSources(URL indexUrl, Map<String, String> result) throws IOException {
+        try (var indexStream = indexUrl.openStream()) {
+            var indexContent = new String(indexStream.readAllBytes(), StandardCharsets.UTF_8);
+            for (String entry : indexContent.split("\n")) {
+                entry = entry.strip();
+                if (entry.isEmpty() || !entry.endsWith(".java")) continue;
+                try (var sourceStream = resolveIndexedSourceUrl(indexUrl, entry).openStream()) {
+                    var source = new String(sourceStream.readAllBytes(), StandardCharsets.UTF_8);
+                    var fileName = entry.contains("/")
+                            ? entry.substring(entry.lastIndexOf('/') + 1) : entry;
+                    var simpleName = fileName.replace(".java", "");
+                    result.putIfAbsent(simpleName, source);
+                }
+            }
+        }
+    }
+
+    private static URL resolveIndexedSourceUrl(URL indexUrl, String entry) throws IOException {
+        String indexPath = indexUrl.toExternalForm();
+        int lastSlash = indexPath.lastIndexOf('/');
+        if (lastSlash < 0) {
+            throw new IOException("Invalid source index URL: " + indexUrl);
+        }
+        return URI.create(indexPath.substring(0, lastSlash + 1) + entry).toURL();
     }
 
     private static void scanFileSystemSources(File dir, Map<String, String> result) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
@@ -118,21 +118,16 @@ public final class LibrarySourceResolver {
      */
     public static Map<String, String> scanClasspathSources(ClassLoader classLoader) {
         var result = new LinkedHashMap<String, String>();
-        // Primary: use every index.txt manifest (works with both file: and jar: protocols)
-        boolean foundIndex = false;
+        // JARs must ship index.txt for reliable discovery. Loose file-system
+        // directories are also scanned to support IDE/dev/test classpaths.
         try {
             var indexes = classLoader.getResources(PLUTUS_SOURCES_INDEX);
             while (indexes.hasMoreElements()) {
-                foundIndex = true;
                 scanIndexedSources(indexes.nextElement(), result);
-            }
-            if (foundIndex) {
-                return result;
             }
         } catch (IOException e) {
             // Fall through to directory scan
         }
-        // Fallback: file-system directory scan (for development/IDE usage)
         try {
             var resources = classLoader.getResources(PLUTUS_SOURCES_DIR);
             while (resources.hasMoreElements()) {

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
@@ -327,6 +327,35 @@ class LibrarySourceResolverTest {
         }
     }
 
+    @Test
+    void scanClasspathSources_readsIndexedJarsAndLooseFilesystemDirs(@TempDir Path tempDir) throws Exception {
+        Path jar = createPlutusSourcesJar(tempDir.resolve("indexed.jar"), Map.of(
+                "com/example/SharedLib.java", "package com.example; class SharedLib { static int fromJar() { return 1; } }",
+                "com/example/IndexedOnlyLib.java", "package com.example; class IndexedOnlyLib {}"
+        ));
+
+        Path classesDir = tempDir.resolve("classes");
+        Path looseSourcesDir = classesDir.resolve("META-INF/plutus-sources/com/example");
+        Files.createDirectories(looseSourcesDir);
+        Files.writeString(looseSourcesDir.resolve("SharedLib.java"),
+                "package com.example; class SharedLib { static int fromLooseDir() { return 2; } }");
+        Files.writeString(looseSourcesDir.resolve("LooseOnlyLib.java"),
+                "package com.example; class LooseOnlyLib {}");
+
+        try (var classLoader = new URLClassLoader(new URL[]{
+                jar.toUri().toURL(),
+                classesDir.toUri().toURL()
+        }, null)) {
+            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+
+            assertEquals(3, result.size());
+            assertTrue(result.get("SharedLib").contains("fromJar"));
+            assertFalse(result.get("SharedLib").contains("fromLooseDir"));
+            assertTrue(result.get("IndexedOnlyLib").contains("class IndexedOnlyLib"));
+            assertTrue(result.get("LooseOnlyLib").contains("class LooseOnlyLib"));
+        }
+    }
+
     private static Path createPlutusSourcesJar(Path jar, Map<String, String> sources) throws Exception {
         try (var out = new JarOutputStream(Files.newOutputStream(jar))) {
             addJarEntry(out, "META-INF/plutus-sources/index.txt",

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
@@ -1,10 +1,18 @@
 package com.bloxbean.cardano.julc.compiler;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -276,5 +284,68 @@ class LibrarySourceResolverTest {
 
         assertNotNull(result);
         // May or may not be empty depending on test classpath, but should not throw
+    }
+
+    @Test
+    void scanClasspathSources_readsEveryIndexOnClasspath(@TempDir Path tempDir) throws Exception {
+        Path firstJar = createPlutusSourcesJar(tempDir.resolve("first.jar"), Map.of(
+                "com/example/FirstLib.java", "package com.example; class FirstLib {}"
+        ));
+        Path secondJar = createPlutusSourcesJar(tempDir.resolve("second.jar"), Map.of(
+                "com/example/SecondLib.java", "package com.example; class SecondLib {}"
+        ));
+
+        try (var classLoader = new URLClassLoader(new URL[]{
+                firstJar.toUri().toURL(),
+                secondJar.toUri().toURL()
+        }, null)) {
+            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+
+            assertEquals(2, result.size());
+            assertTrue(result.get("FirstLib").contains("class FirstLib"));
+            assertTrue(result.get("SecondLib").contains("class SecondLib"));
+        }
+    }
+
+    @Test
+    void scanClasspathSources_doesNotDiscoverJarSourcesWithoutIndex(@TempDir Path tempDir) throws Exception {
+        Path jar = tempDir.resolve("source-only.jar");
+        try (var out = new JarOutputStream(Files.newOutputStream(jar))) {
+            addJarDirectory(out, "META-INF/");
+            addJarDirectory(out, "META-INF/plutus-sources/");
+            addJarDirectory(out, "META-INF/plutus-sources/com/");
+            addJarDirectory(out, "META-INF/plutus-sources/com/example/");
+            addJarEntry(out,
+                    "META-INF/plutus-sources/com/example/SourceOnlyLib.java",
+                    "package com.example; class SourceOnlyLib {}");
+        }
+
+        try (var classLoader = new URLClassLoader(new URL[]{jar.toUri().toURL()}, null)) {
+            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    private static Path createPlutusSourcesJar(Path jar, Map<String, String> sources) throws Exception {
+        try (var out = new JarOutputStream(Files.newOutputStream(jar))) {
+            addJarEntry(out, "META-INF/plutus-sources/index.txt",
+                    String.join("\n", sources.keySet()) + "\n");
+            for (var entry : sources.entrySet()) {
+                addJarEntry(out, "META-INF/plutus-sources/" + entry.getKey(), entry.getValue());
+            }
+        }
+        return jar;
+    }
+
+    private static void addJarDirectory(JarOutputStream out, String name) throws Exception {
+        out.putNextEntry(new JarEntry(name));
+        out.closeEntry();
+    }
+
+    private static void addJarEntry(JarOutputStream out, String name, String content) throws Exception {
+        out.putNextEntry(new JarEntry(name));
+        out.write(content.getBytes(StandardCharsets.UTF_8));
+        out.closeEntry();
     }
 }

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
@@ -6,8 +6,11 @@ import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -41,6 +44,7 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
         Path metaInfDir = outDir.toPath().resolve("META-INF/plutus-sources");
 
         List<File> javaFiles = SourceScanner.findJavaFiles(srcDir);
+        List<String> bundledEntries = new ArrayList<>();
         int bundled = 0;
 
         for (File javaFile : javaFiles) {
@@ -52,9 +56,11 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
             // Compute relative path to preserve package structure
             Path relativePath = srcDir.toPath().relativize(javaFile.toPath());
             Path targetFile = metaInfDir.resolve(relativePath);
+            String indexEntry = relativePath.toString().replace(File.separatorChar, '/');
 
             Files.createDirectories(targetFile.getParent());
-            Files.writeString(targetFile, source);
+            Files.writeString(targetFile, source, StandardCharsets.UTF_8);
+            bundledEntries.add(indexEntry);
 
             getLogger().lifecycle("Bundled {} → META-INF/plutus-sources/{}",
                     javaFile.getName(), relativePath);
@@ -63,6 +69,12 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
 
         if (bundled == 0) {
             getLogger().lifecycle("No @OnchainLibrary sources found to bundle in {}", srcDir);
+        } else {
+            Collections.sort(bundledEntries);
+            Files.createDirectories(metaInfDir);
+            Files.writeString(metaInfDir.resolve("index.txt"),
+                    String.join("\n", bundledEntries) + "\n",
+                    StandardCharsets.UTF_8);
         }
     }
 

--- a/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
+++ b/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
@@ -1,0 +1,58 @@
+package com.bloxbean.cardano.julc.gradle;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BundleJulcSourcesTaskTest {
+
+    @Test
+    void bundleCopiesOnchainLibrarySourcesAndWritesIndex(@TempDir Path tempDir) throws Exception {
+        Path sourceDir = tempDir.resolve("src/main/java");
+        Path librarySource = sourceDir.resolve("com/example/Groth16BLS12381.java");
+        Files.createDirectories(librarySource.getParent());
+        Files.writeString(librarySource, """
+                package com.example;
+
+                import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+
+                @OnchainLibrary
+                public final class Groth16BLS12381 {
+                    private Groth16BLS12381() {}
+                }
+                """);
+
+        Path regularSource = sourceDir.resolve("com/example/OffchainHelper.java");
+        Files.writeString(regularSource, """
+                package com.example;
+
+                public final class OffchainHelper {}
+                """);
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        BundleJulcSourcesTask task = project.getTasks()
+                .create("bundleJulcSources", BundleJulcSourcesTask.class);
+        Path outputDir = tempDir.resolve("build/resources/main");
+        task.getSourceDir().set(sourceDir.toFile());
+        task.getOutputDir().set(outputDir.toFile());
+
+        task.bundle();
+
+        Path plutusSourcesDir = outputDir.resolve("META-INF/plutus-sources");
+        Path copiedSource = plutusSourcesDir.resolve("com/example/Groth16BLS12381.java");
+        assertTrue(Files.exists(copiedSource));
+        assertEquals(Files.readString(librarySource), Files.readString(copiedSource));
+        assertFalse(Files.exists(plutusSourcesDir.resolve("com/example/OffchainHelper.java")));
+        assertEquals(List.of("com/example/Groth16BLS12381.java"),
+                Files.readAllLines(plutusSourcesDir.resolve("index.txt")));
+    }
+}


### PR DESCRIPTION
## Summary

  Fixes JuLC on-chain library source discovery for dependency JARs that package sources under `META-INF/plutus-sources/`.

  This PR makes the Gradle plugin generate `META-INF/plutus-sources/index.txt` and updates the compiler resolver to read all matching indexes on the classpath instead of only the first one.

  ## Changes

  - Generate `META-INF/plutus-sources/index.txt` from `bundleJulcSources`.
  - Store index entries as paths relative to `META-INF/plutus-sources/`, e.g. `com/example/MyLib.java`.
  - Resolve every `META-INF/plutus-sources/index.txt` found via `ClassLoader.getResources(...)`.
  - Keep loose filesystem directory scanning for IDE/dev/test classpaths.
  - Document the source discovery contract in `adr/022-plutus-source-index-discovery.md`.
  - Add regression tests for:
    - Gradle task source copy and index generation.
    - Multiple indexed JARs on the classpath.
    - JARs without `index.txt` remaining unsupported.
    - Indexed JARs plus loose filesystem source directories.

  ## Known Follow-Up

  Library sources are still keyed by simple class name internally. If two packages contain the same library class name, the first discovered source wins. This is deferred to a separate Phase  2 PR for FQCN-aware library source resolution.

  ## Verification

  ```bash
  ./gradlew :julc-compiler:test --tests com.bloxbean.cardano.julc.compiler.LibrarySourceResolverTest
  ./gradlew :julc-gradle-plugin:test :julc-compiler:test
