### PR TITLE
Resolve JuLC library sources by fully qualified class name

### DIFF
--- a/adr/022-plutus-source-index-discovery.md
+++ b/adr/022-plutus-source-index-discovery.md
@@ -1,0 +1,48 @@
+# ADR-022: Plutus Source Index Discovery
+
+**Date**: 2026-05-18
+**Status**: Accepted
+
+---
+
+## Context
+
+JuLC libraries distribute `@OnchainLibrary` Java sources in dependency JARs under:
+
+```text
+META-INF/plutus-sources/
+```
+
+The compiler resolver needs those sources during annotation processing and direct compiler usage. JAR directory listing is not portable through `ClassLoader` APIs, so reliable JAR discovery requires a manifest:
+
+```text
+META-INF/plutus-sources/index.txt
+```
+
+The Gradle plugin previously copied source files but did not generate this index. The resolver also used `getResourceAsStream(...)`, which only reads the first matching `index.txt` on the classpath.
+
+## Decision
+
+1. `bundleJulcSources` generates `META-INF/plutus-sources/index.txt`.
+2. Each index entry is a path relative to `META-INF/plutus-sources/`, for example:
+
+```text
+com/example/Groth16BLS12381.java
+```
+
+3. The resolver reads every `META-INF/plutus-sources/index.txt` via `ClassLoader.getResources(...)`.
+4. JARs must ship `index.txt` for reliable source discovery.
+5. Loose file-system `META-INF/plutus-sources/` directories are still scanned without an index for IDE, test, and development classpaths.
+6. Indexed entries are loaded before loose file-system fallback entries. Existing `putIfAbsent` behavior means indexed entries win and loose directories fill gaps.
+
+## Consequences
+
+- Multiple dependency JARs can each contribute on-chain library sources.
+- The Gradle plugin now produces JARs that satisfy the resolver contract.
+- Hand-built JARs without `index.txt` remain unsupported for reliable discovery.
+- Existing development workflows that use exploded file-system resources continue to work.
+- The resolver still keys discovered libraries by simple class name. That can collide when two packages contain the same class name.
+
+## Follow-Up
+
+The simple-name collision issue should be fixed in a separate Phase 2 PR. That PR should migrate resolver internals and all call sites to an FQCN-aware `LibrarySource` model, remove the simple-name scan API, reject or fully support wildcard imports explicitly, and route ambiguity errors through the compiler diagnostic pipeline.

--- a/docs/src/content/docs/reference/library-developer-guide.md
+++ b/docs/src/content/docs/reference/library-developer-guide.md
@@ -50,6 +50,8 @@ public @interface OnchainLibrary {
 
 A library class must:
 - Be annotated with `@OnchainLibrary`.
+- Be a top-level class. Nested `@OnchainLibrary` classes are not supported by source discovery or JAR packaging.
+- Declare a package, and keep the source file under the matching package path.
 - Contain only `public static` methods.
 - Follow the supported Java subset (see Section 2.5 for details).
 
@@ -431,6 +433,7 @@ com/example/mylib/HelperLib.java
 ```
 
 This manifest enables reliable source discovery from both file-system directories and JAR archives.
+Each entry's path is also the library identity used by consumers: `com/example/mylib/TokenUtils.java` maps to `com.example.mylib.TokenUtils`. The declared package and top-level class name must match that path. The official Gradle plugin validates this and fails the build if the file is misplaced or the `@OnchainLibrary` annotation is on a nested class.
 
 **Example from the standard library (`julc-stdlib`):**
 

--- a/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
+++ b/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
@@ -4,9 +4,9 @@ import com.bloxbean.cardano.julc.blueprint.BlueprintConfig;
 import com.bloxbean.cardano.julc.blueprint.BlueprintGenerator;
 import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.clientlib.ValidatorOutput;
-import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.core.source.SourceMapSerializer;
@@ -64,11 +64,11 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
     /** Accumulated compiled validators for CIP-57 blueprint generation. */
     private final List<BlueprintGenerator.CompiledValidator> compiledValidators = new ArrayList<>();
 
-    /** Same-project @OnchainLibrary sources: simple name → source string */
-    private final Map<String, String> sameProjectLibraries = new LinkedHashMap<>();
+    /** Same-project @OnchainLibrary sources: FQCN -> source metadata */
+    private final Map<String, LibrarySource> sameProjectLibraries = new LinkedHashMap<>();
 
-    /** Classpath library sources: simple name → source string */
-    private final Map<String, String> classpathLibraries = new LinkedHashMap<>();
+    /** Classpath library sources: FQCN -> source metadata */
+    private final Map<String, LibrarySource> classpathLibraries = new LinkedHashMap<>();
 
     /** Whether classpath scanning has been done */
     private boolean classpathScanned = false;
@@ -132,7 +132,10 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
         for (Element element : roundEnv.getElementsAnnotatedWith(
                 findTypeElement("com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary"))) {
             String simpleName = element.getSimpleName().toString();
-            if (sameProjectLibraries.containsKey(simpleName)) {
+            String fqcn = element instanceof TypeElement typeElement
+                    ? typeElement.getQualifiedName().toString()
+                    : simpleName;
+            if (sameProjectLibraries.containsKey(fqcn)) {
                 continue;
             }
             try {
@@ -140,7 +143,7 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
                 if (path != null) {
                     String source = path.getCompilationUnit().getSourceFile()
                             .getCharContent(true).toString();
-                    sameProjectLibraries.put(simpleName, source);
+                    sameProjectLibraries.put(fqcn, LibrarySourceResolver.librarySourceFromSimpleName(simpleName, source));
                 }
             } catch (IOException e) {
                 processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
@@ -270,17 +273,6 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
         // Merge same-project + classpath into one pool (same-project takes precedence)
         var pool = new LinkedHashMap<>(classpathLibraries);
         pool.putAll(sameProjectLibraries);
-
-        // Add same-package libraries that aren't explicitly imported
-        String validatorPkg = LibrarySourceResolver.extractPackageName(validatorSource);
-        if (!validatorPkg.isEmpty()) {
-            for (var entry : sameProjectLibraries.entrySet()) {
-                String libPkg = LibrarySourceResolver.extractPackageName(entry.getValue());
-                if (validatorPkg.equals(libPkg)) {
-                    pool.put(entry.getKey(), entry.getValue());
-                }
-            }
-        }
 
         return LibrarySourceResolver.resolve(validatorSource, pool);
     }

--- a/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
+++ b/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
@@ -16,6 +16,7 @@ import com.sun.source.util.Trees;
 import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import javax.tools.StandardLocation;
@@ -131,10 +132,17 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
     private void collectSameProjectLibraries(RoundEnvironment roundEnv) {
         for (Element element : roundEnv.getElementsAnnotatedWith(
                 findTypeElement("com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary"))) {
-            String simpleName = element.getSimpleName().toString();
-            String fqcn = element instanceof TypeElement typeElement
-                    ? typeElement.getQualifiedName().toString()
-                    : simpleName;
+            if (!(element instanceof TypeElement typeElement)) {
+                continue;
+            }
+            String simpleName = typeElement.getSimpleName().toString();
+            if (typeElement.getNestingKind() != NestingKind.TOP_LEVEL) {
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                        "@OnchainLibrary must be declared on a top-level class. Nested on-chain libraries are not supported.",
+                        element);
+                continue;
+            }
+            String fqcn = typeElement.getQualifiedName().toString();
             if (sameProjectLibraries.containsKey(fqcn)) {
                 continue;
             }

--- a/julc-annotation-processor/src/test/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessorTest.java
+++ b/julc-annotation-processor/src/test/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessorTest.java
@@ -284,6 +284,38 @@ class JulcAnnotationProcessorTest {
                 () -> JulcScriptLoader.load(JulcAnnotationProcessorTest.class));
     }
 
+    @Test
+    void rejectsNestedOnchainLibrary() throws Exception {
+        var source = """
+                import com.bloxbean.cardano.julc.stdlib.annotation.*;
+                import java.math.BigInteger;
+
+                @Validator
+                class UsesNested {
+                    @Entrypoint
+                    static boolean validate(BigInteger redeemer, BigInteger ctx) {
+                        return true;
+                    }
+                }
+
+                class Outer {
+                    @OnchainLibrary
+                    static class Inner {
+                        public static boolean check() {
+                            return true;
+                        }
+                    }
+                }
+                """;
+
+        var result = compileWithProcessor(source, "UsesNested");
+
+        assertFalse(result.success(), "Nested @OnchainLibrary should be rejected");
+        assertTrue(result.diagnostics().stream()
+                        .anyMatch(diagnostic -> diagnostic.getMessage(null).contains("top-level class")),
+                "Expected top-level diagnostic, got: " + result.diagnostics());
+    }
+
     // --- Compilation infrastructure ---
 
     record CompileOutput(boolean success, List<Diagnostic<? extends JavaFileObject>> diagnostics) {}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/check/TestRunner.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/check/TestRunner.java
@@ -20,9 +20,9 @@ import java.util.Map;
 public final class TestRunner {
 
     private final JulcVm vm;
-    private final Map<String, String> libraryPool;
+    private final Map<String, ?> libraryPool;
 
-    public TestRunner(Map<String, String> libraryPool) {
+    public TestRunner(Map<String, ?> libraryPool) {
         this.vm = JulcVm.create();
         this.libraryPool = libraryPool;
     }

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/CheckCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/CheckCommand.java
@@ -4,6 +4,7 @@ import com.bloxbean.julc.cli.check.TestDiscovery;
 import com.bloxbean.julc.cli.check.TestReporter;
 import com.bloxbean.julc.cli.check.TestResult;
 import com.bloxbean.julc.cli.check.TestRunner;
+import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.julc.cli.mcp.lint.LintEngine;
 import com.bloxbean.julc.cli.mcp.lint.LintFinding;
 import com.bloxbean.julc.cli.output.AnsiColors;
@@ -58,7 +59,7 @@ public class CheckCommand implements Runnable {
             var srcScan = ProjectScanner.scan(ProjectLayout.srcDir(root));
             var pool = ProjectSourceResolver.buildPool(srcScan.libraries());
             // Also add src/ validators as libraries (tests may reference them)
-            pool.putAll(srcScan.validators());
+            LibrarySourceResolver.librarySourcesFrom(srcScan.validators()).forEach(pool::put);
 
             // Lint pass — runs across all .java sources in src/ and test/.
             boolean lintHadErrors = false;
@@ -83,7 +84,7 @@ public class CheckCommand implements Runnable {
             var results = new ArrayList<TestResult>();
             for (var test : tests) {
                 // Add the test source file itself to the pool temporarily
-                pool.put(test.className(), test.source());
+                LibrarySourceResolver.putLibrarySource(pool, test.className(), test.source());
                 results.add(runner.run(test));
             }
 

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/mcp/tools/TestTool.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/mcp/tools/TestTool.java
@@ -3,6 +3,7 @@ package com.bloxbean.julc.cli.mcp.tools;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.Term;
@@ -138,10 +139,10 @@ public final class TestTool {
         // Build the library pool for cross-source resolution. We pretend each
         // librarySource has a class name matching its declared class — same
         // shape TestRunner uses on disk.
-        Map<String, String> libraryPool = new LinkedHashMap<>();
+        Map<String, LibrarySource> libraryPool = new LinkedHashMap<>();
         for (var ls : librarySources) {
             String name = extractFirstClassName(ls);
-            if (name != null) libraryPool.put(name, ls);
+            if (name != null) LibrarySourceResolver.putLibrarySource(libraryPool, name, ls);
         }
         var resolvedLibs = LibrarySourceResolver.resolve(src, libraryPool);
         var vm = JulcVm.create();

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/project/ProjectScanner.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/project/ProjectScanner.java
@@ -1,5 +1,7 @@
 package com.bloxbean.julc.cli.project;
 
+import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,7 +24,7 @@ public final class ProjectScanner {
 
     public record ScanResult(
             Map<String, String> validators,  // simpleName -> source (.java validators)
-            Map<String, String> libraries,   // simpleName -> source (.java libraries)
+            Map<String, String> libraries,   // FQCN -> source (.java libraries)
             Map<String, String> jrlFiles     // simpleName -> source (.jrl files)
     ) {}
 
@@ -50,7 +52,7 @@ public final class ProjectScanner {
                                 if (VALIDATOR_PATTERN.matcher(source).find()) {
                                     validators.put(simpleName, source);
                                 } else {
-                                    libraries.put(simpleName, source);
+                                    libraries.put(libraryKey(simpleName, source), source);
                                 }
                             } else if (fileName.endsWith(".jrl")) {
                                 String source = Files.readString(p);
@@ -77,5 +79,11 @@ public final class ProjectScanner {
         if (source.contains("@VotingValidator")) return "PlutusScriptV3-Voting";
         if (source.contains("@ProposingValidator")) return "PlutusScriptV3-Proposing";
         return "PlutusScriptV3";
+    }
+
+    private static String libraryKey(String simpleName, String source) {
+        String packageName = LibrarySourceResolver.extractPackageName(source);
+        String className = LibrarySourceResolver.extractTopLevelTypeName(source).orElse(simpleName);
+        return packageName.isBlank() ? className : packageName + "." + className;
     }
 }

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/project/ProjectSourceResolver.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/project/ProjectSourceResolver.java
@@ -1,5 +1,6 @@
 package com.bloxbean.julc.cli.project;
 
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 
 import java.util.LinkedHashMap;
@@ -19,14 +20,14 @@ public final class ProjectSourceResolver {
      * @param userLibraries user library name->source map from ProjectScanner
      * @return merged library pool
      */
-    public static Map<String, String> buildPool(Map<String, String> userLibraries) {
+    public static Map<String, LibrarySource> buildPool(Map<String, String> userLibraries) {
         // 1. Classpath stdlib (META-INF/plutus-sources/ from julc-stdlib JAR)
         var pool = new LinkedHashMap<>(
                 LibrarySourceResolver.scanClasspathSources(
                         ProjectSourceResolver.class.getClassLoader()));
 
         // 2. User sources override classpath sources
-        pool.putAll(userLibraries);
+        LibrarySourceResolver.librarySourcesFrom(userLibraries).forEach(pool::put);
 
         return pool;
     }
@@ -38,7 +39,7 @@ public final class ProjectSourceResolver {
      * @param pool            the complete library pool
      * @return resolved library sources in dependency order
      */
-    public static List<String> resolve(String validatorSource, Map<String, String> pool) {
+    public static List<String> resolve(String validatorSource, Map<String, ?> pool) {
         return LibrarySourceResolver.resolve(validatorSource, pool);
     }
 }

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/MethodDocExtractor.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/MethodDocExtractor.java
@@ -1,5 +1,6 @@
 package com.bloxbean.julc.cli.repl;
 
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.julc.cli.output.AnsiColors;
 
 import java.util.*;
@@ -50,13 +51,16 @@ public final class MethodDocExtractor {
             Pattern.compile("(?:public\\s+)?class\\s+(\\w+)");
 
     /**
-     * Build the doc extractor from a library pool (className -> Java source).
+     * Build the doc extractor from a library pool (FQCN -> Java source metadata, or legacy className -> source).
      */
-    public MethodDocExtractor(Map<String, String> libraryPool) {
+    public MethodDocExtractor(Map<String, ?> libraryPool) {
         for (var entry : libraryPool.entrySet()) {
-            String className = entry.getKey();
-            String source = entry.getValue();
-            extractFromSource(className, source);
+            Object value = entry.getValue();
+            if (value instanceof LibrarySource librarySource) {
+                extractFromSource(librarySource.simpleName(), librarySource.source());
+            } else if (value instanceof String source) {
+                extractFromSource(simpleName(entry.getKey()), source);
+            }
         }
     }
 
@@ -125,6 +129,11 @@ public final class MethodDocExtractor {
         extractMethodDocs(className, source, methodNames);
 
         classDocs.put(className, new ClassDoc(className, classJavadoc, List.copyOf(methodNames)));
+    }
+
+    private static String simpleName(String name) {
+        int lastDot = name.lastIndexOf('.');
+        return lastDot < 0 ? name : name.substring(lastDot + 1);
     }
 
     private void extractMethodDocs(String className, String source, List<String> methodNames) {

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplCompleter.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplCompleter.java
@@ -60,12 +60,10 @@ public final class ReplCompleter implements Completer {
         // 2. From stdlib source files on classpath (MapLib, MathLib, ByteStringLib, etc.)
         var librarySources = LibrarySourceResolver.scanClasspathSources(
                 Thread.currentThread().getContextClassLoader());
-        for (var entry : librarySources.entrySet()) {
-            String className = entry.getKey();
-            String source = entry.getValue();
-            Set<String> methods = extractPublicStaticMethods(source);
+        for (var librarySource : librarySources.values()) {
+            Set<String> methods = extractPublicStaticMethods(librarySource.source());
             if (!methods.isEmpty()) {
-                methodsByClass.computeIfAbsent(className, k -> new TreeSet<>()).addAll(methods);
+                methodsByClass.computeIfAbsent(librarySource.simpleName(), k -> new TreeSet<>()).addAll(methods);
             }
         }
 

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplEngine.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplEngine.java
@@ -3,10 +3,10 @@ package com.bloxbean.julc.cli.repl;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
 import com.bloxbean.cardano.julc.core.PlutusData;
-import com.bloxbean.cardano.julc.core.text.UplcPrinter;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
@@ -26,7 +26,7 @@ public final class ReplEngine {
 
     private final JulcCompiler compiler;
     private final JulcVm vm;
-    private final Map<String, String> libraryPool;
+    private final Map<String, LibrarySource> libraryPool;
     private final MethodDocExtractor docExtractor;
     private final List<String> userImports = new ArrayList<>();
     private boolean showBudget = true;
@@ -274,10 +274,11 @@ public final class ReplEngine {
         methods.addAll(StdlibRegistry.defaultRegistry().methodsForClass(className));
 
         // Scan source file for public static methods
-        String source = libraryPool.get(className);
-        if (source != null) {
-            methods.addAll(ReplCompleter.extractPublicStaticMethods(source));
-        }
+        libraryPool.values().stream()
+                .filter(librarySource -> librarySource.simpleName().equals(className))
+                .findFirst()
+                .ifPresent(librarySource ->
+                        methods.addAll(ReplCompleter.extractPublicStaticMethods(librarySource.source())));
 
         if (methods.isEmpty()) {
             return new ReplResult.Error("No methods found for class: " + className);

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplEngine.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/repl/ReplEngine.java
@@ -32,10 +32,14 @@ public final class ReplEngine {
     private boolean showBudget = true;
 
     public ReplEngine() {
+        this(LibrarySourceResolver.scanClasspathSources(
+                Thread.currentThread().getContextClassLoader()));
+    }
+
+    ReplEngine(Map<String, LibrarySource> libraryPool) {
         this.compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
         this.vm = JulcVm.create();
-        this.libraryPool = LibrarySourceResolver.scanClasspathSources(
-                Thread.currentThread().getContextClassLoader());
+        this.libraryPool = new LinkedHashMap<>(libraryPool);
         this.docExtractor = new MethodDocExtractor(libraryPool);
     }
 
@@ -274,9 +278,15 @@ public final class ReplEngine {
         methods.addAll(StdlibRegistry.defaultRegistry().methodsForClass(className));
 
         // Scan source file for public static methods
-        libraryPool.values().stream()
-                .filter(librarySource -> librarySource.simpleName().equals(className))
-                .findFirst()
+        List<LibrarySource> matches = libraryPool.values().stream()
+                .filter(librarySource -> librarySource.fqcn().equals(className)
+                        || librarySource.simpleName().equals(className))
+                .toList();
+        if (!className.contains(".") && matches.size() > 1) {
+            return new ReplResult.Error("Ambiguous library class '" + className + "'. Use one of: "
+                    + matches.stream().map(LibrarySource::fqcn).sorted().toList());
+        }
+        matches.stream().findFirst()
                 .ifPresent(librarySource ->
                         methods.addAll(ReplCompleter.extractPublicStaticMethods(librarySource.source())));
 

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/JulcIntegrationTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/JulcIntegrationTest.java
@@ -11,6 +11,7 @@ import com.bloxbean.julc.cli.scaffold.ProjectScaffolder;
 import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -74,11 +75,11 @@ class JulcIntegrationTest {
         assertEquals(2, tests.size());
 
         var testPool = ProjectSourceResolver.buildPool(scanResult.libraries());
-        testPool.putAll(scanResult.validators());
+        LibrarySourceResolver.librarySourcesFrom(scanResult.validators()).forEach(testPool::put);
         var runner = new TestRunner(testPool);
 
         for (var test : tests) {
-            testPool.put(test.className(), test.source());
+            LibrarySourceResolver.putLibrarySource(testPool, test.className(), test.source());
             var testResult = runner.run(test);
             assertTrue(testResult.passed(), "Test " + test.methodName() + " should pass: " + testResult.error());
             assertTrue(testResult.budget().cpuSteps() > 0);
@@ -114,12 +115,12 @@ class JulcIntegrationTest {
         assertTrue(tests.stream().anyMatch(t -> t.className().equals("ContextTest")));
 
         var testPool = ProjectSourceResolver.buildPool(scanResult.libraries());
-        testPool.putAll(scanResult.validators());
+        LibrarySourceResolver.librarySourcesFrom(scanResult.validators()).forEach(testPool::put);
         var runner = new TestRunner(testPool);
 
         for (var test : tests) {
             if (test.className().equals("ContextTest")) {
-                testPool.put(test.className(), test.source());
+                LibrarySourceResolver.putLibrarySource(testPool, test.className(), test.source());
                 var result = runner.run(test);
                 assertTrue(result.passed(), "ContextTest should pass: " + result.error());
                 assertTrue(result.budget().cpuSteps() > 0);

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/project/ProjectScannerTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/project/ProjectScannerTest.java
@@ -34,6 +34,28 @@ class ProjectScannerTest {
     }
 
     @Test
+    void scanKeysLibrariesByFqcnToAvoidSimpleNameCollisions(@TempDir Path tempDir) throws IOException {
+        Path left = tempDir.resolve("com/left/Utils.java");
+        Path right = tempDir.resolve("com/right/Utils.java");
+        Files.createDirectories(left.getParent());
+        Files.createDirectories(right.getParent());
+        Files.writeString(left, """
+                package com.left;
+                public class Utils {}
+                """);
+        Files.writeString(right, """
+                package com.right;
+                public class Utils {}
+                """);
+
+        var result = ProjectScanner.scan(tempDir);
+
+        assertEquals(2, result.libraries().size());
+        assertTrue(result.libraries().containsKey("com.left.Utils"));
+        assertTrue(result.libraries().containsKey("com.right.Utils"));
+    }
+
+    @Test
     void scanDetectsAllAnnotations(@TempDir Path tempDir) throws IOException {
         String[] annotations = {
                 "@Validator", "@SpendingValidator", "@MintingPolicy",

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/project/ProjectSourceResolverTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/project/ProjectSourceResolverTest.java
@@ -13,14 +13,14 @@ class ProjectSourceResolverTest {
         var pool = ProjectSourceResolver.buildPool(Map.of());
         // Should include stdlib sources from classpath (ListsLib, MapLib, etc.)
         assertFalse(pool.isEmpty(), "Pool should include classpath stdlib sources");
-        assertTrue(pool.containsKey("ListsLib"), "Pool should contain ListsLib");
+        assertTrue(pool.containsKey("com.bloxbean.cardano.julc.stdlib.lib.ListsLib"), "Pool should contain ListsLib");
     }
 
     @Test
     void buildPoolUserSourcesOverrideClasspath() {
-        String customSource = "public class ListsLib { /* custom */ }";
+        String customSource = "package com.bloxbean.cardano.julc.stdlib.lib; public class ListsLib { /* custom */ }";
         var pool = ProjectSourceResolver.buildPool(Map.of("ListsLib", customSource));
-        assertEquals(customSource, pool.get("ListsLib"));
+        assertEquals(customSource, pool.get("com.bloxbean.cardano.julc.stdlib.lib.ListsLib").source());
     }
 
     @Test
@@ -40,7 +40,8 @@ class ProjectSourceResolverTest {
                 public class Util { }
                 """;
 
-        var pool = Map.of("Helper", helperSource, "Util", utilSource);
+        var pool = com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.librarySourcesFrom(
+                Map.of("Helper", helperSource, "Util", utilSource));
         var resolved = ProjectSourceResolver.resolve(validatorSource, pool);
         assertEquals(2, resolved.size());
     }

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/MethodDocExtractorTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/MethodDocExtractorTest.java
@@ -86,10 +86,10 @@ class MethodDocExtractorTest {
 
     @BeforeAll
     static void setup() {
-        extractor = new MethodDocExtractor(Map.of(
+        extractor = new MethodDocExtractor(com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.librarySourcesFrom(Map.of(
                 "MathLib", SAMPLE_SOURCE,
                 "MapLib", MAP_SOURCE,
-                "Bare", NO_JAVADOC_SOURCE));
+                "Bare", NO_JAVADOC_SOURCE)));
     }
 
     @Test
@@ -318,7 +318,7 @@ class MethodDocExtractorTest {
     void realLibraryPool_mathLibPow() {
         var pool = com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.scanClasspathSources(
                 Thread.currentThread().getContextClassLoader());
-        if (pool.containsKey("MathLib")) {
+        if (pool.values().stream().anyMatch(source -> source.simpleName().equals("MathLib"))) {
             var realExtractor = new MethodDocExtractor(pool);
             var doc = realExtractor.lookupMethod("MathLib.pow");
             assertNotNull(doc, "MathLib.pow should be found in real stdlib");
@@ -332,7 +332,7 @@ class MethodDocExtractorTest {
     void realLibraryPool_classDocExists() {
         var pool = com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.scanClasspathSources(
                 Thread.currentThread().getContextClassLoader());
-        if (pool.containsKey("MapLib")) {
+        if (pool.values().stream().anyMatch(source -> source.simpleName().equals("MapLib"))) {
             var realExtractor = new MethodDocExtractor(pool);
             var doc = realExtractor.lookupClass("MapLib");
             assertNotNull(doc);

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ReplEngineTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/repl/ReplEngineTest.java
@@ -1,7 +1,11 @@
 package com.bloxbean.julc.cli.repl;
 
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
+import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -122,6 +126,61 @@ class ReplEngineTest {
     void methodsCommand_noClassName_returnsError() {
         var result = engine.evaluate(":methods");
         assertInstanceOf(ReplResult.Error.class, result);
+    }
+
+    @Test
+    void methodsCommand_reportsAmbiguousLibrarySimpleName() {
+        var pool = new LinkedHashMap<String, LibrarySource>();
+        var left = LibrarySourceResolver.librarySource("""
+                package com.left;
+                public final class Utils {
+                    public static boolean leftOnly() { return true; }
+                }
+                """);
+        var right = LibrarySourceResolver.librarySource("""
+                package com.right;
+                public final class Utils {
+                    public static boolean rightOnly() { return true; }
+                }
+                """);
+        pool.put(left.fqcn(), left);
+        pool.put(right.fqcn(), right);
+        var localEngine = new ReplEngine(pool);
+
+        var result = localEngine.evaluate(":methods Utils");
+
+        assertInstanceOf(ReplResult.Error.class, result);
+        var message = ((ReplResult.Error) result).message();
+        assertTrue(message.contains("Ambiguous library class 'Utils'"));
+        assertTrue(message.contains("com.left.Utils"));
+        assertTrue(message.contains("com.right.Utils"));
+    }
+
+    @Test
+    void methodsCommand_acceptsFqcnForDuplicateLibrarySimpleName() {
+        var pool = new LinkedHashMap<String, LibrarySource>();
+        var left = LibrarySourceResolver.librarySource("""
+                package com.left;
+                public final class Utils {
+                    public static boolean leftOnly() { return true; }
+                }
+                """);
+        var right = LibrarySourceResolver.librarySource("""
+                package com.right;
+                public final class Utils {
+                    public static boolean rightOnly() { return true; }
+                }
+                """);
+        pool.put(left.fqcn(), left);
+        pool.put(right.fqcn(), right);
+        var localEngine = new ReplEngine(pool);
+
+        var result = localEngine.evaluate(":methods com.left.Utils");
+
+        assertInstanceOf(ReplResult.MetaOutput.class, result);
+        var text = ((ReplResult.MetaOutput) result).text();
+        assertTrue(text.contains("leftOnly"));
+        assertFalse(text.contains("rightOnly"));
     }
 
     @Test

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySource.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySource.java
@@ -1,0 +1,4 @@
+package com.bloxbean.cardano.julc.compiler;
+
+public record LibrarySource(String fqcn, String simpleName, String packageName, String resourcePath, String source) {
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.compiler;
 
 import java.io.*;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -22,6 +23,9 @@ import java.util.regex.Pattern;
  * {@code SourceDiscovery} (test-time) to avoid duplicating resolution logic.
  */
 public final class LibrarySourceResolver {
+
+    private static final String PLUTUS_SOURCES_DIR = "META-INF/plutus-sources/";
+    private static final String PLUTUS_SOURCES_INDEX = PLUTUS_SOURCES_DIR + "index.txt";
 
     /**
      * Regex matching Java import statements.
@@ -114,24 +118,15 @@ public final class LibrarySourceResolver {
      */
     public static Map<String, String> scanClasspathSources(ClassLoader classLoader) {
         var result = new LinkedHashMap<String, String>();
-        // Primary: use index.txt manifest (works with both file: and jar: protocols)
-        try (var indexStream = classLoader.getResourceAsStream("META-INF/plutus-sources/index.txt")) {
-            if (indexStream != null) {
-                var indexContent = new String(indexStream.readAllBytes(), StandardCharsets.UTF_8);
-                for (String entry : indexContent.split("\n")) {
-                    entry = entry.strip();
-                    if (entry.isEmpty() || !entry.endsWith(".java")) continue;
-                    var resourcePath = "META-INF/plutus-sources/" + entry;
-                    try (var sourceStream = classLoader.getResourceAsStream(resourcePath)) {
-                        if (sourceStream != null) {
-                            var source = new String(sourceStream.readAllBytes(), StandardCharsets.UTF_8);
-                            var fileName = entry.contains("/")
-                                    ? entry.substring(entry.lastIndexOf('/') + 1) : entry;
-                            var simpleName = fileName.replace(".java", "");
-                            result.putIfAbsent(simpleName, source);
-                        }
-                    }
-                }
+        // Primary: use every index.txt manifest (works with both file: and jar: protocols)
+        boolean foundIndex = false;
+        try {
+            var indexes = classLoader.getResources(PLUTUS_SOURCES_INDEX);
+            while (indexes.hasMoreElements()) {
+                foundIndex = true;
+                scanIndexedSources(indexes.nextElement(), result);
+            }
+            if (foundIndex) {
                 return result;
             }
         } catch (IOException e) {
@@ -139,7 +134,7 @@ public final class LibrarySourceResolver {
         }
         // Fallback: file-system directory scan (for development/IDE usage)
         try {
-            var resources = classLoader.getResources("META-INF/plutus-sources/");
+            var resources = classLoader.getResources(PLUTUS_SOURCES_DIR);
             while (resources.hasMoreElements()) {
                 URL resourceUrl = resources.nextElement();
                 if ("file".equals(resourceUrl.getProtocol())) {
@@ -150,6 +145,32 @@ public final class LibrarySourceResolver {
             // Silently ignore
         }
         return result;
+    }
+
+    private static void scanIndexedSources(URL indexUrl, Map<String, String> result) throws IOException {
+        try (var indexStream = indexUrl.openStream()) {
+            var indexContent = new String(indexStream.readAllBytes(), StandardCharsets.UTF_8);
+            for (String entry : indexContent.split("\n")) {
+                entry = entry.strip();
+                if (entry.isEmpty() || !entry.endsWith(".java")) continue;
+                try (var sourceStream = resolveIndexedSourceUrl(indexUrl, entry).openStream()) {
+                    var source = new String(sourceStream.readAllBytes(), StandardCharsets.UTF_8);
+                    var fileName = entry.contains("/")
+                            ? entry.substring(entry.lastIndexOf('/') + 1) : entry;
+                    var simpleName = fileName.replace(".java", "");
+                    result.putIfAbsent(simpleName, source);
+                }
+            }
+        }
+    }
+
+    private static URL resolveIndexedSourceUrl(URL indexUrl, String entry) throws IOException {
+        String indexPath = indexUrl.toExternalForm();
+        int lastSlash = indexPath.lastIndexOf('/');
+        if (lastSlash < 0) {
+            throw new IOException("Invalid source index URL: " + indexUrl);
+        }
+        return URI.create(indexPath.substring(0, lastSlash + 1) + entry).toURL();
     }
 
     private static void scanFileSystemSources(File dir, Map<String, String> result) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
@@ -1,11 +1,35 @@
 package com.bloxbean.cardano.julc.compiler;
 
-import java.io.*;
+import com.bloxbean.cardano.julc.compiler.error.DiagnosticCollector;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,12 +60,20 @@ public final class LibrarySourceResolver {
             "^\\s*import\\s+([a-zA-Z_][a-zA-Z0-9_.]*)\\.([A-Z][a-zA-Z0-9_]*)\\s*;",
             Pattern.MULTILINE);
 
+    public static final Pattern WILDCARD_IMPORT_PATTERN = Pattern.compile(
+            "^\\s*import\\s+([a-zA-Z_][a-zA-Z0-9_.]*)\\.\\*\\s*;",
+            Pattern.MULTILINE);
+
     /**
      * Regex matching Java package declarations.
      * Group 1 = the package name (e.g. {@code com.example.util}).
      */
     private static final Pattern PACKAGE_PATTERN = Pattern.compile(
             "^\\s*package\\s+([a-zA-Z_][a-zA-Z0-9_.]*);", Pattern.MULTILINE);
+
+    private static final Pattern TYPE_PATTERN = Pattern.compile(
+            "(?m)^\\s*(?:public\\s+)?(?:final\\s+|abstract\\s+|sealed\\s+|non-sealed\\s+)*" +
+                    "(?:class|record|interface|enum)\\s+([A-Z][a-zA-Z0-9_]*)");
 
     private LibrarySourceResolver() {}
 
@@ -106,6 +138,49 @@ public final class LibrarySourceResolver {
         return paths;
     }
 
+    public static Set<String> extractWildcardImportPackages(String source) {
+        var packages = new LinkedHashSet<String>();
+        Matcher matcher = WILDCARD_IMPORT_PATTERN.matcher(source);
+        while (matcher.find()) {
+            packages.add(matcher.group(1));
+        }
+        return packages;
+    }
+
+    public static LibrarySource librarySource(String source) {
+        return librarySourceFromSimpleName(null, source);
+    }
+
+    public static LibrarySource librarySourceFromSimpleName(String simpleName, String source) {
+        Objects.requireNonNull(source, "source");
+        String packageName = extractPackageName(source);
+        String resolvedSimpleName = simpleName == null || simpleName.isBlank()
+                ? extractTopLevelTypeName(source).orElseThrow(() ->
+                new IllegalArgumentException("Could not determine library class name from source"))
+                : simpleName(simpleName);
+        String fqcn = packageName.isBlank() ? resolvedSimpleName : packageName + "." + resolvedSimpleName;
+        String resourcePath = packageName.isBlank()
+                ? resolvedSimpleName + ".java"
+                : packageName.replace('.', '/') + "/" + resolvedSimpleName + ".java";
+        return new LibrarySource(fqcn, resolvedSimpleName, packageName, resourcePath, source);
+    }
+
+    public static Map<String, LibrarySource> librarySourcesFrom(Map<String, String> simpleNameToSource) {
+        var result = new LinkedHashMap<String, LibrarySource>();
+        simpleNameToSource.forEach((simpleName, source) -> putLibrarySource(result, simpleName, source));
+        return result;
+    }
+
+    public static void putLibrarySource(Map<String, LibrarySource> target, String simpleName, String source) {
+        LibrarySource librarySource;
+        try {
+            librarySource = librarySource(source);
+        } catch (IllegalArgumentException e) {
+            librarySource = librarySourceFromSimpleName(simpleName, source);
+        }
+        target.put(librarySource.fqcn(), librarySource);
+    }
+
     /**
      * Scan classpath for {@code META-INF/plutus-sources/} entries and collect
      * all {@code .java} files found within them.
@@ -114,14 +189,14 @@ public final class LibrarySourceResolver {
      * file-system directories and JAR archives.
      *
      * @param classLoader the classloader to scan
-     * @return map of simpleName to source code
+     * @return map of FQCN to source metadata
      */
-    public static Map<String, String> scanClasspathSources(ClassLoader classLoader) {
-        var result = new LinkedHashMap<String, String>();
+    public static Map<String, LibrarySource> scanClasspathSources(ClassLoader classLoader) {
+        var result = new LinkedHashMap<String, LibrarySource>();
         // JARs must ship index.txt for reliable discovery. Loose file-system
         // directories are also scanned to support IDE/dev/test classpaths.
         try {
-            var indexes = classLoader.getResources(PLUTUS_SOURCES_INDEX);
+            Enumeration<URL> indexes = classLoader.getResources(PLUTUS_SOURCES_INDEX);
             while (indexes.hasMoreElements()) {
                 scanIndexedSources(indexes.nextElement(), result);
             }
@@ -129,11 +204,12 @@ public final class LibrarySourceResolver {
             // Fall through to directory scan
         }
         try {
-            var resources = classLoader.getResources(PLUTUS_SOURCES_DIR);
+            Enumeration<URL> resources = classLoader.getResources(PLUTUS_SOURCES_DIR);
             while (resources.hasMoreElements()) {
                 URL resourceUrl = resources.nextElement();
                 if ("file".equals(resourceUrl.getProtocol())) {
-                    scanFileSystemSources(new File(resourceUrl.getPath()), result);
+                    File dir = new File(resourceUrl.getPath());
+                    scanFileSystemSources(dir, dir, result);
                 }
             }
         } catch (IOException e) {
@@ -142,18 +218,16 @@ public final class LibrarySourceResolver {
         return result;
     }
 
-    private static void scanIndexedSources(URL indexUrl, Map<String, String> result) throws IOException {
+    private static void scanIndexedSources(URL indexUrl, Map<String, LibrarySource> result) throws IOException {
         try (var indexStream = indexUrl.openStream()) {
             var indexContent = new String(indexStream.readAllBytes(), StandardCharsets.UTF_8);
-            for (String entry : indexContent.split("\n")) {
-                entry = entry.strip();
+            for (String rawEntry : indexContent.split("\n")) {
+                String entry = rawEntry.strip();
                 if (entry.isEmpty() || !entry.endsWith(".java")) continue;
                 try (var sourceStream = resolveIndexedSourceUrl(indexUrl, entry).openStream()) {
                     var source = new String(sourceStream.readAllBytes(), StandardCharsets.UTF_8);
-                    var fileName = entry.contains("/")
-                            ? entry.substring(entry.lastIndexOf('/') + 1) : entry;
-                    var simpleName = fileName.replace(".java", "");
-                    result.putIfAbsent(simpleName, source);
+                    var fqcn = fqcnFromResourcePath(entry);
+                    result.putIfAbsent(fqcn, librarySourceFromPath(fqcn, normalizeResourcePath(entry), source));
                 }
             }
         }
@@ -165,21 +239,29 @@ public final class LibrarySourceResolver {
         if (lastSlash < 0) {
             throw new IOException("Invalid source index URL: " + indexUrl);
         }
-        return URI.create(indexPath.substring(0, lastSlash + 1) + entry).toURL();
+        return URI.create(indexPath.substring(0, lastSlash + 1) + encodeResourcePath(entry)).toURL();
     }
 
-    private static void scanFileSystemSources(File dir, Map<String, String> result) {
+    private static String encodeResourcePath(String resourcePath) {
+        return Arrays.stream(resourcePath.split("/", -1))
+                .map(segment -> URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20"))
+                .reduce((left, right) -> left + "/" + right)
+                .orElse("");
+    }
+
+    private static void scanFileSystemSources(File root, File dir, Map<String, LibrarySource> result) {
         if (!dir.exists() || !dir.isDirectory()) return;
         File[] files = dir.listFiles();
         if (files == null) return;
         for (File file : files) {
             if (file.isDirectory()) {
-                scanFileSystemSources(file, result);
+                scanFileSystemSources(root, file, result);
             } else if (file.getName().endsWith(".java")) {
                 try {
                     String source = Files.readString(file.toPath());
-                    String simpleName = file.getName().replace(".java", "");
-                    result.putIfAbsent(simpleName, source);
+                    String resourcePath = normalizeResourcePath(root.toPath().relativize(file.toPath()).toString());
+                    String fqcn = fqcnFromResourcePath(resourcePath);
+                    result.putIfAbsent(fqcn, librarySourceFromPath(fqcn, resourcePath, source));
                 } catch (IOException e) {
                     // skip unreadable files
                 }
@@ -190,48 +272,269 @@ public final class LibrarySourceResolver {
     /**
      * Resolve library sources transitively from a pool of available libraries.
      * <p>
-     * Starting from the given source's imports, looks up each simple class name
-     * in the pool. For each match, adds the source and recursively resolves
-     * its imports until no new libraries are found.
+     * Starting from the given source's imports and static {@code ClassName.method()}
+     * references, looks up each library by fully qualified class name. Ambiguous
+     * unqualified references fail with a compiler diagnostic instead of picking an
+     * arbitrary classpath winner.
      *
      * @param source             the root source whose imports to resolve
-     * @param availableLibraries map of simpleName to source code
+     * @param availableLibraries map of FQCN to library source metadata
      * @return list of resolved library source strings (in discovery order)
      */
-    public static List<String> resolve(String source, Map<String, String> availableLibraries) {
-        var resolved = new LinkedHashMap<String, String>();
-        var toProcess = new ArrayDeque<>(extractImportedClassNames(source));
-        // Also seed from ClassName.method() references (same-package, no import needed)
-        toProcess.addAll(extractReferencedClassNames(source));
-        var seen = new HashSet<String>();
+    public static List<String> resolve(String source, Map<String, ?> availableLibraries) {
+        return resolveLibrarySources(source, normalizeLibrarySources(availableLibraries)).stream()
+                .map(LibrarySource::source)
+                .toList();
+    }
+
+    public static List<LibrarySource> resolveLibrarySources(String source, Map<String, LibrarySource> availableLibraries) {
+        if (availableLibraries.isEmpty()) {
+            return List.of();
+        }
+
+        var bySimpleName = indexBySimpleName(availableLibraries.values());
+        var diagnostics = new DiagnosticCollector("<source>");
+        var resolved = new LinkedHashMap<String, LibrarySource>();
+        var queued = new HashSet<String>();
+        Queue<LibrarySource> toProcess = new ArrayDeque<>();
+
+        enqueueReferencedLibraries(source, extractPackageName(source), "<source>", availableLibraries,
+                bySimpleName, resolved, queued, toProcess, diagnostics);
+        diagnostics.throwIfErrors();
 
         while (!toProcess.isEmpty()) {
-            String simpleName = toProcess.poll();
-            if (seen.contains(simpleName) || resolved.containsKey(simpleName)) {
+            LibrarySource librarySource = toProcess.poll();
+            if (resolved.containsKey(librarySource.fqcn())) {
                 continue;
             }
-            seen.add(simpleName);
-
-            String libSource = availableLibraries.get(simpleName);
-            if (libSource == null) {
-                continue;
-            }
-
-            resolved.put(simpleName, libSource);
-
-            // Transitively resolve both imports and referenced class names
-            for (String transitiveName : extractImportedClassNames(libSource)) {
-                if (!seen.contains(transitiveName) && !resolved.containsKey(transitiveName)) {
-                    toProcess.add(transitiveName);
-                }
-            }
-            for (String transitiveName : extractReferencedClassNames(libSource)) {
-                if (!seen.contains(transitiveName) && !resolved.containsKey(transitiveName)) {
-                    toProcess.add(transitiveName);
-                }
-            }
+            resolved.put(librarySource.fqcn(), librarySource);
+            enqueueReferencedLibraries(librarySource.source(), librarySource.packageName(), librarySource.resourcePath(),
+                    availableLibraries, bySimpleName, resolved, queued, toProcess, diagnostics);
+            diagnostics.throwIfErrors();
         }
 
         return new ArrayList<>(resolved.values());
+    }
+
+    private static void enqueueReferencedLibraries(String source,
+                                                   String packageName,
+                                                   String fileName,
+                                                   Map<String, LibrarySource> availableLibraries,
+                                                   Map<String, List<LibrarySource>> bySimpleName,
+                                                   Map<String, LibrarySource> resolved,
+                                                   Set<String> queued,
+                                                   Queue<LibrarySource> toProcess,
+                                                   DiagnosticCollector diagnostics) {
+        diagnostics.setFileName(fileName);
+        SourceContext context = parseSourceContext(source, packageName, diagnostics);
+
+        for (String fqcn : context.importsBySimpleName().values()) {
+            enqueue(availableLibraries.get(fqcn), resolved, queued, toProcess);
+        }
+
+        for (ClassReference reference : context.staticReferences()) {
+            LibrarySource librarySource = resolveStaticReference(reference, context.packageName(),
+                    context.importsBySimpleName(), context.wildcardPackages(),
+                    availableLibraries, bySimpleName, diagnostics);
+            enqueue(librarySource, resolved, queued, toProcess);
+        }
+    }
+
+    private static LibrarySource resolveStaticReference(ClassReference reference,
+                                                        String packageName,
+                                                        Map<String, String> importsBySimpleName,
+                                                        Set<String> wildcardPackages,
+                                                        Map<String, LibrarySource> availableLibraries,
+                                                        Map<String, List<LibrarySource>> bySimpleName,
+                                                        DiagnosticCollector diagnostics) {
+        if (reference.fqcn() != null) {
+            return availableLibraries.get(reference.fqcn());
+        }
+
+        String importedFqcn = importsBySimpleName.get(reference.simpleName());
+        if (importedFqcn != null) {
+            return availableLibraries.get(importedFqcn);
+        }
+
+        String samePackageFqcn = packageName.isBlank()
+                ? reference.simpleName()
+                : packageName + "." + reference.simpleName();
+        LibrarySource samePackageSource = availableLibraries.get(samePackageFqcn);
+        if (samePackageSource != null) {
+            return samePackageSource;
+        }
+
+        List<LibrarySource> wildcardCandidates = bySimpleName.getOrDefault(reference.simpleName(), List.of()).stream()
+                .filter(librarySource -> wildcardPackages.contains(librarySource.packageName()))
+                .toList();
+        if (wildcardCandidates.size() == 1) {
+            return wildcardCandidates.get(0);
+        }
+        if (wildcardCandidates.size() > 1) {
+            diagnostics.error(reference.node(),
+                    "Ambiguous on-chain library reference '" + reference.simpleName() + "'",
+                    "Add an explicit import for one of: " + wildcardCandidates.stream()
+                            .map(LibrarySource::fqcn)
+                            .sorted()
+                            .toList());
+            return null;
+        }
+
+        List<LibrarySource> candidates = bySimpleName.getOrDefault(reference.simpleName(), List.of());
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+        if (candidates.size() > 1) {
+            diagnostics.error(reference.node(),
+                    "Ambiguous on-chain library reference '" + reference.simpleName() + "'",
+                    "Add an explicit import for one of: " + candidates.stream()
+                            .map(LibrarySource::fqcn)
+                            .sorted()
+                            .toList());
+        }
+        return null;
+    }
+
+    private static void enqueue(LibrarySource librarySource,
+                                Map<String, LibrarySource> resolved,
+                                Set<String> queued,
+                                Queue<LibrarySource> toProcess) {
+        if (librarySource == null || resolved.containsKey(librarySource.fqcn()) || !queued.add(librarySource.fqcn())) {
+            return;
+        }
+        toProcess.add(librarySource);
+    }
+
+    private static SourceContext parseSourceContext(String source,
+                                                    String packageName,
+                                                    DiagnosticCollector diagnostics) {
+        try {
+            StaticJavaParser.getParserConfiguration()
+                    .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
+            var cu = StaticJavaParser.parse(source);
+            var resolvedPackageName = packageName == null || packageName.isBlank()
+                    ? cu.getPackageDeclaration().map(pd -> pd.getName().asString()).orElse("")
+                    : packageName;
+            var importsBySimpleName = new LinkedHashMap<String, String>();
+            var wildcardPackages = new LinkedHashSet<String>();
+            var staticReferences = new ArrayList<ClassReference>();
+
+            for (ImportDeclaration importDeclaration : cu.getImports()) {
+                if (importDeclaration.isAsterisk()) {
+                    if (!importDeclaration.isStatic()) {
+                        wildcardPackages.add(importDeclaration.getName().asString());
+                    }
+                    continue;
+                }
+                if (importDeclaration.isStatic()) {
+                    continue;
+                }
+                String fqcn = importDeclaration.getName().asString();
+                importsBySimpleName.put(simpleName(fqcn), fqcn);
+            }
+
+            cu.findAll(MethodCallExpr.class).forEach(methodCall -> methodCall.getScope().ifPresent(scope -> {
+                classReferenceFromScope(scope).ifPresent(staticReferences::add);
+            }));
+
+            return new SourceContext(resolvedPackageName, importsBySimpleName, wildcardPackages, staticReferences);
+        } catch (RuntimeException e) {
+            var fallbackPackageName = packageName == null ? extractPackageName(source) : packageName;
+            var staticReferences = extractReferencedClassNames(source).stream()
+                    .map(simpleName -> new ClassReference(simpleName, null, null))
+                    .toList();
+            return new SourceContext(fallbackPackageName, extractImportPaths(source),
+                    extractWildcardImportPackages(source), staticReferences);
+        }
+    }
+
+    private static Map<String, LibrarySource> normalizeLibrarySources(Map<String, ?> availableLibraries) {
+        var result = new LinkedHashMap<String, LibrarySource>();
+        for (var entry : availableLibraries.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof LibrarySource librarySource) {
+                result.put(librarySource.fqcn(), librarySource);
+            } else if (value instanceof String source) {
+                putLibrarySource(result, entry.getKey(), source);
+            } else if (value != null) {
+                throw new IllegalArgumentException("Unsupported library source value type: "
+                        + value.getClass().getName());
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, List<LibrarySource>> indexBySimpleName(Collection<LibrarySource> librarySources) {
+        var result = new HashMap<String, List<LibrarySource>>();
+        for (LibrarySource librarySource : librarySources) {
+            result.computeIfAbsent(librarySource.simpleName(), ignored -> new ArrayList<>()).add(librarySource);
+        }
+        result.replaceAll((ignored, sources) -> Collections.unmodifiableList(sources));
+        return result;
+    }
+
+    private static LibrarySource librarySourceFromPath(String fqcn, String resourcePath, String source) {
+        String simpleName = simpleName(fqcn);
+        String packageName = packageName(fqcn);
+        return new LibrarySource(fqcn, simpleName, packageName, resourcePath, source);
+    }
+
+    private static String fqcnFromResourcePath(String resourcePath) {
+        String normalized = normalizeResourcePath(resourcePath);
+        return normalized.substring(0, normalized.length() - ".java".length()).replace('/', '.');
+    }
+
+    public static Optional<String> extractTopLevelTypeName(String source) {
+        try {
+            StaticJavaParser.getParserConfiguration()
+                    .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
+            var cu = StaticJavaParser.parse(source);
+            if (!cu.getTypes().isEmpty()) {
+                return Optional.of(cu.getTypes().get(0).getNameAsString());
+            }
+        } catch (RuntimeException ignored) {
+            // Fall through to regex extraction for partial or otherwise unparsable source.
+        }
+        Matcher matcher = TYPE_PATTERN.matcher(source);
+        return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    }
+
+    private static String simpleName(String fqcn) {
+        int lastDot = fqcn.lastIndexOf('.');
+        return lastDot < 0 ? fqcn : fqcn.substring(lastDot + 1);
+    }
+
+    private static String packageName(String fqcn) {
+        int lastDot = fqcn.lastIndexOf('.');
+        return lastDot < 0 ? "" : fqcn.substring(0, lastDot);
+    }
+
+    private static boolean looksLikeClassName(String name) {
+        return !name.isBlank() && Character.isUpperCase(name.charAt(0));
+    }
+
+    private static Optional<ClassReference> classReferenceFromScope(Node scope) {
+        String scopeText = scope.toString();
+        String className = simpleName(scopeText);
+        if (!looksLikeClassName(className)) {
+            return Optional.empty();
+        }
+        String fqcn = scopeText.contains(".") && Character.isLowerCase(scopeText.charAt(0))
+                ? scopeText
+                : null;
+        return Optional.of(new ClassReference(className, fqcn, scope));
+    }
+
+    private static String normalizeResourcePath(String resourcePath) {
+        return resourcePath.replace(File.separatorChar, '/').replace('\\', '/');
+    }
+
+    private record SourceContext(String packageName,
+                                 Map<String, String> importsBySimpleName,
+                                 Set<String> wildcardPackages,
+                                 List<ClassReference> staticReferences) {
+    }
+
+    private record ClassReference(String simpleName, String fqcn, Node node) {
     }
 }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
@@ -118,21 +118,16 @@ public final class LibrarySourceResolver {
      */
     public static Map<String, String> scanClasspathSources(ClassLoader classLoader) {
         var result = new LinkedHashMap<String, String>();
-        // Primary: use every index.txt manifest (works with both file: and jar: protocols)
-        boolean foundIndex = false;
+        // JARs must ship index.txt for reliable discovery. Loose file-system
+        // directories are also scanned to support IDE/dev/test classpaths.
         try {
             var indexes = classLoader.getResources(PLUTUS_SOURCES_INDEX);
             while (indexes.hasMoreElements()) {
-                foundIndex = true;
                 scanIndexedSources(indexes.nextElement(), result);
-            }
-            if (foundIndex) {
-                return result;
             }
         } catch (IOException e) {
             // Fall through to directory scan
         }
-        // Fallback: file-system directory scan (for development/IDE usage)
         try {
             var resources = classLoader.getResources(PLUTUS_SOURCES_DIR);
             while (resources.hasMoreElements()) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolver.java
@@ -1,10 +1,12 @@
 package com.bloxbean.cardano.julc.compiler;
 
 import com.bloxbean.cardano.julc.compiler.error.DiagnosticCollector;
+import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParserConfiguration;
-import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 
 import java.io.File;
@@ -75,6 +77,10 @@ public final class LibrarySourceResolver {
             "(?m)^\\s*(?:public\\s+)?(?:final\\s+|abstract\\s+|sealed\\s+|non-sealed\\s+)*" +
                     "(?:class|record|interface|enum)\\s+([A-Z][a-zA-Z0-9_]*)");
 
+    private static final Pattern STATIC_REFERENCE_PATTERN = Pattern.compile(
+            "\\b(([a-z_][a-zA-Z0-9_]*\\.)*[A-Z][a-zA-Z0-9_]*(?:\\.[A-Z][a-zA-Z0-9_]*)*)" +
+                    "\\s*\\.\\s*[a-zA-Z_][a-zA-Z0-9_]*\\s*(?:\\(|\\b)");
+
     private LibrarySourceResolver() {}
 
     /**
@@ -104,18 +110,16 @@ public final class LibrarySourceResolver {
     }
 
     /**
-     * Extract class names referenced via {@code ClassName.method(} patterns.
+     * Extract class names referenced via static {@code ClassName.member} patterns.
      * This catches same-package references that don't require imports.
      *
      * @param source the Java source code
-     * @return set of simple class names referenced in static-call patterns
+     * @return set of simple class names referenced in static member patterns
      */
     public static Set<String> extractReferencedClassNames(String source) {
-        var pattern = Pattern.compile("\\b([A-Z][a-zA-Z0-9_]*)\\s*\\.\\s*[a-z_][a-zA-Z0-9_]*\\s*\\(");
         var result = new LinkedHashSet<String>();
-        var matcher = pattern.matcher(source);
-        while (matcher.find()) {
-            result.add(matcher.group(1));
+        for (ClassReference reference : extractFallbackClassReferences(source)) {
+            result.add(reference.simpleName());
         }
         return result;
     }
@@ -171,10 +175,16 @@ public final class LibrarySourceResolver {
         return result;
     }
 
+    /**
+     * Add a legacy string library source to an FQCN-keyed pool.
+     * <p>
+     * The source should declare its package. If it is intentionally package-less,
+     * pass an FQCN as {@code simpleName} so imports can still resolve it.
+     */
     public static void putLibrarySource(Map<String, LibrarySource> target, String simpleName, String source) {
         LibrarySource librarySource;
         try {
-            librarySource = librarySource(source);
+            librarySource = librarySourceFromLegacyKey(simpleName, source);
         } catch (IllegalArgumentException e) {
             librarySource = librarySourceFromSimpleName(simpleName, source);
         }
@@ -272,13 +282,14 @@ public final class LibrarySourceResolver {
     /**
      * Resolve library sources transitively from a pool of available libraries.
      * <p>
-     * Starting from the given source's imports and static {@code ClassName.method()}
+     * Starting from the given source's imports and static {@code ClassName.member}
      * references, looks up each library by fully qualified class name. Ambiguous
      * unqualified references fail with a compiler diagnostic instead of picking an
      * arbitrary classpath winner.
      *
      * @param source             the root source whose imports to resolve
-     * @param availableLibraries map of FQCN to library source metadata
+     * @param availableLibraries map of FQCN to library source metadata, or a legacy
+     *                           map of class name/FQCN to source string
      * @return list of resolved library source strings (in discovery order)
      */
     public static List<String> resolve(String source, Map<String, ?> availableLibraries) {
@@ -409,9 +420,7 @@ public final class LibrarySourceResolver {
                                                     String packageName,
                                                     DiagnosticCollector diagnostics) {
         try {
-            StaticJavaParser.getParserConfiguration()
-                    .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
-            var cu = StaticJavaParser.parse(source);
+            var cu = parseCompilationUnit(source);
             var resolvedPackageName = packageName == null || packageName.isBlank()
                     ? cu.getPackageDeclaration().map(pd -> pd.getName().asString()).orElse("")
                     : packageName;
@@ -436,13 +445,13 @@ public final class LibrarySourceResolver {
             cu.findAll(MethodCallExpr.class).forEach(methodCall -> methodCall.getScope().ifPresent(scope -> {
                 classReferenceFromScope(scope).ifPresent(staticReferences::add);
             }));
+            cu.findAll(FieldAccessExpr.class).forEach(fieldAccess ->
+                    classReferenceFromScope(fieldAccess.getScope()).ifPresent(staticReferences::add));
 
             return new SourceContext(resolvedPackageName, importsBySimpleName, wildcardPackages, staticReferences);
         } catch (RuntimeException e) {
             var fallbackPackageName = packageName == null ? extractPackageName(source) : packageName;
-            var staticReferences = extractReferencedClassNames(source).stream()
-                    .map(simpleName -> new ClassReference(simpleName, null, null))
-                    .toList();
+            var staticReferences = extractFallbackClassReferences(source);
             return new SourceContext(fallbackPackageName, extractImportPaths(source),
                     extractWildcardImportPackages(source), staticReferences);
         }
@@ -479,6 +488,22 @@ public final class LibrarySourceResolver {
         return new LibrarySource(fqcn, simpleName, packageName, resourcePath, source);
     }
 
+    private static LibrarySource librarySourceFromLegacyKey(String key, String source) {
+        Objects.requireNonNull(source, "source");
+        if (key == null || key.isBlank()) {
+            return librarySource(source);
+        }
+        String packageName = extractPackageName(source);
+        if (packageName.isBlank() && key.contains(".")) {
+            String fqcn = key;
+            String resolvedSimpleName = simpleName(fqcn);
+            String resolvedPackageName = packageName(fqcn);
+            String resourcePath = resolvedPackageName.replace('.', '/') + "/" + resolvedSimpleName + ".java";
+            return new LibrarySource(fqcn, resolvedSimpleName, resolvedPackageName, resourcePath, source);
+        }
+        return librarySource(source);
+    }
+
     private static String fqcnFromResourcePath(String resourcePath) {
         String normalized = normalizeResourcePath(resourcePath);
         return normalized.substring(0, normalized.length() - ".java".length()).replace('/', '.');
@@ -486,9 +511,7 @@ public final class LibrarySourceResolver {
 
     public static Optional<String> extractTopLevelTypeName(String source) {
         try {
-            StaticJavaParser.getParserConfiguration()
-                    .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
-            var cu = StaticJavaParser.parse(source);
+            var cu = parseCompilationUnit(source);
             if (!cu.getTypes().isEmpty()) {
                 return Optional.of(cu.getTypes().get(0).getNameAsString());
             }
@@ -497,6 +520,32 @@ public final class LibrarySourceResolver {
         }
         Matcher matcher = TYPE_PATTERN.matcher(source);
         return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    }
+
+    public static boolean hasTopLevelOnchainLibraryAnnotation(String source, String typeName) {
+        try {
+            var cu = parseCompilationUnit(source);
+            return cu.getTypes().stream()
+                    .filter(type -> type.getNameAsString().equals(typeName))
+                    .anyMatch(type -> type.getAnnotations().stream()
+                            .anyMatch(annotation -> "OnchainLibrary".equals(simpleName(annotation.getNameAsString()))));
+        } catch (RuntimeException ignored) {
+            String regex = "(?m)^\\s*@(?:[a-zA-Z_][a-zA-Z0-9_]*\\.)*OnchainLibrary(?:\\([^)]*\\))?\\s*" +
+                    "(?:public\\s+|protected\\s+|private\\s+|static\\s+|final\\s+|abstract\\s+|sealed\\s+|non-sealed\\s+)*" +
+                    "(?:class|record|interface|enum)\\s+" + Pattern.quote(typeName) + "\\b";
+            return Pattern.compile(regex).matcher(source).find();
+        }
+    }
+
+    private static CompilationUnit parseCompilationUnit(String source) {
+        var configuration = new ParserConfiguration()
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
+        var result = new JavaParser(configuration).parse(source);
+        if (!result.isSuccessful()) {
+            throw new IllegalArgumentException("Could not parse Java source: " + result.getProblems());
+        }
+        return result.getResult().orElseThrow(() ->
+                new IllegalArgumentException("Could not parse Java source: " + result.getProblems()));
     }
 
     private static String simpleName(String fqcn) {
@@ -515,6 +564,19 @@ public final class LibrarySourceResolver {
 
     private static Optional<ClassReference> classReferenceFromScope(Node scope) {
         String scopeText = scope.toString();
+        return classReferenceFromText(scopeText, scope);
+    }
+
+    private static List<ClassReference> extractFallbackClassReferences(String source) {
+        var result = new ArrayList<ClassReference>();
+        Matcher matcher = STATIC_REFERENCE_PATTERN.matcher(source);
+        while (matcher.find()) {
+            classReferenceFromText(matcher.group(1), null).ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private static Optional<ClassReference> classReferenceFromText(String scopeText, Node node) {
         String className = simpleName(scopeText);
         if (!looksLikeClassName(className)) {
             return Optional.empty();
@@ -522,7 +584,7 @@ public final class LibrarySourceResolver {
         String fqcn = scopeText.contains(".") && Character.isLowerCase(scopeText.charAt(0))
                 ? scopeText
                 : null;
-        return Optional.of(new ClassReference(className, fqcn, scope));
+        return Optional.of(new ClassReference(className, fqcn, node));
     }
 
     private static String normalizeResourcePath(String resourcePath) {

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
@@ -175,6 +175,26 @@ class LibrarySourceResolverTest {
     }
 
     @Test
+    void resolve_acceptsLegacyFqcnKeyForPackageLessSource() {
+        String validatorSource = """
+                import com.example.util.SumTest;
+
+                class MyValidator {
+                    static boolean validate() {
+                        return SumTest.check();
+                    }
+                }
+                """;
+
+        String sumTestSource = "class SumTest { static boolean check() { return true; } }";
+        Map<String, String> legacyPool = Map.of("com.example.util.SumTest", sumTestSource);
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, legacyPool);
+
+        assertEquals(List.of(sumTestSource), resolved);
+    }
+
+    @Test
     void extractPackageName_findsPackage() {
         String source = """
                 package com.example.validators;
@@ -442,6 +462,70 @@ class LibrarySourceResolverTest {
         var resolved = LibrarySourceResolver.resolve(validatorSource, pool(source));
 
         assertEquals(List.of(source), resolved);
+    }
+
+    @Test
+    void resolve_findsStaticFieldReference() {
+        String validatorSource = """
+                package com.example;
+
+                class MyValidator {
+                    static boolean validate() {
+                        return Constants.ALLOWED;
+                    }
+                }
+                """;
+
+        String source = """
+                package com.example;
+                class Constants { static final boolean ALLOWED = true; }
+                """;
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, pool(source));
+
+        assertEquals(List.of(source), resolved);
+    }
+
+    @Test
+    void resolve_findsFullyQualifiedStaticFieldReference() {
+        String validatorSource = """
+                class MyValidator {
+                    static boolean validate() {
+                        return com.left.Constants.ALLOWED;
+                    }
+                }
+                """;
+
+        String leftSource = """
+                package com.left;
+                class Constants { static final boolean ALLOWED = true; }
+                """;
+        String rightSource = """
+                package com.right;
+                class Constants { static final boolean ALLOWED = false; }
+                """;
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, pool(leftSource, rightSource));
+
+        assertEquals(List.of(leftSource), resolved);
+    }
+
+    @Test
+    void resolve_parseFallbackPreservesFullyQualifiedStaticCall() {
+        String validatorSource = """
+                class MyValidator {
+                    static boolean validate() {
+                        return com.left.Utils.check(;
+                    }
+                }
+                """;
+
+        String leftSource = "package com.left; class Utils { static boolean check() { return true; } }";
+        String rightSource = "package com.right; class Utils { static boolean check() { return false; } }";
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, pool(leftSource, rightSource));
+
+        assertEquals(List.of(leftSource), resolved);
     }
 
     @Test

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
@@ -8,7 +8,7 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -74,10 +74,9 @@ class LibrarySourceResolverTest {
                 class MyValidator {}
                 """;
 
-        String sumTestSource = "class SumTest { static int sum(int a, int b) { return a + b; } }";
+        String sumTestSource = "package com.example.util; class SumTest { static int sum(int a, int b) { return a + b; } }";
 
-        Map<String, String> pool = new LinkedHashMap<>();
-        pool.put("SumTest", sumTestSource);
+        Map<String, LibrarySource> pool = pool(sumTestSource);
 
         var resolved = LibrarySourceResolver.resolve(validatorSource, pool);
 
@@ -95,16 +94,18 @@ class LibrarySourceResolverTest {
                 """;
 
         String mathUtilsSource = """
+                package com.example.util;
                 import com.example.util.Helper;
 
                 class MathUtils { static int max(int a, int b) { return Helper.compare(a, b); } }
                 """;
 
-        String helperSource = "class Helper { static int compare(int a, int b) { return a > b ? a : b; } }";
+        String helperSource = """
+                package com.example.util;
+                class Helper { static int compare(int a, int b) { return a > b ? a : b; } }
+                """;
 
-        Map<String, String> pool = new LinkedHashMap<>();
-        pool.put("MathUtils", mathUtilsSource);
-        pool.put("Helper", helperSource);
+        Map<String, LibrarySource> pool = pool(mathUtilsSource, helperSource);
 
         var resolved = LibrarySourceResolver.resolve(validatorSource, pool);
 
@@ -124,14 +125,11 @@ class LibrarySourceResolverTest {
                 """;
 
         // Both A and B depend on C
-        String aSource = "import com.example.C;\nclass A {}";
-        String bSource = "import com.example.C;\nclass B {}";
-        String cSource = "class C {}";
+        String aSource = "package com.example;\nimport com.example.C;\nclass A {}";
+        String bSource = "package com.example;\nimport com.example.C;\nclass B {}";
+        String cSource = "package com.example;\nclass C {}";
 
-        Map<String, String> pool = new LinkedHashMap<>();
-        pool.put("A", aSource);
-        pool.put("B", bSource);
-        pool.put("C", cSource);
+        Map<String, LibrarySource> pool = pool(aSource, bSource, cSource);
 
         var resolved = LibrarySourceResolver.resolve(validatorSource, pool);
 
@@ -151,12 +149,29 @@ class LibrarySourceResolverTest {
                 class MyValidator {}
                 """;
 
-        Map<String, String> pool = new LinkedHashMap<>();
+        Map<String, LibrarySource> pool = Map.of();
         // Pool is empty — no libraries available
 
         var resolved = LibrarySourceResolver.resolve(validatorSource, pool);
 
         assertTrue(resolved.isEmpty());
+    }
+
+    @Test
+    void resolve_acceptsLegacyStringSourcePool() {
+        String validatorSource = """
+                import com.example.util.SumTest;
+
+                @Validator
+                class MyValidator {}
+                """;
+
+        String sumTestSource = "package com.example.util; class SumTest {}";
+        Map<String, String> legacyPool = Map.of("SumTest", sumTestSource);
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, legacyPool);
+
+        assertEquals(List.of(sumTestSource), resolved);
     }
 
     @Test
@@ -235,8 +250,7 @@ class LibrarySourceResolverTest {
                 }
                 """;
 
-        Map<String, String> pool = new LinkedHashMap<>();
-        pool.put("MathLib", mathLibSource);
+        Map<String, LibrarySource> pool = pool(mathLibSource);
 
         var resolved = LibrarySourceResolver.resolve(validatorSource, pool);
 
@@ -267,9 +281,7 @@ class LibrarySourceResolverTest {
                 }
                 """;
 
-        Map<String, String> pool = new LinkedHashMap<>();
-        pool.put("A", aSource);
-        pool.put("B", bSource);
+        Map<String, LibrarySource> pool = pool(aSource, bSource);
 
         var resolved = LibrarySourceResolver.resolve(validatorSource, pool);
 
@@ -299,11 +311,11 @@ class LibrarySourceResolverTest {
                 firstJar.toUri().toURL(),
                 secondJar.toUri().toURL()
         }, null)) {
-            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+            Map<String, LibrarySource> result = LibrarySourceResolver.scanClasspathSources(classLoader);
 
             assertEquals(2, result.size());
-            assertTrue(result.get("FirstLib").contains("class FirstLib"));
-            assertTrue(result.get("SecondLib").contains("class SecondLib"));
+            assertTrue(result.get("com.example.FirstLib").source().contains("class FirstLib"));
+            assertTrue(result.get("com.example.SecondLib").source().contains("class SecondLib"));
         }
     }
 
@@ -321,7 +333,7 @@ class LibrarySourceResolverTest {
         }
 
         try (var classLoader = new URLClassLoader(new URL[]{jar.toUri().toURL()}, null)) {
-            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+            Map<String, LibrarySource> result = LibrarySourceResolver.scanClasspathSources(classLoader);
 
             assertTrue(result.isEmpty());
         }
@@ -346,14 +358,130 @@ class LibrarySourceResolverTest {
                 jar.toUri().toURL(),
                 classesDir.toUri().toURL()
         }, null)) {
-            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+            Map<String, LibrarySource> result = LibrarySourceResolver.scanClasspathSources(classLoader);
 
             assertEquals(3, result.size());
-            assertTrue(result.get("SharedLib").contains("fromJar"));
-            assertFalse(result.get("SharedLib").contains("fromLooseDir"));
-            assertTrue(result.get("IndexedOnlyLib").contains("class IndexedOnlyLib"));
-            assertTrue(result.get("LooseOnlyLib").contains("class LooseOnlyLib"));
+            assertTrue(result.get("com.example.SharedLib").source().contains("fromJar"));
+            assertFalse(result.get("com.example.SharedLib").source().contains("fromLooseDir"));
+            assertTrue(result.get("com.example.IndexedOnlyLib").source().contains("class IndexedOnlyLib"));
+            assertTrue(result.get("com.example.LooseOnlyLib").source().contains("class LooseOnlyLib"));
         }
+    }
+
+    @Test
+    void resolve_usesExplicitImportToDisambiguateDuplicateSimpleNames() {
+        String validatorSource = """
+                import com.left.Utils;
+
+                class MyValidator {
+                    static boolean validate() {
+                        return Utils.check();
+                    }
+                }
+                """;
+
+        String leftSource = """
+                package com.left;
+                class Utils { static boolean check() { return true; } }
+                """;
+        String rightSource = """
+                package com.right;
+                class Utils { static boolean check() { return false; } }
+                """;
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, pool(leftSource, rightSource));
+
+        assertEquals(1, resolved.size());
+        assertEquals(leftSource, resolved.get(0));
+    }
+
+    @Test
+    void resolve_explicitImportWinsOverSamePackageSimpleName() {
+        String validatorSource = """
+                package com.validator;
+
+                import com.left.Utils;
+
+                class MyValidator {
+                    static boolean validate() {
+                        return Utils.check();
+                    }
+                }
+                """;
+
+        String leftSource = """
+                package com.left;
+                class Utils { static boolean check() { return true; } }
+                """;
+        String samePackageSource = """
+                package com.validator;
+                class Utils { static boolean check() { return false; } }
+                """;
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, pool(leftSource, samePackageSource));
+
+        assertEquals(1, resolved.size());
+        assertEquals(leftSource, resolved.get(0));
+    }
+
+    @Test
+    void resolve_findsFullyQualifiedStaticCall() {
+        String validatorSource = """
+                class MyValidator {
+                    static boolean validate() {
+                        return com.example.Utils.check();
+                    }
+                }
+                """;
+
+        String source = """
+                package com.example;
+                class Utils { static boolean check() { return true; } }
+                """;
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, pool(source));
+
+        assertEquals(List.of(source), resolved);
+    }
+
+    @Test
+    void resolve_reportsAmbiguousUnqualifiedSimpleName() {
+        String validatorSource = """
+                class MyValidator {
+                    static boolean validate() {
+                        return Utils.check();
+                    }
+                }
+                """;
+
+        String leftSource = "package com.left; class Utils { static boolean check() { return true; } }";
+        String rightSource = "package com.right; class Utils { static boolean check() { return false; } }";
+
+        CompilerException ex = assertThrows(CompilerException.class,
+                () -> LibrarySourceResolver.resolve(validatorSource, pool(leftSource, rightSource)));
+
+        assertTrue(ex.getMessage().contains("Ambiguous on-chain library reference 'Utils'"));
+        assertTrue(ex.getMessage().contains("com.left.Utils"));
+        assertTrue(ex.getMessage().contains("com.right.Utils"));
+    }
+
+    @Test
+    void resolve_supportsWildcardImportsAsPackageScan() {
+        String validatorSource = """
+                import com.example.*;
+
+                class MyValidator {
+                    static boolean validate() {
+                        return Utils.check();
+                    }
+                }
+                """;
+
+        String source = "package com.example; class Utils { static boolean check() { return true; } }";
+
+        var resolved = LibrarySourceResolver.resolve(validatorSource, pool(source));
+
+        assertEquals(List.of(source), resolved);
     }
 
     private static Path createPlutusSourcesJar(Path jar, Map<String, String> sources) throws Exception {
@@ -376,5 +504,14 @@ class LibrarySourceResolverTest {
         out.putNextEntry(new JarEntry(name));
         out.write(content.getBytes(StandardCharsets.UTF_8));
         out.closeEntry();
+    }
+
+    private static Map<String, LibrarySource> pool(String... sources) {
+        var pool = new java.util.LinkedHashMap<String, LibrarySource>();
+        for (String source : sources) {
+            LibrarySource librarySource = LibrarySourceResolver.librarySource(source);
+            pool.put(librarySource.fqcn(), librarySource);
+        }
+        return pool;
     }
 }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
@@ -327,6 +327,35 @@ class LibrarySourceResolverTest {
         }
     }
 
+    @Test
+    void scanClasspathSources_readsIndexedJarsAndLooseFilesystemDirs(@TempDir Path tempDir) throws Exception {
+        Path jar = createPlutusSourcesJar(tempDir.resolve("indexed.jar"), Map.of(
+                "com/example/SharedLib.java", "package com.example; class SharedLib { static int fromJar() { return 1; } }",
+                "com/example/IndexedOnlyLib.java", "package com.example; class IndexedOnlyLib {}"
+        ));
+
+        Path classesDir = tempDir.resolve("classes");
+        Path looseSourcesDir = classesDir.resolve("META-INF/plutus-sources/com/example");
+        Files.createDirectories(looseSourcesDir);
+        Files.writeString(looseSourcesDir.resolve("SharedLib.java"),
+                "package com.example; class SharedLib { static int fromLooseDir() { return 2; } }");
+        Files.writeString(looseSourcesDir.resolve("LooseOnlyLib.java"),
+                "package com.example; class LooseOnlyLib {}");
+
+        try (var classLoader = new URLClassLoader(new URL[]{
+                jar.toUri().toURL(),
+                classesDir.toUri().toURL()
+        }, null)) {
+            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+
+            assertEquals(3, result.size());
+            assertTrue(result.get("SharedLib").contains("fromJar"));
+            assertFalse(result.get("SharedLib").contains("fromLooseDir"));
+            assertTrue(result.get("IndexedOnlyLib").contains("class IndexedOnlyLib"));
+            assertTrue(result.get("LooseOnlyLib").contains("class LooseOnlyLib"));
+        }
+    }
+
     private static Path createPlutusSourcesJar(Path jar, Map<String, String> sources) throws Exception {
         try (var out = new JarOutputStream(Files.newOutputStream(jar))) {
             addJarEntry(out, "META-INF/plutus-sources/index.txt",

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LibrarySourceResolverTest.java
@@ -1,10 +1,18 @@
 package com.bloxbean.cardano.julc.compiler;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -276,5 +284,68 @@ class LibrarySourceResolverTest {
 
         assertNotNull(result);
         // May or may not be empty depending on test classpath, but should not throw
+    }
+
+    @Test
+    void scanClasspathSources_readsEveryIndexOnClasspath(@TempDir Path tempDir) throws Exception {
+        Path firstJar = createPlutusSourcesJar(tempDir.resolve("first.jar"), Map.of(
+                "com/example/FirstLib.java", "package com.example; class FirstLib {}"
+        ));
+        Path secondJar = createPlutusSourcesJar(tempDir.resolve("second.jar"), Map.of(
+                "com/example/SecondLib.java", "package com.example; class SecondLib {}"
+        ));
+
+        try (var classLoader = new URLClassLoader(new URL[]{
+                firstJar.toUri().toURL(),
+                secondJar.toUri().toURL()
+        }, null)) {
+            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+
+            assertEquals(2, result.size());
+            assertTrue(result.get("FirstLib").contains("class FirstLib"));
+            assertTrue(result.get("SecondLib").contains("class SecondLib"));
+        }
+    }
+
+    @Test
+    void scanClasspathSources_doesNotDiscoverJarSourcesWithoutIndex(@TempDir Path tempDir) throws Exception {
+        Path jar = tempDir.resolve("source-only.jar");
+        try (var out = new JarOutputStream(Files.newOutputStream(jar))) {
+            addJarDirectory(out, "META-INF/");
+            addJarDirectory(out, "META-INF/plutus-sources/");
+            addJarDirectory(out, "META-INF/plutus-sources/com/");
+            addJarDirectory(out, "META-INF/plutus-sources/com/example/");
+            addJarEntry(out,
+                    "META-INF/plutus-sources/com/example/SourceOnlyLib.java",
+                    "package com.example; class SourceOnlyLib {}");
+        }
+
+        try (var classLoader = new URLClassLoader(new URL[]{jar.toUri().toURL()}, null)) {
+            Map<String, String> result = LibrarySourceResolver.scanClasspathSources(classLoader);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    private static Path createPlutusSourcesJar(Path jar, Map<String, String> sources) throws Exception {
+        try (var out = new JarOutputStream(Files.newOutputStream(jar))) {
+            addJarEntry(out, "META-INF/plutus-sources/index.txt",
+                    String.join("\n", sources.keySet()) + "\n");
+            for (var entry : sources.entrySet()) {
+                addJarEntry(out, "META-INF/plutus-sources/" + entry.getKey(), entry.getValue());
+            }
+        }
+        return jar;
+    }
+
+    private static void addJarDirectory(JarOutputStream out, String name) throws Exception {
+        out.putNextEntry(new JarEntry(name));
+        out.closeEntry();
+    }
+
+    private static void addJarEntry(JarOutputStream out, String name, String content) throws Exception {
+        out.putNextEntry(new JarEntry(name));
+        out.write(content.getBytes(StandardCharsets.UTF_8));
+        out.closeEntry();
     }
 }

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
@@ -6,8 +6,11 @@ import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -41,6 +44,7 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
         Path metaInfDir = outDir.toPath().resolve("META-INF/plutus-sources");
 
         List<File> javaFiles = SourceScanner.findJavaFiles(srcDir);
+        List<String> bundledEntries = new ArrayList<>();
         int bundled = 0;
 
         for (File javaFile : javaFiles) {
@@ -52,9 +56,11 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
             // Compute relative path to preserve package structure
             Path relativePath = srcDir.toPath().relativize(javaFile.toPath());
             Path targetFile = metaInfDir.resolve(relativePath);
+            String indexEntry = relativePath.toString().replace(File.separatorChar, '/');
 
             Files.createDirectories(targetFile.getParent());
-            Files.writeString(targetFile, source);
+            Files.writeString(targetFile, source, StandardCharsets.UTF_8);
+            bundledEntries.add(indexEntry);
 
             getLogger().lifecycle("Bundled {} → META-INF/plutus-sources/{}",
                     javaFile.getName(), relativePath);
@@ -63,6 +69,12 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
 
         if (bundled == 0) {
             getLogger().lifecycle("No @OnchainLibrary sources found to bundle in {}", srcDir);
+        } else {
+            Collections.sort(bundledEntries);
+            Files.createDirectories(metaInfDir);
+            Files.writeString(metaInfDir.resolve("index.txt"),
+                    String.join("\n", bundledEntries) + "\n",
+                    StandardCharsets.UTF_8);
         }
     }
 

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.julc.gradle;
 
+import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.tasks.*;
 
@@ -45,7 +47,6 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
 
         List<File> javaFiles = SourceScanner.findJavaFiles(srcDir);
         List<String> bundledEntries = new ArrayList<>();
-        int bundled = 0;
 
         for (File javaFile : javaFiles) {
             String source = Files.readString(javaFile.toPath());
@@ -57,6 +58,7 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
             Path relativePath = srcDir.toPath().relativize(javaFile.toPath());
             Path targetFile = metaInfDir.resolve(relativePath);
             String indexEntry = relativePath.toString().replace(File.separatorChar, '/');
+            validatePackageMatchesPath(javaFile, source, indexEntry);
 
             Files.createDirectories(targetFile.getParent());
             Files.writeString(targetFile, source, StandardCharsets.UTF_8);
@@ -64,10 +66,9 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
 
             getLogger().lifecycle("Bundled {} → META-INF/plutus-sources/{}",
                     javaFile.getName(), relativePath);
-            bundled++;
         }
 
-        if (bundled == 0) {
+        if (bundledEntries.isEmpty()) {
             getLogger().lifecycle("No @OnchainLibrary sources found to bundle in {}", srcDir);
         } else {
             Collections.sort(bundledEntries);
@@ -75,6 +76,27 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
             Files.writeString(metaInfDir.resolve("index.txt"),
                     String.join("\n", bundledEntries) + "\n",
                     StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void validatePackageMatchesPath(File javaFile, String source, String indexEntry) {
+        String packageName = LibrarySourceResolver.extractPackageName(source);
+        String fileClassName = javaFile.getName().replace(".java", "");
+        String sourceClassName = LibrarySourceResolver.extractTopLevelTypeName(source)
+                .orElseThrow(() -> new GradleException("Could not determine @OnchainLibrary class name in " + javaFile));
+        if (!fileClassName.equals(sourceClassName)) {
+            throw new GradleException("@OnchainLibrary class/path mismatch for " + javaFile
+                    + ": source declares " + sourceClassName
+                    + " but source path is " + indexEntry);
+        }
+
+        String expectedEntry = packageName.isBlank()
+                ? javaFile.getName()
+                : packageName.replace('.', '/') + "/" + javaFile.getName();
+        if (!expectedEntry.equals(indexEntry)) {
+            throw new GradleException("@OnchainLibrary package/path mismatch for " + javaFile
+                    + ": declared package expects " + expectedEntry
+                    + " but source path is " + indexEntry);
         }
     }
 

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTask.java
@@ -84,6 +84,10 @@ public abstract class BundleJulcSourcesTask extends DefaultTask {
         String fileClassName = javaFile.getName().replace(".java", "");
         String sourceClassName = LibrarySourceResolver.extractTopLevelTypeName(source)
                 .orElseThrow(() -> new GradleException("Could not determine @OnchainLibrary class name in " + javaFile));
+        if (!LibrarySourceResolver.hasTopLevelOnchainLibraryAnnotation(source, sourceClassName)) {
+            throw new GradleException("@OnchainLibrary must be declared on the top-level class in " + javaFile
+                    + ". Nested on-chain libraries are not supported.");
+        }
         if (!fileClassName.equals(sourceClassName)) {
             throw new GradleException("@OnchainLibrary class/path mismatch for " + javaFile
                     + ": source declares " + sourceClassName

--- a/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
+++ b/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.gradle;
 
 import org.gradle.api.Project;
+import org.gradle.api.GradleException;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -54,5 +55,63 @@ class BundleJulcSourcesTaskTest {
         assertFalse(Files.exists(plutusSourcesDir.resolve("com/example/OffchainHelper.java")));
         assertEquals(List.of("com/example/Groth16BLS12381.java"),
                 Files.readAllLines(plutusSourcesDir.resolve("index.txt")));
+    }
+
+    @Test
+    void bundleFailsWhenDeclaredPackageDoesNotMatchPath(@TempDir Path tempDir) throws Exception {
+        Path sourceDir = tempDir.resolve("src/main/java");
+        Path librarySource = sourceDir.resolve("com/wrong/Groth16BLS12381.java");
+        Files.createDirectories(librarySource.getParent());
+        Files.writeString(librarySource, """
+                package com.example;
+
+                import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+
+                @OnchainLibrary
+                public final class Groth16BLS12381 {
+                    private Groth16BLS12381() {}
+                }
+                """);
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        BundleJulcSourcesTask task = project.getTasks()
+                .create("bundleJulcSources", BundleJulcSourcesTask.class);
+        task.getSourceDir().set(sourceDir.toFile());
+        task.getOutputDir().set(tempDir.resolve("build/resources/main").toFile());
+
+        GradleException ex = assertThrows(GradleException.class, task::bundle);
+        assertTrue(ex.getMessage().contains("package/path mismatch"));
+        assertTrue(ex.getMessage().contains("com/example/Groth16BLS12381.java"));
+    }
+
+    @Test
+    void bundleFailsWhenDeclaredClassDoesNotMatchPath(@TempDir Path tempDir) throws Exception {
+        Path sourceDir = tempDir.resolve("src/main/java");
+        Path librarySource = sourceDir.resolve("com/example/Groth16BLS12381.java");
+        Files.createDirectories(librarySource.getParent());
+        Files.writeString(librarySource, """
+                package com.example;
+
+                import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+
+                @OnchainLibrary
+                final class DifferentName {
+                    private DifferentName() {}
+                }
+                """);
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        BundleJulcSourcesTask task = project.getTasks()
+                .create("bundleJulcSources", BundleJulcSourcesTask.class);
+        task.getSourceDir().set(sourceDir.toFile());
+        task.getOutputDir().set(tempDir.resolve("build/resources/main").toFile());
+
+        GradleException ex = assertThrows(GradleException.class, task::bundle);
+        assertTrue(ex.getMessage().contains("class/path mismatch"));
+        assertTrue(ex.getMessage().contains("DifferentName"));
     }
 }

--- a/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
+++ b/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
@@ -114,4 +114,35 @@ class BundleJulcSourcesTaskTest {
         assertTrue(ex.getMessage().contains("class/path mismatch"));
         assertTrue(ex.getMessage().contains("DifferentName"));
     }
+
+    @Test
+    void bundleFailsWhenOnchainLibraryIsNested(@TempDir Path tempDir) throws Exception {
+        Path sourceDir = tempDir.resolve("src/main/java");
+        Path librarySource = sourceDir.resolve("com/example/Outer.java");
+        Files.createDirectories(librarySource.getParent());
+        Files.writeString(librarySource, """
+                package com.example;
+
+                import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+
+                public final class Outer {
+                    @OnchainLibrary
+                    static final class Inner {
+                        static boolean check() { return true; }
+                    }
+                }
+                """);
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        BundleJulcSourcesTask task = project.getTasks()
+                .create("bundleJulcSources", BundleJulcSourcesTask.class);
+        task.getSourceDir().set(sourceDir.toFile());
+        task.getOutputDir().set(tempDir.resolve("build/resources/main").toFile());
+
+        GradleException ex = assertThrows(GradleException.class, task::bundle);
+        assertTrue(ex.getMessage().contains("top-level class"));
+        assertTrue(ex.getMessage().contains("Nested on-chain libraries are not supported"));
+    }
 }

--- a/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
+++ b/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/BundleJulcSourcesTaskTest.java
@@ -1,0 +1,58 @@
+package com.bloxbean.cardano.julc.gradle;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BundleJulcSourcesTaskTest {
+
+    @Test
+    void bundleCopiesOnchainLibrarySourcesAndWritesIndex(@TempDir Path tempDir) throws Exception {
+        Path sourceDir = tempDir.resolve("src/main/java");
+        Path librarySource = sourceDir.resolve("com/example/Groth16BLS12381.java");
+        Files.createDirectories(librarySource.getParent());
+        Files.writeString(librarySource, """
+                package com.example;
+
+                import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+
+                @OnchainLibrary
+                public final class Groth16BLS12381 {
+                    private Groth16BLS12381() {}
+                }
+                """);
+
+        Path regularSource = sourceDir.resolve("com/example/OffchainHelper.java");
+        Files.writeString(regularSource, """
+                package com.example;
+
+                public final class OffchainHelper {}
+                """);
+
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        BundleJulcSourcesTask task = project.getTasks()
+                .create("bundleJulcSources", BundleJulcSourcesTask.class);
+        Path outputDir = tempDir.resolve("build/resources/main");
+        task.getSourceDir().set(sourceDir.toFile());
+        task.getOutputDir().set(outputDir.toFile());
+
+        task.bundle();
+
+        Path plutusSourcesDir = outputDir.resolve("META-INF/plutus-sources");
+        Path copiedSource = plutusSourcesDir.resolve("com/example/Groth16BLS12381.java");
+        assertTrue(Files.exists(copiedSource));
+        assertEquals(Files.readString(librarySource), Files.readString(copiedSource));
+        assertFalse(Files.exists(plutusSourcesDir.resolve("com/example/OffchainHelper.java")));
+        assertEquals(List.of("com/example/Groth16BLS12381.java"),
+                Files.readAllLines(plutusSourcesDir.resolve("index.txt")));
+    }
+}

--- a/julc-playground/src/main/java/com/bloxbean/julc/playground/api/CompileController.java
+++ b/julc-playground/src/main/java/com/bloxbean/julc/playground/api/CompileController.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.julc.blueprint.BlueprintGenerator;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.julc.playground.model.*;
 
@@ -27,9 +28,9 @@ public class CompileController {
 
     private final JulcCompiler julcCompiler;
     private final CompilationSandbox sandbox;
-    private final Map<String, String> cachedLibSources;
+    private final Map<String, LibrarySource> cachedLibSources;
 
-    public CompileController(JulcCompiler julcCompiler, CompilationSandbox sandbox, Map<String, String> cachedLibSources) {
+    public CompileController(JulcCompiler julcCompiler, CompilationSandbox sandbox, Map<String, LibrarySource> cachedLibSources) {
         this.julcCompiler = julcCompiler;
         this.sandbox = sandbox;
         this.cachedLibSources = cachedLibSources;

--- a/julc-playground/src/main/java/com/bloxbean/julc/playground/api/EvaluateController.java
+++ b/julc-playground/src/main/java/com/bloxbean/julc/playground/api/EvaluateController.java
@@ -2,6 +2,7 @@ package com.bloxbean.julc.playground.api;
 
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.core.PlutusData;
 
@@ -28,9 +29,9 @@ public class EvaluateController {
 
     private final JulcCompiler julcCompiler;
     private final CompilationSandbox sandbox;
-    private final java.util.Map<String, String> cachedLibSources;
+    private final java.util.Map<String, LibrarySource> cachedLibSources;
 
-    public EvaluateController(JulcCompiler julcCompiler, CompilationSandbox sandbox, java.util.Map<String, String> cachedLibSources) {
+    public EvaluateController(JulcCompiler julcCompiler, CompilationSandbox sandbox, java.util.Map<String, LibrarySource> cachedLibSources) {
         this.julcCompiler = julcCompiler;
         this.sandbox = sandbox;
         this.cachedLibSources = cachedLibSources;

--- a/julc-playground/src/main/java/com/bloxbean/julc/playground/repl/PlaygroundEvaluator.java
+++ b/julc-playground/src/main/java/com/bloxbean/julc/playground/repl/PlaygroundEvaluator.java
@@ -2,6 +2,7 @@ package com.bloxbean.julc.playground.repl;
 
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Term;
@@ -44,7 +45,7 @@ public final class PlaygroundEvaluator {
 
     private final JulcCompiler compiler;
     private final JulcVm vm;
-    private final Map<String, String> libraryPool;
+    private final Map<String, LibrarySource> libraryPool;
 
     public PlaygroundEvaluator() {
         this.compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());

--- a/julc-playground/src/test/java/com/bloxbean/julc/playground/api/CompileControllerTest.java
+++ b/julc-playground/src/test/java/com/bloxbean/julc/playground/api/CompileControllerTest.java
@@ -1,6 +1,7 @@
 package com.bloxbean.julc.playground.api;
 
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.julc.playground.model.CompileRequest;
 import com.bloxbean.julc.playground.model.CompileResponse;
 import com.bloxbean.julc.playground.sandbox.CompilationSandbox;
@@ -17,7 +18,7 @@ class CompileControllerTest {
     static final ObjectMapper mapper = new ObjectMapper();
     static final JulcCompiler julcCompiler = new JulcCompiler();
     static final CompilationSandbox sandbox = new CompilationSandbox(2, 30);
-    static final java.util.Map<String, String> cachedLibs =
+    static final java.util.Map<String, LibrarySource> cachedLibs =
             com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.scanClasspathSources(
                     JulcCompiler.class.getClassLoader());
     static final CompileController controller = new CompileController(julcCompiler, sandbox, cachedLibs);

--- a/julc-playground/src/test/java/com/bloxbean/julc/playground/api/EvaluateControllerTest.java
+++ b/julc-playground/src/test/java/com/bloxbean/julc/playground/api/EvaluateControllerTest.java
@@ -1,6 +1,7 @@
 package com.bloxbean.julc.playground.api;
 
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.julc.playground.model.EvaluateRequest;
 import com.bloxbean.julc.playground.model.EvaluateResponse;
 import com.bloxbean.julc.playground.model.ScenarioOverrides;
@@ -21,7 +22,7 @@ class EvaluateControllerTest {
     static final ObjectMapper mapper = new ObjectMapper();
     static final JulcCompiler julcCompiler = new JulcCompiler();
     static final CompilationSandbox sandbox = new CompilationSandbox(2, 30);
-    static final java.util.Map<String, String> cachedLibs =
+    static final java.util.Map<String, LibrarySource> cachedLibs =
             com.bloxbean.cardano.julc.compiler.LibrarySourceResolver.scanClasspathSources(
                     JulcCompiler.class.getClassLoader());
     static final EvaluateController controller = new EvaluateController(julcCompiler, sandbox, cachedLibs);

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/SourceDiscovery.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/SourceDiscovery.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.testkit;
 
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
@@ -76,7 +77,7 @@ public final class SourceDiscovery {
         }
 
         // Build library pool and resolve dependencies
-        Map<String, String> pool = buildLibraryPool(validatorSource, sourceRoot);
+        Map<String, LibrarySource> pool = buildLibraryPool(validatorSource, sourceRoot);
         List<String> libSources = LibrarySourceResolver.resolve(validatorSource, pool);
 
         // Compile with stdlib
@@ -131,7 +132,7 @@ public final class SourceDiscovery {
             throw new AssertionError("Cannot read validator source: " + sourceFile, e);
         }
 
-        Map<String, String> pool = buildLibraryPool(validatorSource, sourceRoot);
+        Map<String, LibrarySource> pool = buildLibraryPool(validatorSource, sourceRoot);
         List<String> libSources = LibrarySourceResolver.resolve(validatorSource, pool);
 
         var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry(), options);
@@ -149,8 +150,8 @@ public final class SourceDiscovery {
      * Build the available library pool from same-project sources (Tier 1)
      * and classpath META-INF/plutus-sources/ (Tier 2).
      */
-    private static Map<String, String> buildLibraryPool(String validatorSource, Path sourceRoot) {
-        var pool = new LinkedHashMap<String, String>();
+    private static Map<String, LibrarySource> buildLibraryPool(String validatorSource, Path sourceRoot) {
+        var pool = new LinkedHashMap<String, LibrarySource>();
 
         // Tier 2: Classpath sources (added first, lower precedence)
         pool.putAll(LibrarySourceResolver.scanClasspathSources(
@@ -159,7 +160,6 @@ public final class SourceDiscovery {
         // Tier 1: Same-project sources from import paths (higher precedence)
         Map<String, String> importPaths = LibrarySourceResolver.extractImportPaths(validatorSource);
         for (var entry : importPaths.entrySet()) {
-            String simpleName = entry.getKey();
             String fullPath = entry.getValue();
 
             // Convert package path to file system path
@@ -168,7 +168,7 @@ public final class SourceDiscovery {
                 try {
                     String src = Files.readString(sourceFile);
                     if (src.contains("@OnchainLibrary")) {
-                        pool.put(simpleName, src);
+                        LibrarySourceResolver.putLibrarySource(pool, entry.getKey(), src);
                     }
                 } catch (IOException e) {
                     // skip unreadable files
@@ -176,24 +176,14 @@ public final class SourceDiscovery {
             }
         }
 
+        for (String wildcardPackage : LibrarySourceResolver.extractWildcardImportPackages(validatorSource)) {
+            addPackageSources(pool, sourceRoot, wildcardPackage);
+        }
+
         // Tier 1b: Same-package sources (no import needed in Java)
         String pkg = LibrarySourceResolver.extractPackageName(validatorSource);
         if (!pkg.isEmpty()) {
-            Path pkgDir = sourceRoot.resolve(pkg.replace('.', '/'));
-            if (Files.isDirectory(pkgDir)) {
-                try (var stream = Files.list(pkgDir)) {
-                    stream.filter(p -> p.toString().endsWith(".java"))
-                            .forEach(p -> {
-                                try {
-                                    String src = Files.readString(p);
-                                    if (src.contains("@OnchainLibrary")) {
-                                        String name = p.getFileName().toString().replace(".java", "");
-                                        pool.putIfAbsent(name, src);
-                                    }
-                                } catch (IOException ignored) {}
-                            });
-                } catch (IOException ignored) {}
-            }
+            addPackageSourcesIfAbsent(pool, sourceRoot, pkg);
         }
 
         // Also scan transitive imports from already-found sources
@@ -236,7 +226,7 @@ public final class SourceDiscovery {
             throw new AssertionError("Cannot read source: " + sourceFile, e);
         }
 
-        Map<String, String> pool = buildLibraryPool(source, sourceRoot);
+        Map<String, LibrarySource> pool = buildLibraryPool(source, sourceRoot);
         List<String> libSources = LibrarySourceResolver.resolve(source, pool);
 
         var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
@@ -280,7 +270,7 @@ public final class SourceDiscovery {
             throw new AssertionError("Cannot read source for " + fqcn + ": " + sourceFile, e);
         }
 
-        Map<String, String> pool = buildLibraryPool(source, sourceRoot);
+        Map<String, LibrarySource> pool = buildLibraryPool(source, sourceRoot);
         List<String> libSources = LibrarySourceResolver.resolve(source, pool);
 
         var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
@@ -297,24 +287,23 @@ public final class SourceDiscovery {
     /**
      * Recursively discover same-project sources referenced by already-found libraries.
      */
-    private static void addTransitiveSameProjectSources(Map<String, String> pool, Path sourceRoot) {
+    private static void addTransitiveSameProjectSources(Map<String, LibrarySource> pool, Path sourceRoot) {
         boolean changed = true;
         while (changed) {
             changed = false;
             var snapshot = new LinkedHashMap<>(pool);
-            for (String libSource : snapshot.values()) {
-                Map<String, String> importPaths = LibrarySourceResolver.extractImportPaths(libSource);
+            for (LibrarySource librarySource : snapshot.values()) {
+                Map<String, String> importPaths = LibrarySourceResolver.extractImportPaths(librarySource.source());
                 for (var entry : importPaths.entrySet()) {
-                    String simpleName = entry.getKey();
-                    if (pool.containsKey(simpleName)) continue;
-
                     String fullPath = entry.getValue();
+                    if (pool.containsKey(fullPath)) continue;
+
                     Path sourceFile = sourceRoot.resolve(fullPath.replace('.', '/') + ".java");
                     if (Files.exists(sourceFile)) {
                         try {
                             String src = Files.readString(sourceFile);
                             if (src.contains("@OnchainLibrary")) {
-                                pool.put(simpleName, src);
+                                LibrarySourceResolver.putLibrarySource(pool, entry.getKey(), src);
                                 changed = true;
                             }
                         } catch (IOException e) {
@@ -322,7 +311,60 @@ public final class SourceDiscovery {
                         }
                     }
                 }
+
+                for (String wildcardPackage : LibrarySourceResolver.extractWildcardImportPackages(librarySource.source())) {
+                    if (addPackageSources(pool, sourceRoot, wildcardPackage)) {
+                        changed = true;
+                    }
+                }
+
+                if (!librarySource.packageName().isEmpty()
+                        && addPackageSourcesIfAbsent(pool, sourceRoot, librarySource.packageName())) {
+                    changed = true;
+                }
             }
         }
+    }
+
+    private static boolean addPackageSources(Map<String, LibrarySource> pool, Path sourceRoot, String packageName) {
+        return addPackageSources(pool, sourceRoot, packageName, false);
+    }
+
+    private static boolean addPackageSourcesIfAbsent(Map<String, LibrarySource> pool, Path sourceRoot, String packageName) {
+        return addPackageSources(pool, sourceRoot, packageName, true);
+    }
+
+    private static boolean addPackageSources(Map<String, LibrarySource> pool,
+                                             Path sourceRoot,
+                                             String packageName,
+                                             boolean preserveExisting) {
+        Path pkgDir = sourceRoot.resolve(packageName.replace('.', '/'));
+        if (!Files.isDirectory(pkgDir)) {
+            return false;
+        }
+
+        final boolean[] changed = {false};
+        try (var stream = Files.list(pkgDir)) {
+            stream.filter(p -> p.toString().endsWith(".java"))
+                    .forEach(p -> {
+                        try {
+                            String src = Files.readString(p);
+                            if (src.contains("@OnchainLibrary")) {
+                                String name = p.getFileName().toString().replace(".java", "");
+                                LibrarySource librarySource = LibrarySourceResolver.librarySourceFromSimpleName(name, src);
+                                if (preserveExisting) {
+                                    if (!pool.containsKey(librarySource.fqcn())) {
+                                        pool.put(librarySource.fqcn(), librarySource);
+                                        changed[0] = true;
+                                    }
+                                } else {
+                                    LibrarySource previous = pool.put(librarySource.fqcn(), librarySource);
+                                    changed[0] = previous == null || !previous.source().equals(librarySource.source());
+                                }
+                            }
+                        } catch (IOException ignored) {}
+                    });
+        } catch (IOException ignored) {}
+        return changed[0];
     }
 }

--- a/julc-testkit/src/test/java/com/bloxbean/cardano/julc/testkit/SourceDiscoveryTest.java
+++ b/julc-testkit/src/test/java/com/bloxbean/cardano/julc/testkit/SourceDiscoveryTest.java
@@ -60,6 +60,15 @@ class SourceDiscoveryTest {
     }
 
     @Test
+    void compileFqcn_discoversTransitiveSamePackageLibrary() {
+        CompileResult result = SourceDiscovery.compile(
+                "com.example.libs.ValidatorUsesTransitiveSamePackageLibrary", TEST_SOURCE_ROOT);
+        assertNotNull(result);
+        assertFalse(result.hasErrors(), "Expected no errors: " + result.diagnostics());
+        assertNotNull(result.program());
+    }
+
+    @Test
     void compileFqcn_nonExistentClassGivesClearError() {
         var error = assertThrows(AssertionError.class, () ->
                 SourceDiscovery.compile("com.example.NonExistent", TEST_SOURCE_ROOT));

--- a/julc-testkit/src/test/resources/testdata/com/example/libs/A.java
+++ b/julc-testkit/src/test/resources/testdata/com/example/libs/A.java
@@ -1,0 +1,8 @@
+package com.example.libs;
+
+@OnchainLibrary
+class A {
+    static long calc() {
+        return B.helper();
+    }
+}

--- a/julc-testkit/src/test/resources/testdata/com/example/libs/B.java
+++ b/julc-testkit/src/test/resources/testdata/com/example/libs/B.java
@@ -1,0 +1,8 @@
+package com.example.libs;
+
+@OnchainLibrary
+class B {
+    static long helper() {
+        return 42;
+    }
+}

--- a/julc-testkit/src/test/resources/testdata/com/example/libs/ValidatorUsesTransitiveSamePackageLibrary.java
+++ b/julc-testkit/src/test/resources/testdata/com/example/libs/ValidatorUsesTransitiveSamePackageLibrary.java
@@ -1,0 +1,11 @@
+package com.example.libs;
+
+import com.example.libs.A;
+
+@Validator
+class ValidatorUsesTransitiveSamePackageLibrary {
+    @Entrypoint
+    static boolean validate(long redeemer, long ctx) {
+        return A.calc() == 42;
+    }
+}


### PR DESCRIPTION
 This PR fixes the remaining library source resolution limitation where `OnchainLibrar`  classes were indexed by simple class name. That caused collisions when different packages contained libraries with the same simple name.

  **Changes:**

  - Adds a LibrarySource model with FQCN, simple name, package name, resource path, and source.
  - Resolves library sources by FQCN instead of simple class name.
  - Supports Java-style resolution for explicit imports, same-package references, wildcard imports, fully-qualified static calls, and transitive library dependencies.
  - Reports ambiguity when an unqualified simple name matches multiple libraries.
  - Migrates compiler, annotation processor, testkit, CLI, and playground call sites.
  - Updates project scanning so duplicate library simple names in different packages are preserved.
  - Adds Gradle plugin validation that bundled @OnchainLibrary package/type declarations match their resource path.
  - Adds tests covering duplicate simple names, import precedence, wildcard imports, FQCN static calls, ambiguity diagnostics, same-package transitive discovery, and bundle validation.