### PR TITLE
Centralize Plutus target metadata and split script purpose from type

### DIFF
--- a/adr/architecture-reference.md
+++ b/adr/architecture-reference.md
@@ -16,7 +16,8 @@ This document is the canonical architecture reference for JuLC. It consolidates 
 
 **Root Gradle project:** `julc`
 **Package prefix:** `com.bloxbean.cardano.julc`
-**Plutus version:** V3 only (Conway era). No V1/V2 support.
+**Compiler Plutus target:** V3 only (Conway era), represented in code by `PlutusTarget.CURRENT`.
+**VM evaluation:** V1, V2, and V3 external scripts can be evaluated through `JulcVm` by selecting the appropriate `PlutusLanguage`.
 **Java build toolchain:** 24 (Temurin)
 **Gradle:** 9.2.0
 
@@ -60,6 +61,7 @@ This document is the canonical architecture reference for JuLC. It consolidates 
 - **VM SPI:** `JulcVmProvider` is discovered via `ServiceLoader`. The highest-priority provider wins. This allows swapping the Scalus backend for a future pure-Java CEK machine without API changes.
 - **Scala isolation:** Only `julc-vm-scalus` has a Scala dependency. All other modules are pure Java.
 - **BOM:** `julc-bom` provides consistent version alignment across all modules for downstream consumers.
+- **Script metadata:** Generated validator JSON uses a cardano-cli-style text-envelope `type` such as `PlutusScriptV3`; script purpose is emitted separately as lowercase metadata such as `spending` or `minting`.
 
 ### Dependency Flow
 

--- a/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
+++ b/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
@@ -6,9 +6,11 @@ import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.clientlib.ValidatorOutput;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.JavaSourceIntrospector;
 import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.ScriptPurposeMetadata;
 import com.bloxbean.cardano.julc.core.source.SourceMapSerializer;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import com.sun.source.util.Trees;
@@ -199,7 +201,9 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
             var program = result.program();
             var script = JulcScriptAdapter.fromProgram(program);
 
-            String scriptType = resolveScriptType(annotation.getSimpleName().toString());
+            var scriptPurpose = JavaSourceIntrospector.scriptPurpose(annotation.getSimpleName().toString());
+            String scriptType = ScriptPurposeMetadata.textEnvelopeType();
+            String purpose = ScriptPurposeMetadata.jsonPurpose(scriptPurpose);
 
             // Build params string from CompileResult
             String paramsStr = result.params().stream()
@@ -213,7 +217,7 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
             int sizeBytes = result.scriptSizeBytes();
             String sizeStr = result.scriptSizeFormatted();
 
-            var output = new ValidatorOutput(scriptType, className,
+            var output = new ValidatorOutput(scriptType, purpose, className,
                     script.getCborHex(), scriptHash, paramsStr, sizeBytes);
 
             // 5. Write to META-INF/plutus/<ClassName>.plutus.json
@@ -279,19 +283,6 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
         pool.putAll(sameProjectLibraries);
 
         return LibrarySourceResolver.resolve(validatorSource, pool);
-    }
-
-    private String resolveScriptType(String annotationSimpleName) {
-        return switch (annotationSimpleName) {
-            case "SpendingValidator" -> "PlutusScriptV3";
-            case "MintingValidator" -> "PlutusScriptV3-Minting";
-            case "WithdrawValidator" -> "PlutusScriptV3-Withdraw";
-            case "CertifyingValidator" -> "PlutusScriptV3-Certifying";
-            case "VotingValidator" -> "PlutusScriptV3-Voting";
-            case "ProposingValidator" -> "PlutusScriptV3-Proposing";
-            case "MultiValidator" -> "PlutusScriptV3";
-            default -> "PlutusScriptV3";
-        };
     }
 
     /**

--- a/julc-annotation-processor/src/test/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessorTest.java
+++ b/julc-annotation-processor/src/test/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessorTest.java
@@ -48,6 +48,7 @@ class JulcAnnotationProcessorTest {
         String json = Files.readString(jsonFile);
         var output = ValidatorOutput.fromJson(json);
         assertEquals("PlutusScriptV3", output.type());
+        assertEquals("spending", output.purpose());
         assertEquals("SimpleValidator", output.description());
         assertNotNull(output.cborHex());
         assertFalse(output.cborHex().isEmpty());
@@ -78,7 +79,8 @@ class JulcAnnotationProcessorTest {
         assertTrue(Files.exists(jsonFile));
 
         var output = ValidatorOutput.fromJson(Files.readString(jsonFile));
-        assertEquals("PlutusScriptV3-Minting", output.type());
+        assertEquals("PlutusScriptV3", output.type());
+        assertEquals("minting", output.purpose());
         assertEquals("SimpleMinting", output.description());
     }
 
@@ -108,6 +110,7 @@ class JulcAnnotationProcessorTest {
 
         var output = ValidatorOutput.fromJson(Files.readString(jsonFile));
         assertEquals("PlutusScriptV3", output.type());
+        assertEquals("spending", output.purpose());
         assertTrue(output.isParameterized());
         assertEquals(2, output.paramList().size());
         assertEquals("owner", output.paramList().get(0).name());
@@ -126,6 +129,7 @@ class JulcAnnotationProcessorTest {
         var parsed = ValidatorOutput.fromJson(json);
 
         assertEquals(original.type(), parsed.type());
+        assertEquals(original.purpose(), parsed.purpose());
         assertEquals(original.description(), parsed.description());
         assertEquals(original.cborHex(), parsed.cborHex());
         assertEquals(original.hash(), parsed.hash());
@@ -140,6 +144,7 @@ class JulcAnnotationProcessorTest {
         var parsed = ValidatorOutput.fromJson(json);
 
         assertEquals(original.type(), parsed.type());
+        assertEquals(original.purpose(), parsed.purpose());
         assertEquals(original.description(), parsed.description());
         assertEquals(original.cborHex(), parsed.cborHex());
         assertEquals(original.hash(), parsed.hash());
@@ -189,6 +194,7 @@ class JulcAnnotationProcessorTest {
                 """;
         var output = ValidatorOutput.fromJson(json);
         assertEquals("PlutusScriptV3", output.type());
+        assertEquals("", output.purpose());
         assertEquals("OldValidator", output.description());
         assertEquals("", output.params());
         assertFalse(output.isParameterized());

--- a/julc-blueprint/src/main/java/com/bloxbean/cardano/julc/blueprint/BlueprintGenerator.java
+++ b/julc-blueprint/src/main/java/com/bloxbean/cardano/julc/blueprint/BlueprintGenerator.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.blueprint;
 
 import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
+import com.bloxbean.cardano.julc.core.PlutusTarget;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -23,7 +24,7 @@ public final class BlueprintGenerator {
         var preamble = new Blueprint.Preamble(
                 config.projectName(),
                 config.projectVersion(),
-                "v3",
+                PlutusTarget.CURRENT.languageVersion(),
                 new Blueprint.Compiler("julc", JulcVersion.VERSION)
         );
 

--- a/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/ValidatorOutput.java
+++ b/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/ValidatorOutput.java
@@ -6,27 +6,54 @@ import java.util.List;
 /**
  * Output record for a compiled Plutus validator.
  *
- * @param type        script type, e.g. "PlutusScriptV3" or "PlutusScriptV3-Minting"
+ * @param type        script text-envelope type, e.g. "PlutusScriptV3"
+ * @param purpose     validator purpose, e.g. "spending" or "minting"; may be empty for legacy metadata
  * @param description validator name
  * @param cborHex     double-CBOR-wrapped FLAT-encoded UPLC program
  * @param hash        script hash (28 bytes hex), empty for parameterized validators
  * @param params      comma-separated param metadata, e.g. "owner:byte[],deadline:BigInteger"
  * @param sizeBytes   FLAT-encoded script size in bytes, or -1 if unknown
  */
-public record ValidatorOutput(String type, String description, String cborHex, String hash, String params, int sizeBytes) {
+public record ValidatorOutput(String type, String purpose, String description, String cborHex,
+                              String hash, String params, int sizeBytes) {
+
+    public ValidatorOutput {
+        var typeParts = splitLegacyType(type);
+        type = typeParts.type();
+        if (purpose == null || purpose.isBlank()) {
+            purpose = typeParts.purpose();
+        }
+        params = params != null ? params : "";
+    }
+
+    /**
+     * Backward-compatible constructor without purpose.
+     */
+    public ValidatorOutput(String type, String description, String cborHex,
+                           String hash, String params, int sizeBytes) {
+        this(type, "", description, cborHex, hash, params, sizeBytes);
+    }
 
     /**
      * Backward-compatible constructor without sizeBytes.
      */
     public ValidatorOutput(String type, String description, String cborHex, String hash, String params) {
-        this(type, description, cborHex, hash, params, -1);
+        this(type, "", description, cborHex, hash, params, -1);
+    }
+
+    /**
+     * Constructor with purpose and without sizeBytes.
+     */
+    public ValidatorOutput(String type, String purpose, String description,
+                           String cborHex, String hash, String params) {
+        this(type, purpose, description, cborHex, hash, params, -1);
     }
 
     /**
      * Backward-compatible constructor for non-parameterized validators.
      */
     public ValidatorOutput(String type, String description, String cborHex, String hash) {
-        this(type, description, cborHex, hash, "", -1);
+        this(type, "", description, cborHex, hash, "", -1);
     }
 
     /**
@@ -77,13 +104,15 @@ public record ValidatorOutput(String type, String description, String cborHex, S
         return """
                 {
                   "type": "%s",
+                  "purpose": "%s",
                   "description": "%s",
                   "cborHex": "%s",
                   "hash": "%s",
                   "params": "%s",
                   "sizeBytes": %d
                 }
-                """.formatted(type, description, cborHex, hash, params != null ? params : "", sizeBytes);
+                """.formatted(type, purpose != null ? purpose : "", description, cborHex,
+                hash, params != null ? params : "", sizeBytes);
     }
 
     /**
@@ -92,13 +121,32 @@ public record ValidatorOutput(String type, String description, String cborHex, S
      */
     public static ValidatorOutput fromJson(String json) {
         String type = extractField(json, "type");
+        String purpose = extractFieldOptional(json, "purpose");
         String description = extractField(json, "description");
         String cborHex = extractField(json, "cborHex");
         String hash = extractField(json, "hash");
         String params = extractFieldOptional(json, "params");
         int sizeBytes = extractIntFieldOptional(json, "sizeBytes", -1);
-        return new ValidatorOutput(type, description, cborHex, hash, params, sizeBytes);
+        return new ValidatorOutput(type, purpose, description, cborHex, hash, params, sizeBytes);
     }
+
+    private static TypeParts splitLegacyType(String type) {
+        if (type == null) {
+            return new TypeParts("", "");
+        }
+        return switch (type) {
+            case "PlutusScriptV3-Spending" -> new TypeParts("PlutusScriptV3", "spending");
+            case "PlutusScriptV3-Minting" -> new TypeParts("PlutusScriptV3", "minting");
+            case "PlutusScriptV3-Withdraw" -> new TypeParts("PlutusScriptV3", "withdraw");
+            case "PlutusScriptV3-Certifying" -> new TypeParts("PlutusScriptV3", "certifying");
+            case "PlutusScriptV3-Voting" -> new TypeParts("PlutusScriptV3", "voting");
+            case "PlutusScriptV3-Proposing" -> new TypeParts("PlutusScriptV3", "proposing");
+            case "PlutusScriptV3-Multi" -> new TypeParts("PlutusScriptV3", "multi");
+            default -> new TypeParts(type, "");
+        };
+    }
+
+    private record TypeParts(String type, String purpose) {}
 
     private static String extractField(String json, String field) {
         String key = "\"" + field + "\"";

--- a/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/ValidatorOutputTest.java
+++ b/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/ValidatorOutputTest.java
@@ -1,0 +1,72 @@
+package com.bloxbean.cardano.julc.clientlib;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidatorOutputTest {
+
+    @Test
+    void toJsonRoundTripsTypeAndPurpose() {
+        var original = new ValidatorOutput("PlutusScriptV3", "minting",
+                "Policy", "8201", "aabb", "", 42);
+
+        var parsed = ValidatorOutput.fromJson(original.toJson());
+
+        assertEquals("PlutusScriptV3", parsed.type());
+        assertEquals("minting", parsed.purpose());
+        assertEquals("Policy", parsed.description());
+        assertEquals("8201", parsed.cborHex());
+        assertEquals("aabb", parsed.hash());
+        assertEquals(42, parsed.sizeBytes());
+    }
+
+    @Test
+    void fromJsonParsesLegacyPurposeSuffixedType() {
+        String json = """
+                {
+                  "type": "PlutusScriptV3-Minting",
+                  "description": "LegacyPolicy",
+                  "cborHex": "8201",
+                  "hash": "aabb",
+                  "params": "",
+                  "sizeBytes": 99
+                }
+                """;
+
+        var parsed = ValidatorOutput.fromJson(json);
+
+        assertEquals("PlutusScriptV3", parsed.type());
+        assertEquals("minting", parsed.purpose());
+        assertEquals("LegacyPolicy", parsed.description());
+        assertEquals(99, parsed.sizeBytes());
+    }
+
+    @Test
+    void fromJsonKeepsLegacyPlainTypeWithoutGuessingPurpose() {
+        String json = """
+                {
+                  "type": "PlutusScriptV3",
+                  "description": "LegacyValidator",
+                  "cborHex": "8201",
+                  "hash": "aabb"
+                }
+                """;
+
+        var parsed = ValidatorOutput.fromJson(json);
+
+        assertEquals("PlutusScriptV3", parsed.type());
+        assertEquals("", parsed.purpose());
+        assertEquals("", parsed.params());
+        assertEquals(-1, parsed.sizeBytes());
+    }
+
+    @Test
+    void oldConstructorsNormalizeLegacyPurposeSuffixedType() {
+        var output = new ValidatorOutput("PlutusScriptV3-Withdraw",
+                "LegacyWithdraw", "8201", "aabb");
+
+        assertEquals("PlutusScriptV3", output.type());
+        assertEquals("withdraw", output.purpose());
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/blueprint/ConvertCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/blueprint/ConvertCommand.java
@@ -1,5 +1,6 @@
 package com.bloxbean.julc.cli.cmd.blueprint;
 
+import com.bloxbean.cardano.julc.core.PlutusTarget;
 import com.bloxbean.julc.cli.cmd.EvalCommand;
 import com.bloxbean.julc.cli.output.AnsiColors;
 import com.bloxbean.julc.cli.project.ProjectLayout;
@@ -34,11 +35,11 @@ public class ConvertCommand implements Runnable {
             // cardano-cli TextEnvelope format
             String textEnvelope = """
                     {
-                        "type": "PlutusScriptV3",
+                        "type": "%s",
                         "description": "",
                         "cborHex": "%s"
                     }
-                    """.formatted(hex);
+                    """.formatted(PlutusTarget.CURRENT.textEnvelopeType(), hex);
 
             if (outFile != null) {
                 Files.writeString(outFile, textEnvelope);

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/project/ProjectScanner.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/project/ProjectScanner.java
@@ -2,6 +2,7 @@ package com.bloxbean.julc.cli.project;
 
 import com.bloxbean.cardano.julc.compiler.JavaSourceIntrospector;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
+import com.bloxbean.cardano.julc.compiler.ScriptPurposeMetadata;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -76,11 +77,11 @@ public final class ProjectScanner {
     }
 
     /**
-     * Determine the script type from validator annotations.
+     * Determine the script text-envelope type from validator annotations.
      */
     public static String resolveScriptType(String source) {
         if (!JavaSourceIntrospector.mightContainValidatorAnnotation(source)) {
-            return "PlutusScriptV3";
+            return ScriptPurposeMetadata.textEnvelopeType();
         }
         var sourceInfo = JavaSourceIntrospector.inspect(source);
         rejectRoleConflicts(sourceInfo);
@@ -88,7 +89,9 @@ public final class ProjectScanner {
             throw new IllegalArgumentException(JavaSourceIntrospector.legacyAnnotationMigrationMessage(
                     sourceInfo.legacyValidatorType().get()));
         }
-        return sourceInfo.scriptType().orElse("PlutusScriptV3");
+        return sourceInfo.scriptPurpose()
+                .map(purpose -> ScriptPurposeMetadata.textEnvelopeType())
+                .orElse(ScriptPurposeMetadata.textEnvelopeType());
     }
 
     private static void rejectRoleConflicts(JavaSourceIntrospector.SourceInfo sourceInfo) {

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/project/ProjectScannerTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/project/ProjectScannerTest.java
@@ -140,8 +140,8 @@ class ProjectScannerTest {
 
     @Test
     void resolveScriptType() {
-        assertEquals("PlutusScriptV3-Minting", ProjectScanner.resolveScriptType("@MintingValidator class X {}"));
-        assertEquals("PlutusScriptV3-Withdraw", ProjectScanner.resolveScriptType("@WithdrawValidator class X {}"));
+        assertEquals("PlutusScriptV3", ProjectScanner.resolveScriptType("@MintingValidator class X {}"));
+        assertEquals("PlutusScriptV3", ProjectScanner.resolveScriptType("@WithdrawValidator class X {}"));
         assertEquals("PlutusScriptV3", ProjectScanner.resolveScriptType("@SpendingValidator class X {}"));
         assertEquals("PlutusScriptV3", ProjectScanner.resolveScriptType("""
                 /** Mentions @MintingValidator in a comment. */

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JavaSourceIntrospector.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JavaSourceIntrospector.java
@@ -59,10 +59,6 @@ public final class JavaSourceIntrospector {
             return validatorType.map(type -> JavaSourceIntrospector.scriptPurpose(type.annotationName()));
         }
 
-        public Optional<String> scriptType() {
-            return scriptPurpose().map(JavaSourceIntrospector::scriptType);
-        }
-
         public boolean hasRoleConflicts() {
             return !roleConflicts.isEmpty();
         }
@@ -246,17 +242,6 @@ public final class JavaSourceIntrospector {
             case "ProposingValidator" -> JulcCompiler.ScriptPurpose.PROPOSING;
             case "MultiValidator" -> JulcCompiler.ScriptPurpose.MULTI;
             default -> throw new IllegalArgumentException("Unsupported validator annotation: " + annotationName);
-        };
-    }
-
-    public static String scriptType(JulcCompiler.ScriptPurpose purpose) {
-        return switch (purpose) {
-            case MINTING -> "PlutusScriptV3-Minting";
-            case WITHDRAW -> "PlutusScriptV3-Withdraw";
-            case CERTIFYING -> "PlutusScriptV3-Certifying";
-            case VOTING -> "PlutusScriptV3-Voting";
-            case PROPOSING -> "PlutusScriptV3-Proposing";
-            default -> "PlutusScriptV3";
         };
     }
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
@@ -14,6 +14,7 @@ import com.bloxbean.cardano.julc.compiler.uplc.UplcGenerator;
 import com.bloxbean.cardano.julc.compiler.uplc.UplcOptimizer;
 import com.bloxbean.cardano.julc.compiler.util.MethodDependencyResolver;
 import com.bloxbean.cardano.julc.compiler.validate.SubsetValidator;
+import com.bloxbean.cardano.julc.core.PlutusTarget;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.Term;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
@@ -499,7 +500,7 @@ public class JulcCompiler {
         Term capturedUplc = captureDetails ? uplcTerm : null;
 
         // 21. Create Program
-        var program = Program.plutusV3(uplcTerm);
+        var program = PlutusTarget.CURRENT.program(uplcTerm);
 
         // 22. Build ParamInfo list
         var paramInfos = paramFields.stream()
@@ -572,7 +573,7 @@ public class JulcCompiler {
     public Program compilePirToProgram(PirTerm pirTerm) {
         var uplcGenerator = new UplcGenerator();
         var uplcTerm = uplcGenerator.generate(pirTerm);
-        return Program.plutusV3(uplcTerm);
+        return PlutusTarget.CURRENT.program(uplcTerm);
     }
 
     // --- Method compilation (for expression evaluation) ---
@@ -803,7 +804,7 @@ public class JulcCompiler {
         var paramInfos = paramFields.stream()
                 .map(pf -> new CompileResult.ParamInfo(pf.name, pf.javaType))
                 .toList();
-        var program = Program.plutusV3(uplcTerm);
+        var program = PlutusTarget.CURRENT.program(uplcTerm);
         return new CompileResult(program, diagnostics, paramInfos, body, uplcTerm, sourceMap);
     }
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/ScriptPurposeMetadata.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/ScriptPurposeMetadata.java
@@ -1,0 +1,27 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.core.PlutusTarget;
+
+/**
+ * Output metadata formatting for JuLC validator purposes.
+ */
+public final class ScriptPurposeMetadata {
+
+    private ScriptPurposeMetadata() {}
+
+    public static String textEnvelopeType() {
+        return PlutusTarget.CURRENT.textEnvelopeType();
+    }
+
+    public static String jsonPurpose(JulcCompiler.ScriptPurpose purpose) {
+        return switch (purpose) {
+            case SPENDING -> "spending";
+            case MINTING -> "minting";
+            case WITHDRAW -> "withdraw";
+            case CERTIFYING -> "certifying";
+            case VOTING -> "voting";
+            case PROPOSING -> "proposing";
+            case MULTI -> "multi";
+        };
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/JavaSourceIntrospectorTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/JavaSourceIntrospectorTest.java
@@ -40,7 +40,7 @@ class JavaSourceIntrospectorTest {
         assertEquals("Mint", info.validatorType().get().simpleName());
         assertEquals("com.example.Mint", info.validatorType().get().fqcn());
         assertEquals("MintingValidator", info.validatorType().get().annotationName());
-        assertEquals("PlutusScriptV3-Minting", info.scriptType().orElseThrow());
+        assertEquals(JulcCompiler.ScriptPurpose.MINTING, info.scriptPurpose().orElseThrow());
     }
 
     @Test
@@ -58,7 +58,7 @@ class JavaSourceIntrospectorTest {
 
         assertEquals("Withdraw", info.validatorType().orElseThrow().simpleName());
         assertEquals("WithdrawValidator", info.validatorType().orElseThrow().annotationName());
-        assertEquals("PlutusScriptV3-Withdraw", info.scriptType().orElseThrow());
+        assertEquals(JulcCompiler.ScriptPurpose.WITHDRAW, info.scriptPurpose().orElseThrow());
     }
 
     @Test

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ScriptPurposeMetadataTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ScriptPurposeMetadataTest.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ScriptPurposeMetadataTest {
+
+    @Test
+    void textEnvelopeTypeUsesCurrentPlutusTarget() {
+        assertEquals("PlutusScriptV3", ScriptPurposeMetadata.textEnvelopeType());
+    }
+
+    @Test
+    void jsonPurposeMapsAllCompilerPurposes() {
+        assertEquals("spending", ScriptPurposeMetadata.jsonPurpose(JulcCompiler.ScriptPurpose.SPENDING));
+        assertEquals("minting", ScriptPurposeMetadata.jsonPurpose(JulcCompiler.ScriptPurpose.MINTING));
+        assertEquals("withdraw", ScriptPurposeMetadata.jsonPurpose(JulcCompiler.ScriptPurpose.WITHDRAW));
+        assertEquals("certifying", ScriptPurposeMetadata.jsonPurpose(JulcCompiler.ScriptPurpose.CERTIFYING));
+        assertEquals("voting", ScriptPurposeMetadata.jsonPurpose(JulcCompiler.ScriptPurpose.VOTING));
+        assertEquals("proposing", ScriptPurposeMetadata.jsonPurpose(JulcCompiler.ScriptPurpose.PROPOSING));
+        assertEquals("multi", ScriptPurposeMetadata.jsonPurpose(JulcCompiler.ScriptPurpose.MULTI));
+    }
+}

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/PlutusTarget.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/PlutusTarget.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.julc.core;
+
+/**
+ * JuLC's compile target for generated scripts.
+ * <p>
+ * JuLC currently emits Plutus V3 scripts. The VM/evaluator can execute other
+ * Plutus language versions when given external scripts, but compiler output is
+ * intentionally pinned to this target.
+ */
+public enum PlutusTarget {
+    V3("v3", "PlutusScriptV3", 1, 1, 0);
+
+    public static final PlutusTarget CURRENT = V3;
+
+    private final String languageVersion;
+    private final String textEnvelopeType;
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    PlutusTarget(String languageVersion, String textEnvelopeType,
+                 int major, int minor, int patch) {
+        this.languageVersion = languageVersion;
+        this.textEnvelopeType = textEnvelopeType;
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    public String languageVersion() {
+        return languageVersion;
+    }
+
+    public String textEnvelopeType() {
+        return textEnvelopeType;
+    }
+
+    public Program program(Term term) {
+        return new Program(major, minor, patch, term);
+    }
+}

--- a/julc-core/src/test/java/com/bloxbean/cardano/julc/core/PlutusTargetTest.java
+++ b/julc-core/src/test/java/com/bloxbean/cardano/julc/core/PlutusTargetTest.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.julc.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PlutusTargetTest {
+
+    @Test
+    void currentTargetIsPlutusV3() {
+        assertEquals(PlutusTarget.V3, PlutusTarget.CURRENT);
+        assertEquals("v3", PlutusTarget.CURRENT.languageVersion());
+        assertEquals("PlutusScriptV3", PlutusTarget.CURRENT.textEnvelopeType());
+
+        var program = PlutusTarget.CURRENT.program(Term.const_(Constant.unit()));
+        assertEquals("1.1.0", program.versionString());
+    }
+}

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/CompileJulcTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/CompileJulcTask.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
 import com.bloxbean.cardano.julc.compiler.JavaSourceIntrospector;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
+import com.bloxbean.cardano.julc.compiler.ScriptPurposeMetadata;
 import com.bloxbean.cardano.julc.core.source.SourceMapSerializer;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 
@@ -79,7 +80,7 @@ public abstract class CompileJulcTask extends DefaultTask {
             }
             if (sourceInfo.validatorType().isPresent()) {
                 validatorFiles.add(new ValidatorFile(javaFile,
-                        sourceInfo.scriptType().orElse("PlutusScriptV3")));
+                        sourceInfo.scriptPurpose().orElseThrow()));
             } else {
                 getLogger().info("Treating {} as a library source: text matched validator annotation but no real validator annotation was found",
                         javaFile);
@@ -115,7 +116,8 @@ public abstract class CompileJulcTask extends DefaultTask {
             int sizeBytes = result.scriptSizeBytes();
             String sizeStr = result.scriptSizeFormatted();
 
-            var output = new ValidatorOutput(validatorFile.scriptType(), validatorName,
+            var output = new ValidatorOutput(ScriptPurposeMetadata.textEnvelopeType(),
+                    ScriptPurposeMetadata.jsonPurpose(validatorFile.scriptPurpose()), validatorName,
                     script.getCborHex(), scriptHash, sizeBytes);
 
             File outputFile = new File(outDir, validatorName + ".json");
@@ -175,7 +177,7 @@ public abstract class CompileJulcTask extends DefaultTask {
         }
     }
 
-    private record ValidatorFile(File file, String scriptType) {}
+    private record ValidatorFile(File file, JulcCompiler.ScriptPurpose scriptPurpose) {}
 
     private static JavaSourceIntrospector.SourceInfo inspect(File javaFile, String source) {
         try {

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/ValidatorOutput.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/ValidatorOutput.java
@@ -3,19 +3,37 @@ package com.bloxbean.cardano.julc.gradle;
 /**
  * Output record for a compiled Plutus validator.
  *
- * @param type        script type, e.g. "PlutusScriptV3" or "PlutusScriptV3-Minting"
+ * @param type        script text-envelope type, e.g. "PlutusScriptV3"
+ * @param purpose     validator purpose, e.g. "spending" or "minting"
  * @param description validator name
  * @param cborHex     double-CBOR-wrapped FLAT-encoded UPLC program
  * @param hash        script hash (28 bytes hex)
  * @param sizeBytes   FLAT-encoded script size in bytes, or -1 if unknown
  */
-public record ValidatorOutput(String type, String description, String cborHex, String hash, int sizeBytes) {
+public record ValidatorOutput(String type, String purpose, String description,
+                              String cborHex, String hash, int sizeBytes) {
 
     /**
-     * Backward-compatible constructor without sizeBytes.
+     * Backward-compatible constructor without purpose.
+     */
+    public ValidatorOutput(String type, String description, String cborHex,
+                           String hash, int sizeBytes) {
+        this(type, "", description, cborHex, hash, sizeBytes);
+    }
+
+    /**
+     * Backward-compatible constructor without purpose or sizeBytes.
      */
     public ValidatorOutput(String type, String description, String cborHex, String hash) {
-        this(type, description, cborHex, hash, -1);
+        this(type, "", description, cborHex, hash, -1);
+    }
+
+    /**
+     * Constructor with purpose and without sizeBytes.
+     */
+    public ValidatorOutput(String type, String purpose, String description,
+                           String cborHex, String hash) {
+        this(type, purpose, description, cborHex, hash, -1);
     }
 
     /**
@@ -25,11 +43,12 @@ public record ValidatorOutput(String type, String description, String cborHex, S
         return """
                 {
                   "type": "%s",
+                  "purpose": "%s",
                   "description": "%s",
                   "cborHex": "%s",
                   "hash": "%s",
                   "sizeBytes": %d
                 }
-                """.formatted(type, description, cborHex, hash, sizeBytes);
+                """.formatted(type, purpose != null ? purpose : "", description, cborHex, hash, sizeBytes);
     }
 }

--- a/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/JulcPluginTest.java
+++ b/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/JulcPluginTest.java
@@ -69,6 +69,7 @@ class JulcPluginTest {
 
         String json = Files.readString(outputJson);
         assertTrue(json.contains("\"type\": \"PlutusScriptV3\""));
+        assertTrue(json.contains("\"purpose\": \"spending\""));
         assertTrue(json.contains("\"description\": \"AlwaysTrue\""));
         assertTrue(json.contains("\"cborHex\":"));
         assertTrue(json.contains("\"hash\":"));
@@ -105,7 +106,8 @@ class JulcPluginTest {
         assertTrue(Files.exists(outputJson));
 
         String json = Files.readString(outputJson);
-        assertTrue(json.contains("\"type\": \"PlutusScriptV3-Minting\""));
+        assertTrue(json.contains("\"type\": \"PlutusScriptV3\""));
+        assertTrue(json.contains("\"purpose\": \"minting\""));
     }
 
     @Test


### PR DESCRIPTION
###  Description

  This PR keeps JuLC’s compiler output V3-only, but removes scattered hardcoded V3 metadata and separates script language type from validator purpose.

###   Changes:

  - Adds PlutusTarget.CURRENT as the single source of truth for compiler target metadata:
      - language version: v3
      - text envelope type: PlutusScriptV3
      - UPLC program version: 1.1.0
  - Replaces direct Program.plutusV3(...) compiler output construction with PlutusTarget.CURRENT.program(...).
  - Removes output-formatting responsibility from JavaSourceIntrospector.
  - Adds ScriptPurposeMetadata for purpose formatting.
  - Changes generated validator JSON from combined type strings like:
      - PlutusScriptV3-Minting

    to:
      - type: PlutusScriptV3
      - purpose: minting
  - Preserves backward compatibility when reading old JSON files with legacy combined type strings.
  - Updates Gradle plugin, annotation processor, CLI blueprint conversion, and blueprint generation to use the centralized target metadata.
  - Updates architecture docs to clarify:
      - JuLC compiler output targets V3.
      - VM evaluation can still handle V1/V2/V3 external scripts.