### PR TITLE
 fix: Scalus 0.17 upgrade + correct chain cost-model application in JulcTransactionEvaluator

### DIFF
--- a/julc-cardano-client-lib/build.gradle
+++ b/julc-cardano-client-lib/build.gradle
@@ -10,11 +10,11 @@ dependencies {
     implementation project(':julc-ledger-api')
     implementation project(':julc-stdlib')
     implementation project(':julc-vm')
-    implementation 'com.bloxbean.cardano:cardano-client-lib:0.7.1'
+    implementation 'com.bloxbean.cardano:cardano-client-lib:0.7.2'
 
     testImplementation project(':julc-vm-java')
     testRuntimeOnly project(':julc-vm-scalus')
-    testImplementation 'org.scalus:scalus-bloxbean-cardano-client-lib_3:0.16.0'
+    testImplementation 'org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0'
 }
 
 publishing {

--- a/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluator.java
+++ b/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluator.java
@@ -19,7 +19,6 @@ import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.ledger.*;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
-import com.bloxbean.cardano.julc.vm.JulcVm;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 import com.bloxbean.cardano.julc.vm.trace.ExecutionTraceEntry;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
@@ -42,6 +41,15 @@ import java.util.*;
  *     .withSigner(signer)
  *     .complete();
  * }</pre>
+ *
+ * <p><b>Thread-safety:</b> an instance is <b>not</b> thread-safe. Each {@link #evaluateTx} call
+ * (re)configures the cost model on a cached VM provider and then evaluates on it; the registered
+ * source maps/programs and trace flags are also mutable instance state. Concurrent use of a single
+ * instance can therefore race (e.g. one call reconfiguring the provider's cost model while another
+ * is evaluating). <b>Create a new {@code JulcTransactionEvaluator} per transaction / evaluation
+ * context (or confine one instance to a single thread); do not share an instance across threads.</b>
+ * Note: this warning is about this evaluator's per-call reconfiguration and mutable state.
+ * Do not rely on a cached provider inside this evaluator for concurrent evaluateTx calls.
  */
 public class JulcTransactionEvaluator implements TransactionEvaluator {
 
@@ -50,7 +58,6 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
     private final ScriptSupplier scriptSupplier;
     private final SlotConfig slotConfig;
 
-    private volatile JulcVm vm;
     private volatile com.bloxbean.cardano.julc.vm.JulcVmProvider provider;
 
     // Source map support
@@ -206,12 +213,15 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
                     Long.parseLong(params.getMaxTxExSteps()),
                     Long.parseLong(params.getMaxTxExMem()));
 
-            // 6. Create VM (lazy, cached) and configure cost models for all language versions
-            JulcVm julcVm = getOrCreateVm();
+            // 6. Resolve the VM provider (lazy, cached) and configure cost models for all language
+            //    versions. The SAME provider instance must be used for setCostModelParams AND
+            //    evaluation: cost-model params are stored per provider instance, so configuring one
+            //    instance and evaluating on another would silently fall back to the built-in defaults.
+            var vmProvider = getProvider();
             int pvMinor = params.getProtocolMinorVer() != null ? params.getProtocolMinorVer() : 0;
             for (var lang : List.of(Language.PLUTUS_V1, Language.PLUTUS_V2, Language.PLUTUS_V3)) {
                 CostModelUtil.getCostModelFromProtocolParams(params, lang)
-                        .ifPresent(cm -> julcVm.setCostModelParams(
+                        .ifPresent(cm -> vmProvider.setCostModelParams(
                                 cm.getCosts(), toPlutusLanguage(lang), pvMajor, pvMinor));
             }
 
@@ -261,10 +271,10 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
                     Program evalProgram = scriptPrograms.containsKey(scriptHash)
                             ? scriptPrograms.get(scriptHash) : resolved.program();
 
-                    // e. Evaluate — traces are captured in the EvalResult
-                    var langVm = JulcVm.withProvider(getProvider(), resolved.language());
-                    EvalResult evalResult = langVm.evaluateWithArgs(
-                            evalProgram, args, maxBudget, evalOptions);
+                    // e. Evaluate on the SAME provider configured above (not a fresh lookup), passing
+                    //    the resolved script's language explicitly.
+                    EvalResult evalResult = vmProvider.evaluateWithArgs(
+                            evalProgram, resolved.language(), args, maxBudget, evalOptions);
                     var executionTrace = evalResult.executionTrace();
                     var builtinTrace = evalResult.builtinTrace();
 
@@ -314,17 +324,6 @@ public class JulcTransactionEvaluator implements TransactionEvaluator {
         } catch (Exception e) {
             return Result.error("Transaction evaluation failed: " + e.getMessage());
         }
-    }
-
-    private JulcVm getOrCreateVm() {
-        if (vm == null) {
-            synchronized (this) {
-                if (vm == null) {
-                    vm = JulcVm.create();
-                }
-            }
-        }
-        return vm;
     }
 
     private com.bloxbean.cardano.julc.vm.JulcVmProvider getProvider() {

--- a/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluatorTest.java
+++ b/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluatorTest.java
@@ -16,6 +16,7 @@ import com.bloxbean.cardano.julc.core.Term;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.JulcVm;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.java.cost.CostModelParser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -160,6 +161,94 @@ class JulcTransactionEvaluatorTest {
         assertTrue(evalResult.getExUnits().getMem().longValue() > 0
                 || evalResult.getExUnits().getSteps().longValue() > 0,
                 "Expected non-zero ExUnits");
+    }
+
+    @Test
+    void evaluateTx_usesSuppliedCostModel_notBuiltInDefault() throws Exception {
+        // Regression for the provider-instance bug: the cost model was applied to one provider
+        // instance (getOrCreateVm/JulcVm.create) but evaluation ran on another (getProvider), so the
+        // chain cost model from ProtocolParams was silently ignored and the VM's built-in default was
+        // used. We supply two PlutusV3 cost models that differ (one with every cost doubled) via
+        // ProtocolParams.costModelsRaw and assert the evaluated CPU budget changes. Pre-fix, both runs
+        // would have produced the same (built-in default) budget and this test would FAIL.
+        String scriptAddr = buildScriptAddress(alwaysTrueHash);
+        String txHash = "ab".repeat(32);
+
+        Utxo inputUtxo = Utxo.builder()
+                .txHash(txHash)
+                .outputIndex(0)
+                .address(scriptAddr)
+                .amount(List.of(Amount.lovelace(BigInteger.valueOf(5_000_000))))
+                .build();
+
+        var redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.ZERO)
+                .data(new BigIntPlutusData(BigInteger.ZERO))
+                .exUnits(ExUnits.builder().mem(BigInteger.ZERO).steps(BigInteger.ZERO).build())
+                .build();
+
+        var tx = Transaction.builder()
+                .body(TransactionBody.builder()
+                        .inputs(List.of(new TransactionInput(txHash, 0)))
+                        .outputs(List.of())
+                        .fee(BigInteger.valueOf(200_000))
+                        .build())
+                .witnessSet(TransactionWitnessSet.builder()
+                        .redeemers(List.of(redeemer))
+                        .plutusV3Scripts(List.of(alwaysTrueScript))
+                        .build())
+                .build();
+        byte[] cbor = tx.serialize();
+
+        // A valid PV10 PlutusV3 cost model (297 entries; pvMajor defaults to 10 in the evaluator),
+        // and a copy with every cost doubled.
+        long[] baseCosts = CostModelParser.defaultToFlatArray(10);
+        long[] scaledCosts = new long[baseCosts.length];
+        for (int i = 0; i < baseCosts.length; i++) {
+            scaledCosts[i] = baseCosts[i] * 2;
+        }
+
+        long baseCpu = evaluateV3SpendCpu(cbor, inputUtxo, baseCosts);
+        long scaledCpu = evaluateV3SpendCpu(cbor, inputUtxo, scaledCosts);
+
+        assertTrue(baseCpu > 0, "expected a non-zero CPU budget");
+        assertNotEquals(baseCpu, scaledCpu,
+                "supplied cost model must drive the budget; equal values mean the evaluator is "
+                        + "ignoring setCostModelParams and using the built-in default (the bug)");
+        assertTrue(scaledCpu > baseCpu, "doubling all costs should increase the CPU budget");
+    }
+
+    /** Evaluate the single spend redeemer with a supplied PlutusV3 cost model; return CPU steps. */
+    private long evaluateV3SpendCpu(byte[] cbor, Utxo inputUtxo, long[] v3Costs) throws Exception {
+        UtxoSupplier utxoSupplier = new UtxoSupplier() {
+            @Override
+            public List<Utxo> getPage(String address, Integer nrOfItems, Integer page,
+                    com.bloxbean.cardano.client.api.common.OrderEnum order) {
+                return List.of();
+            }
+            @Override
+            public Optional<Utxo> getTxOutput(String txHash, int outputIndex) {
+                return Optional.empty();
+            }
+        };
+        ProtocolParamsSupplier protocolParamsSupplier = () -> {
+            var params = new ProtocolParams();
+            params.setMaxTxExMem("14000000");
+            params.setMaxTxExSteps("10000000000");
+            var raw = new LinkedHashMap<String, List<Long>>();
+            var list = new ArrayList<Long>(v3Costs.length);
+            for (long c : v3Costs) {
+                list.add(c);
+            }
+            raw.put("PlutusV3", list);
+            params.setCostModelsRaw(raw);
+            return params;
+        };
+        var evaluator = new JulcTransactionEvaluator(utxoSupplier, protocolParamsSupplier, null);
+        var result = evaluator.evaluateTx(cbor, Set.of(inputUtxo));
+        assertTrue(result.isSuccessful(), "eval should succeed: " + result.getResponse());
+        return result.getValue().getFirst().getExUnits().getSteps().longValue();
     }
 
     @Test

--- a/julc-vm-scalus/build.gradle
+++ b/julc-vm-scalus/build.gradle
@@ -15,7 +15,7 @@ sourceSets {
 
 dependencies {
     api project(':julc-vm')
-    implementation 'org.scalus:scalus_3:0.16.0'
+    implementation 'org.scalus:scalus_3:0.17.0'
 }
 
 publishing {

--- a/julc-vm-scalus/src/main/java/com/bloxbean/cardano/julc/vm/scalus/ScalusVmProvider.java
+++ b/julc-vm-scalus/src/main/java/com/bloxbean/cardano/julc/vm/scalus/ScalusVmProvider.java
@@ -1,6 +1,5 @@
 package com.bloxbean.cardano.julc.vm.scalus;
 
-import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.Term;
@@ -41,10 +40,11 @@ public class ScalusVmProvider implements JulcVmProvider {
     @Override
     public void setCostModelParams(long[] costModelValues, PlutusLanguage language,
                                    int protocolMajorVersion, int protocolMinorVersion) {
-        // Map protocol major version to Scalus MajorProtocolVersion
-        MajorProtocolVersion pv = protocolMajorVersion >= 10
-                ? MajorProtocolVersion.plominPV()
-                : MajorProtocolVersion.changPV();
+        // Map the chain's protocol major version DIRECTLY to Scalus's MajorProtocolVersion
+        // (9 -> changPV, 10 -> plominPV, 11 -> vanRossemPV, and future versions). Do NOT collapse
+        // 11+ to plominPV: PlutusVM gates PV11 semantics (e.g. case-on-builtins) on
+        // protocolVersion >= vanRossemPV, so feeding the wrong version silently disables them.
+        MajorProtocolVersion pv = new MajorProtocolVersion(protocolMajorVersion);
         this.protocolVersion = pv;
 
         // Only V3 supports custom MachineParams in Scalus; V1/V2 use built-in defaults
@@ -59,10 +59,12 @@ public class ScalusVmProvider implements JulcVmProvider {
         }
         scala.collection.immutable.IndexedSeq<Object> indexedSeq = builder.result();
 
-        // Build CostModels map: Language.PlutusV3 -> indexedSeq
+        // Build CostModels map: the key MUST be the integer languageId (Language.PlutusV3.languageId() == 2,
+        // which equals the enum ordinal). MachineParams.fromCostModels() looks the model up via
+        // boxToInteger(language.ordinal()), so keying by the Language enum object caused "key not found: 2".
         scala.collection.immutable.Map<Object, scala.collection.immutable.IndexedSeq<Object>> map =
                 scala.collection.immutable.Map$.MODULE$.<Object, scala.collection.immutable.IndexedSeq<Object>>empty()
-                        .updated(Language.PlutusV3, indexedSeq);
+                        .updated(Language.PlutusV3.languageId(), indexedSeq);
 
         CostModels costModels = new CostModels(map);
         this.machineParams = MachineParams.fromCostModels(costModels, Language.PlutusV3, pv);
@@ -128,8 +130,10 @@ public class ScalusVmProvider implements JulcVmProvider {
 
             // Evaluate using evaluateDeBruijnedTerm (general evaluation,
             // does not enforce script return-value semantics like evaluateScriptDebug)
+            // Scalus 0.17.0 added a 4th 'tracing' boolean (default false); pass false to preserve
+            // the prior 3-arg behaviour (no script return-value enforcement / tracing).
             scalus.uplc.Term scalusResult = vm.evaluateDeBruijnedTerm(
-                    scalusTerm, budgetSpender, logger);
+                    scalusTerm, budgetSpender, logger, false);
 
             // Convert result
             Term resultTerm = TermConverter.fromScalus(scalusResult);


### PR DESCRIPTION
 ## Summary

  Two related fixes that make JuLC apply the **chain's** Plutus V3 cost model correctly when evaluating transactions, rather than silently falling back to built-in default. Together they correct script-budget (ExUnits) over-estimation on Plutus V11 (vanRossem) and any chain with custom cost-model params.

  - Upgrade Scalus to **0.17.0** and adapt the Scalus VM integration to its API.
  - Fix `JulcTransactionEvaluator` so cost-model setup and evaluation use the **same** VM provider instance.

  ## Why
  
  On a PV11 devnet, `JulcTransactionEvaluator` reported **65,563,707 CPU** for a script, while the node's `evaluateTx` and JuLC's own VMs (invoked correctly) reported **65,559,542 CPU** — a constant +4,165 gap (memory identical). Since `QuickTx.buildAndSign(...)` bakes the evaluator's ExUnits into the transaction, every transaction built through this evaluator carried a wrong-for-the-protocol budget. It was masked on PV10 because the built-in default happened to match. Two independent root causes had to be fixed for the chain cost model to reach the evaluating VM:

  ### 1. Scalus 0.17 integration

  `ScalusVmProvider` mishandled custom V3 cost models and protocol versions:

  - **`CostModels` map key**: keyed by the `Language.PlutusV3` enum object, but `MachineParams.fromCostModels()` looks the model up by integer language id (`languageId() == ordinal() == 2`) → runtime `key not found: 2`. Now keyed by `Language.PlutusV3.languageId()`.
  - **Protocol version mapping**: `protocolMajorVersion >= 10 ? plominPV : changPV` collapsed **PV11 → PV10**. `PlutusVM` gates PV11 semantics (e.g. case-on-builtins) on `protocolVersion >= vanRossemPV`, so this silently disabled them. Now maps directly: `new MajorProtocolVersion(protocolMajorVersion)`.
  - **Scalus 0.17 API**: `evaluateDeBruijnedTerm` gained a 4th `tracing` boolean; pass `false` to preserve prior non-tracing behaviour.
  - Bump `scalus_3` and `scalus-bloxbean-cardano-client-lib_3` to `0.17.0`, and `cardano-client-lib` to `0.7.2`.

  ### 2. Single VM provider instance 
  
  `JulcTransactionEvaluator` configured the cost model on one provider instance but evaluated on another:

  - **Setup**: `getOrCreateVm()` → `JulcVm.create()` did its own `ServiceLoader` lookup → instance **A**; `setCostModelParams(...)` ran on **A**.
  - **Eval**: `JulcVm.withProvider(getProvider(), lang)` — a *separate* `ServiceLoader` lookup → instance **B**; evaluation ran on **B**.

  Cost-model params are stored per provider instance, so **B** never received the chain cost model and fell back to its built-in (PV10-shaped) default. Affected all backends (Java, Truffle, Scalus).

  Fix: resolve the provider once via `getProvider()` and use that same instance for both `setCostModelParams` and `evaluateWithArgs`, passing the resolved script's language explicitly. Remove the now-unused `vm` field, `getOrCreateVm()`, and the `JulcVm` import. Document the evaluator's (unchanged) non-thread-safe contract.

  ## Behavioral change
  
  Transactions built via this evaluator now use the **chain's** cost model for ExUnits on non-PV10 protocol versions (and any custom cost models), instead of the built-in default. Budgets/fees will change accordingly on such chains
  (correctly).

  ## Tests
  
  - New regression test `evaluateTx_usesSuppliedCostModel_notBuiltInDefault`: supplies two differing PlutusV3 cost models (one with every cost doubled) and asserts the evaluated CPU budget tracks the supplied model — pre-fix both runs  produced the same built-in-default budget and the test fails.
  - `JulcTransactionEvaluatorTest`: 19/19 pass.
  - Integration (`EscrowBudgetComparisonTest`, julc-examples, Yaci DevKit PV11): JuLC Java VM, JuLC Scalus VM, and the DevKit `evaluateTx` endpoint now all report **65,559,542 / 208,684**; strict-equality and 3-way comparison pass.

  ## Out of scope (tracked separately)

  - JuLC's Java/Truffle VMs don't yet gate PV11-introduced features (case-on-builtins, new builtins) by protocol version.
  - `JulcTransactionEvaluator` thread-safety is documented, not enforced; making per-call cost-model config atomic (or per-call rather than instance state) is a follow-up.
