### PR TITLE
Hide JRL scaffolding and apply JuLC Gradle plugin in new projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,9 @@ bin/
 
 ### Mac OS ###
 .DS_Store
-/.claude/
+/.claude/*
+!/.claude/skills/
+!/.claude/skills/**
 /.idea/
 .jqwik-database
 /.playwright-mcp/

--- a/adr/025-julc-test-automation-skills.md
+++ b/adr/025-julc-test-automation-skills.md
@@ -1,0 +1,298 @@
+# ADR-025: JuLC Test-Automation Skills
+
+**Date**: 2026-05-21
+**Status**: Proposed
+
+---
+
+## Context
+
+JuLC's unit and integration tests cover the compiler, VM, annotation processor,
+Gradle plugin internals, and stdlib in detail, but several recent regressions
+slipped past the in-repo suite and only surfaced through manual sanity checks
+against the external `julc-examples` project:
+
+- The `bundleJulcSources` task wrote into `build/resources/main`, which Gradle's
+  implicit-dependency validator rejects when `compileTestJava` runs (ADR-024).
+- The annotation processor failed to discover stdlib `@OnchainLibrary` source
+  files (`Undefined variable: ValuesLib`) when invoked under Gradle, even
+  though direct `JulcCompiler` use worked. This regression is currently being
+  diagnosed.
+- A validator whose Javadoc mentioned `@OnchainLibrary` was misclassified as a
+  library (ADR-023, MpfRegistryValidator).
+- Legacy `@Validator` / `@MintingPolicy` removal affected downstream projects
+  that depend on JuLC via Maven local.
+
+What the in-repo suite does not exercise:
+
+- End-to-end "publish to mavenLocal → consume from a fresh Gradle project"
+  flow, including Gradle daemon caching behavior.
+- CLI commands invoked as a user would invoke them (`julc init`, `julc check`,
+  `julc build`, `julc test`).
+- Library jar produced by project A consumed by project B (cross-jar bundling
+  and FQCN resolution through annotation processor classpath).
+- Configuration-cache compatibility and Gradle 9 deprecation warnings under
+  realistic project layouts.
+- The full `julc-examples` build against the local SNAPSHOT.
+
+These gaps are repeatedly the place where regressions land. They are also the
+gaps that are tedious to test by hand: each round of manual verification
+involves publishing to mavenLocal, stopping Gradle daemons, creating temp
+projects, writing throwaway sources, and inspecting jar contents.
+
+## Decision
+
+Introduce a layered set of Claude Code skills under
+`.claude/commands/` that automate these manual flows. Skills
+compose so that foundation work (build + publish) runs once per test session,
+and higher-level scenarios reuse it.
+
+Each skill is a self-contained markdown slash command invoked directly (e.g.
+`/julc-publish-local`). These are dev-facing skills for JuLC language
+developers, distinct from the user-facing `julc` skill at
+`tools/claude-skill/julc/` (which targets end users writing validators).
+Skills are not new Gradle tasks or JUnit tests; they exist precisely to cover
+the gap between in-repo unit tests and "did I break something downstream?"
+
+## Skill Catalog
+
+### Foundation
+
+1. **`julc-publish-local`**
+   - Runs a fast subset of unit tests
+     (`:julc-stdlib :julc-compiler :julc-gradle-plugin :julc-annotation-processor`).
+   - `./gradlew publishToMavenLocal -PskipSigning`.
+   - `./gradlew --stop` and verifies no stale daemon classes (the ADR-024
+     gotcha).
+   - Echoes the published version (read from `gradle.properties`).
+   - Used as a prerequisite step by every downstream skill. Skips if a marker
+     file in the session workspace indicates the same SHA was already
+     published.
+
+### Smoke (basic happy paths, ~30–60s each)
+
+2. **`julc-smoke-gradle-plugin`**
+   - Temp Gradle project applying `id 'com.bloxbean.cardano.julc'`.
+   - Minimal `@SpendingValidator` returning `true`.
+   - `./gradlew clean build --configuration-cache --warning-mode fail`.
+   - Asserts `build/plutus/<Name>.json` exists.
+
+3. **`julc-smoke-gradle-stdlib-usage`**
+   - Same shape but the validator uses `ValuesLib`, `OutputLib`, `ContextsLib`.
+   - This is the smoke test that would have caught the current
+     "Undefined variable: ValuesLib" regression.
+
+4. **`julc-smoke-cli-init-build`**
+   - Uses the built CLI distribution (`./gradlew :julc-cli:installDist`).
+   - `julc init my-project`, then `julc check`, then `julc build`.
+
+5. **`julc-smoke-cli-test`**
+   - Continuation of init-build: writes a `@Test` method, runs `julc test`.
+
+### Integration (multi-step, cross-jar)
+
+6. **`julc-test-library-roundtrip`** — the highest-value catcher
+   - Project A bundles an `@OnchainLibrary`, publishes its jar to mavenLocal.
+   - Project B depends on A via mavenLocal and uses the library in a
+     `@SpendingValidator`.
+   - Verifies B compiles, produces UPLC, and exits clean.
+
+7. **`julc-test-multimodule`**
+   - Single multi-project Gradle build with `:lib` and `:validator` modules.
+   - Cheaper than roundtrip; exercises same-build library discovery.
+
+8. **`julc-test-blueprint`**
+   - Verifies CIP-57 `plutus.json` generation: schema presence, validator
+     listing, hash format.
+
+9. **`julc-test-testkit`**
+   - Temp project using `julc-testkit` to compile + evaluate a validator from
+     JUnit.
+
+### Negative (error-path verification)
+
+10. **`julc-test-error-paths`**
+    Single skill exercising several misuse scenarios; each subcase asserts a
+    specific error message:
+    - `@OnchainLibrary` only in Javadoc → silently not bundled (no error).
+    - Nested `@OnchainLibrary` → "must be top-level" error.
+    - `@OnchainLibrary` + `@SpendingValidator` → "must not combine" error.
+    - Legacy `@Validator` / `@MintingPolicy` → migration error.
+    - Misnamed file (class `Foo` in `Bar.java`) → path-mismatch error.
+    - Library source with a validator annotation → clear rejection.
+
+### External-project verification
+
+11. **`julc-test-julc-examples`**
+    - `julc-publish-local`, then
+      `cd /Users/satya/work/bloxbean/julc-examples && ./gradlew --stop && ./gradlew clean test --refresh-dependencies`.
+    - Reports per-example pass/fail. This is the skill that would have caught
+      every recent downstream regression in this branch's history.
+
+12. **`julc-test-yaci-e2e`** (requires Yaci Devkit)
+    - Probes `http://localhost:10000/local-cluster/api/admin/devnet`; skips
+      with a clear note if not running.
+    - If running: resets devnet, builds a validator, submits a transaction,
+      verifies success.
+
+### Maintenance
+
+13. **`julc-cleanup-test-artifacts`**
+    - Removes the skill workspace directory tree.
+
+## Composite Skills (user-facing entry points)
+
+14. **`julc-test-quick`** (~2 min): `julc-publish-local` +
+    `julc-smoke-gradle-plugin` + `julc-smoke-gradle-stdlib-usage` +
+    `julc-test-error-paths`. Catches ~80% of recent regression classes.
+
+15. **`julc-test-full`** (~8 min, no Yaci): quick + `library-roundtrip` +
+    `multimodule` + `blueprint` + `testkit` + `julc-examples`.
+
+16. **`julc-test-release`** (~15 min, requires Yaci): full + CLI smokes +
+    `yaci-e2e`. Pre-release gate.
+
+## Conventions
+
+The following conventions apply to every skill in the catalog. They are
+mandatory; deviations should be called out explicitly in the skill's
+description.
+
+- **Workspace root**: `~/.julc-test-workspace/<skill-name>/<timestamp>/`.
+  Survives reboots (unlike `/tmp` on macOS) so failure artifacts remain
+  available for post-mortem. The maintenance skill cleans it up.
+
+- **Version pinning**: each skill reads `version` from
+  `/Users/satya/work/bloxbean/julc/gradle.properties` and substitutes it into
+  generated `build.gradle` / `pom.xml`. No hardcoded versions. The version is
+  echoed at the start of every run so failure logs are unambiguous.
+
+- **Daemon hygiene**: any skill that depends on a freshly published artifact
+  calls `./gradlew --stop` in both the JuLC repo and the temp project before
+  running. Documented in ADR-024 — stale daemons keep stale annotation
+  processor class definitions in memory and silently mask regressions.
+
+- **Structured outcome**: each skill exits with `0` on PASS and non-zero on
+  FAIL. Last line of stdout is exactly `PASS` or `FAIL: <reason>`. This makes
+  composition trivial (composite skills check exit codes, not parse text).
+
+- **Idempotency**: re-running a skill on the same workspace must work without
+  manual cleanup. Skills create timestamped subdirectories rather than
+  overwriting.
+
+- **Composition over duplication**: composite skills invoke leaf skills via
+  the `Skill` tool. Leaf skills do not duplicate publish/setup logic.
+
+- **Skip with note**: when a precondition is unmet (Yaci not running, CLI
+  distribution not built), skills exit with `SKIP: <reason>` and exit code 0.
+  Composite skills treat SKIP as a non-failure but report it in the summary.
+
+## File Layout
+
+```
+.claude/commands/
+├── julc-publish-local.md
+├── julc-smoke-gradle-plugin.md
+├── julc-smoke-gradle-stdlib-usage.md
+├── julc-smoke-cli-init-build.md
+├── julc-smoke-cli-test.md
+├── julc-test-library-roundtrip.md
+├── julc-test-multimodule.md
+├── julc-test-blueprint.md
+├── julc-test-testkit.md
+├── julc-test-error-paths.md
+├── julc-test-julc-examples.md
+├── julc-test-yaci-e2e.md
+├── julc-cleanup-test-artifacts.md
+├── julc-test-quick.md         # composite
+├── julc-test-full.md          # composite
+└── julc-test-release.md       # composite
+```
+
+Each command file follows the template:
+
+1. **Purpose** — one sentence.
+2. **When to trigger** — user-visible phrases that should invoke this skill.
+3. **Inputs / environment** — required env vars, expected working directory.
+4. **Steps** — numbered bash sequence (or `Skill` invocations for composites).
+5. **Assertions** — what success looks like.
+6. **Cleanup** — what (if anything) is removed at end.
+7. **Expected output** — sample PASS line, sample FAIL line.
+
+## Implementation Order
+
+Skills should be added in this order so each unlocks downstream value:
+
+1. `julc-publish-local` — foundation; everything else depends on it.
+2. `julc-smoke-gradle-plugin` — proves the foundation works end-to-end.
+3. `julc-smoke-gradle-stdlib-usage` — directly catches the current AP
+   classpath regression.
+4. `julc-test-library-roundtrip` — highest-value integration catcher.
+5. `julc-test-error-paths` — locks in ADR-023 negative scenarios.
+6. `julc-test-julc-examples` — converts the existing manual sanity check into
+   automation.
+7. `julc-cleanup-test-artifacts` — quick hygiene win.
+8. `julc-test-quick` composite — first "ship it?" button.
+9. CLI smokes, multimodule, blueprint, testkit (ordered by perceived risk).
+10. `julc-test-yaci-e2e` and the `release` composite last.
+
+## Verification
+
+To validate the skill catalog itself (separate from validating JuLC):
+
+- Run `julc-test-quick` against the current branch. Expected: PASS.
+- Intentionally introduce the historical `bundleJulcSources` resource-path bug
+  (write to `build/resources/main` directly). Re-run `julc-test-quick`.
+  Expected: FAIL with a clear pointer to `compileTestJava`.
+- Intentionally re-introduce the Javadoc `@OnchainLibrary` misclassification.
+  Re-run. Expected: `julc-test-error-paths` FAILs with a clear pointer.
+- Run `julc-test-full` without Yaci. Expected: SKIP for `yaci-e2e`, PASS for
+  the rest.
+
+The catalog is considered working once the three reintroduced regressions are
+each caught by a distinct skill.
+
+## Consequences
+
+Benefits:
+
+- Regressions that depend on cross-jar / cross-project behavior get a fast,
+  reproducible automation layer instead of relying on manual smoke testing.
+- The "publish + consume + verify" loop, currently the slowest part of
+  validating a release candidate, becomes a single skill invocation.
+- Skill names map cleanly to bug classes ("did stdlib discovery break?" →
+  `julc-smoke-gradle-stdlib-usage`), so future bug reports can cite the
+  catching skill.
+
+Tradeoffs:
+
+- Skills live outside the Gradle test suite, so CI integration is a separate
+  question (each skill can be wrapped in a shell job, but is not automatic).
+- Maintaining temp-project templates inside markdown skill files is brittle
+  compared to keeping them in a normal test source tree. Mitigation: keep
+  templates minimal; complex templates can live under
+  `.claude/templates/` and be referenced by skills.
+- The skill catalog grows the surface area of `.claude/commands/`.
+  Documented in this ADR + each skill's "When to trigger" section.
+- These dev-facing skills live alongside (not under) the user-facing
+  `tools/claude-skill/julc/` skill; the two have different audiences (JuLC
+  language developers vs. JuLC end users) and different distribution paths.
+
+## Non-Goals
+
+- Replace existing JUnit / Gradle test suites. Skills complement, not
+  duplicate, the in-repo suite.
+- Become a CI pipeline. CI integration is a follow-up; this ADR scopes the
+  local-development surface only.
+- Cover non-JuLC tooling (Yaci Store MCP, etc.).
+- Cover Maven plugin flows unless a JuLC Maven plugin actually ships.
+
+## Follow-Up
+
+- Wire the composite skills into a GitHub Actions job that runs on
+  pre-release tags. Out of scope here.
+- If `.claude/templates/` is created (for shared temp-project skeletons),
+  document its contract in a top-level note so users editing skills know
+  where to look.
+- Consider exporting the failure log structure so CI integrations can grep
+  for `FAIL:` deterministically.

--- a/adr/026-julc-new-jrl-removal-gradle-plugin-template.md
+++ b/adr/026-julc-new-jrl-removal-gradle-plugin-template.md
@@ -1,0 +1,127 @@
+# ADR-026: Hide JRL from `julc new` and Apply the Gradle Plugin in the Scaffolded Gradle Template
+
+Date: 2026-06-08
+
+## Status
+
+Accepted and implemented.
+
+## Goal
+
+Two scaffolding (`julc new`) improvements:
+
+1. Stop advertising the experimental **JRL (JuLC Rule Language)** project type from the CLI, since
+   JRL is not being publicly announced yet.
+2. Make a scaffolded **Gradle** project able to publish a reusable `@OnchainLibrary` out of the box,
+   by applying the official JuLC Gradle plugin in the generated `build.gradle`.
+
+The two changes are independent and are bundled in one ADR because both touch the `julc new`
+scaffolding surface only.
+
+## Decision 1 — Remove the `--jrl` option from `julc new`
+
+`julc new --jrl` scaffolded a `.jrl` starter contract instead of a `.java` validator. We remove the
+flag and the now-dead `.jrl` scaffolding branch:
+
+- `NewCommand.java`: delete the `@Option(names = {"--jrl"})` field; call the existing two-argument
+  `ProjectScaffolder.scaffold(projectRoot, name)`; drop the `"JRL project"` success message variant.
+- `ProjectScaffolder.java`: collapse to a single `scaffold(Path, String)` method, removing the
+  `boolean jrl` parameter and the `if (jrl) { … AlwaysSucceeds.jrl … }` branch. The Java validator
+  path is retained unchanged.
+
+### Scope boundary
+
+This is a **CLI-surface-only** change. We intentionally keep:
+
+- `.jrl` scanning and compilation in `julc build` / `julc check`
+  (`ProjectScanner.java`, `BuildCommand.java`) — hand-written `.jrl` files still build.
+- The `julc-jrl` module, its `settings.gradle` include, and the `julc-cli` dependency on it.
+
+So re-enabling the option later (when JRL is announced) is a small, additive change: restore the flag
+and the scaffolding branch. Nothing in the JRL compiler pipeline is deleted.
+
+### Known follow-up
+
+`docs/src/content/docs/experimental/jrl-guide.md` still instructs `julc new my-contract --jrl`, which
+no longer works. The guide lives under `experimental/`; updating or dropping that instruction is a
+minor, non-blocking follow-up tracked separately.
+
+## Decision 2 — Apply the Gradle plugin in the generated Gradle template
+
+The scaffolded Gradle `build.gradle` previously applied only `id 'java'` and relied solely on the
+JuLC **annotation processor**. The annotation processor compiles validators and writes the blueprint
+to `META-INF/plutus/`, but it **does not bundle `@OnchainLibrary` source files**. Only the Gradle
+plugin's `bundleJulcSources` task writes them to `META-INF/plutus-sources/`, which is exactly where
+`LibrarySourceResolver` (used by downstream consumers' annotation processors) looks. Consequently, a
+scaffolded Gradle project could not publish a reusable on-chain library.
+
+We add the plugin to the generated `build.gradle`:
+
+```gradle
+plugins {
+    id 'java'
+    // Bundles @OnchainLibrary sources into META-INF/plutus-sources/ in the jar
+    // so downstream projects can discover and reuse them.
+    id 'com.bloxbean.cardano.julc' version '<julcVersion>'
+}
+```
+
+The version is the same `JulcVersionProvider.VERSION` already injected for the dependency
+coordinates, substituted as a literal in the `plugins {}` block. The generated `settings.gradle`
+already declares `pluginManagement` repositories (`mavenLocal()`, the Sonatype snapshots repo, and
+`gradlePluginPortal()`), so the plugin marker resolves with no `settings.gradle` change.
+
+### Why this is safe (no regression to `./gradlew build`)
+
+Verified against the plugin source:
+
+- `CompileJulcTask.getSourceDir()` is annotated `@SkipWhenEmpty` and defaults to `src/main/plutus`.
+  The template never creates that directory, so `compileJulc` is **skipped** (not failed), and
+  `build.dependsOn(compileJulc)` treats a skipped task as success.
+- `BundleJulcSourcesTask` scans `src/main/java`. With only the `AlwaysSucceeds` validator (which is
+  not `@OnchainLibrary`), it logs "No `@OnchainLibrary` sources found" and writes nothing. When the
+  user later adds an `@OnchainLibrary` class, its source is bundled automatically.
+- The plugin applies `JavaPlugin` internally; combining it with `id 'java'` is idempotent and matches
+  how `julc-examples` applies it.
+
+This matches the canonical pattern documented in
+`docs/src/content/docs/reference/library-developer-guide.md` and exercised by the
+`julc-test-library-roundtrip` and `julc-test-multimodule` skills.
+
+### Scope boundary
+
+The Maven template is unchanged — there is no Maven equivalent of the JuLC Gradle plugin, so Maven
+projects still cannot auto-bundle `@OnchainLibrary` sources. The BASIC (`julc.toml`/CLI) template is
+unaffected.
+
+## Verification
+
+```bash
+# Unit tests for the scaffolders (no Gradle execution required)
+./gradlew :julc-cli:test
+```
+
+`JulcIntegrationTest.scaffoldGradleProject` is extended to assert the generated `build.gradle` applies
+`id 'com.bloxbean.cardano.julc' version '<JulcVersionProvider.VERSION>'`. The existing
+`scaffoldBuildCheck`, `scaffoldContext`, and `scaffoldMavenProject` tests continue to pass after the
+`ProjectScaffolder` signature change.
+
+End-to-end (manual / skill-driven):
+
+```bash
+# Plugin marker + artifacts must be in Maven local first
+./gradlew publishToMavenLocal
+./gradlew --stop
+
+# Task 1: --jrl is gone
+julc new demo            # scaffolds AlwaysSucceeds.java
+julc new demo --jrl      # now fails with "Unknown option: '--jrl'"
+
+# Task 2: gradle template builds with the plugin applied (compileJulc SKIPPED)
+julc new gdemo -t gradle
+cd gdemo && ./gradlew build
+```
+
+Bundling can be confirmed by adding a minimal `@OnchainLibrary` under `src/main/java` and asserting the
+jar contains `META-INF/plutus-sources/<pkg>/<Lib>.java` plus `index.txt` — the same assertion used by
+`julc-test-library-roundtrip`.

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/JulcVersionProvider.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/JulcVersionProvider.java
@@ -7,7 +7,7 @@ public class JulcVersionProvider implements CommandLine.IVersionProvider {
 
     public static final String VERSION = JulcVersion.VERSION;
     public static final String PLUTUS_VERSION = "V3";
-    public static final String CARDANO_CLIENT_LIB_VERSION = "0.8.0-preview1";
+    public static final String CARDANO_CLIENT_LIB_VERSION = "0.8.0-pre4";
 
     @Override
     public String[] getVersion() {

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/NewCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/NewCommand.java
@@ -34,9 +34,6 @@ public class NewCommand implements Runnable {
     @Option(names = {"-p", "--package"}, description = "Java package name (default: <group>.<name>)")
     private String pkg;
 
-    @Option(names = {"--jrl"}, description = "Create a JRL (JuLC Rule Language) project instead of Java")
-    private boolean jrl;
-
     @Override
     public void run() {
         try {
@@ -50,9 +47,9 @@ public class NewCommand implements Runnable {
 
             switch (template) {
                 case BASIC -> {
-                    ProjectScaffolder.scaffold(projectRoot, name, jrl);
+                    ProjectScaffolder.scaffold(projectRoot, name);
                     System.out.println(AnsiColors.green(
-                            (jrl ? "JRL project" : "Project") + " created at ./" + name));
+                            "Project created at ./" + name));
                     System.out.println();
                     System.out.println("  cd " + name);
                     System.out.println("  julc build    # compile validators");

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/scaffold/GradleProjectScaffolder.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/scaffold/GradleProjectScaffolder.java
@@ -53,6 +53,9 @@ public final class GradleProjectScaffolder {
         return """
                 plugins {
                     id 'java'
+                    // Bundles @OnchainLibrary sources into META-INF/plutus-sources/ in the jar
+                    // so downstream projects can discover and reuse them.
+                    id 'com.bloxbean.cardano.julc' version '%s'
                 }
 
                 group = '%s'
@@ -111,7 +114,7 @@ public final class GradleProjectScaffolder {
                     useJUnitPlatform()
                     failOnNoDiscoveredTests = false
                 }
-                """.formatted(group, julcVersion, cclVersion);
+                """.formatted(julcVersion, group, julcVersion, cclVersion);
     }
 
     private static String settingsGradle(String projectName) {

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/scaffold/ProjectScaffolder.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/scaffold/ProjectScaffolder.java
@@ -15,10 +15,6 @@ public final class ProjectScaffolder {
     private ProjectScaffolder() {}
 
     public static void scaffold(Path projectRoot, String projectName) throws IOException {
-        scaffold(projectRoot, projectName, false);
-    }
-
-    public static void scaffold(Path projectRoot, String projectName, boolean jrl) throws IOException {
         // Create directory structure
         Files.createDirectories(ProjectLayout.srcDir(projectRoot));
         Files.createDirectories(ProjectLayout.testDir(projectRoot));
@@ -37,45 +33,27 @@ public final class ProjectScaffolder {
                 *.class
                 """);
 
-        // Starter validator
-        if (jrl) {
-            Files.writeString(ProjectLayout.srcDir(projectRoot).resolve("AlwaysSucceeds.jrl"),
-                    """
-                    contract "AlwaysSucceeds"
-                    version  "1.0"
-                    purpose  spending
+        // Starter validator. Uses a typed record redeemer + @SpendingValidator,
+        // modelling the idiomatic JuLC pattern (no raw PlutusData) so the file the
+        // AI sees in a fresh project matches the rules in AGENTS.md.
+        Files.writeString(ProjectLayout.srcDir(projectRoot).resolve("AlwaysSucceeds.java"),
+                """
+                import com.bloxbean.cardano.julc.stdlib.annotation.SpendingValidator;
+                import com.bloxbean.cardano.julc.stdlib.annotation.Entrypoint;
+                import com.bloxbean.cardano.julc.ledger.ScriptContext;
 
-                    rule "Always allow"
-                    when
-                        Condition( true )
-                    then
-                        allow
+                @SpendingValidator
+                public class AlwaysSucceeds {
 
-                    default: deny
-                    """);
-        } else {
-            // Use a typed record redeemer + @SpendingValidator. Models the
-            // idiomatic JuLC pattern (no raw PlutusData) so the file the AI
-            // sees in a fresh project matches the rules in AGENTS.md.
-            Files.writeString(ProjectLayout.srcDir(projectRoot).resolve("AlwaysSucceeds.java"),
-                    """
-                    import com.bloxbean.cardano.julc.stdlib.annotation.SpendingValidator;
-                    import com.bloxbean.cardano.julc.stdlib.annotation.Entrypoint;
-                    import com.bloxbean.cardano.julc.ledger.ScriptContext;
+                    record Datum() {}
+                    record Redeemer() {}
 
-                    @SpendingValidator
-                    public class AlwaysSucceeds {
-
-                        record Datum() {}
-                        record Redeemer() {}
-
-                        @Entrypoint
-                        public static boolean validate(Datum datum, Redeemer redeemer, ScriptContext ctx) {
-                            return true;
-                        }
+                    @Entrypoint
+                    public static boolean validate(Datum datum, Redeemer redeemer, ScriptContext ctx) {
+                        return true;
                     }
-                    """);
-        }
+                }
+                """);
 
         // Starter test
         Files.writeString(ProjectLayout.testDir(projectRoot).resolve("AlwaysSucceedsTest.java"),

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/JulcIntegrationTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/JulcIntegrationTest.java
@@ -200,6 +200,8 @@ class JulcIntegrationTest {
         // Verify build.gradle content
         String buildGradle = Files.readString(projectRoot.resolve("build.gradle"));
         assertTrue(buildGradle.contains("group = 'com.myorg'"));
+        assertTrue(buildGradle.contains("id 'com.bloxbean.cardano.julc' version '" + JulcVersionProvider.VERSION + "'"),
+                "Gradle template must apply the julc plugin so @OnchainLibrary sources are bundled into the jar");
         assertTrue(buildGradle.contains("julcVersion = '" + JulcVersionProvider.VERSION + "'"));
         assertTrue(buildGradle.contains("cardanoClientLibVersion = '" + JulcVersionProvider.CARDANO_CLIENT_LIB_VERSION + "'"));
         assertTrue(buildGradle.contains("julc-stdlib"));

--- a/tools/claude-skill/julc/README.md
+++ b/tools/claude-skill/julc/README.md
@@ -16,6 +16,10 @@ tools/claude-skill/julc/
   README.md             # this file
 ```
 
+> Note: this is the **end-user** skill — for developers writing JuLC
+> validators. JuLC compiler-developer test-automation skills live separately
+> at `.claude/commands/julc-*.md`; see `adr/025-julc-test-automation-skills.md`.
+
 ## Install
 
 1. **Install the JuLC CLI** (provides the MCP server):


### PR DESCRIPTION
  ## Summary

  - remove the experimental `julc new --jrl` option from the public CLI surface
  - simplify the basic project scaffolder to always generate the Java starter validator
  - apply the official `com.bloxbean.cardano.julc` Gradle plugin in generated Gradle projects so `@OnchainLibrary` sources are bundled into published jars
  - bump generated project `cardano-client-lib` version to `0.8.0-pre4`
  - add ADR notes for the scaffolding change and JuLC test-automation skills