### PR TITLE
 Fix Java division semantics for negative integers

### DIFF
--- a/adr/architecture-reference.md
+++ b/adr/architecture-reference.md
@@ -362,7 +362,7 @@ Library method ordering uses Kahn's algorithm on the dependency graph, with self
 | `ValuesLib` | `geqMultiAsset`, `leq`, `eq`, `isZero`, `singleton`, `negate`, `flatten`, `add`, `subtract` |
 | `OutputLib` | `txOutAddress`, `txOutValue`, `txOutDatum`, `outputsAt`, `countOutputsAt`, `uniqueOutputAt`, `outputsWithToken`, `valueHasToken`, `lovelacePaidTo`, `paidAtLeast`, `getInlineDatum`, `resolveDatum` |
 | `ContextsLib` | `txInfoMint`, `txInfoFee`, `txInfoId`, `txInfoRefInputs`, `txInfoWithdrawals`, `txInfoRedeemers`, `findOwnInput`, `getContinuingOutputs`, `findDatum`, `valueSpent`, `valuePaid`, `ownHash`, `scriptOutputsAt`, `listIndex`, `trace` |
-| `MathLib` | `abs`, `max`, `min`, `divMod`, `quotRem`, `pow`, `sign`, `expMod` |
+| `MathLib` | `abs`, `max`, `min`, `floorDiv`, `floorMod`, `divMod`, `quotRem`, `pow`, `sign`, `expMod` |
 | `IntervalLib` | `between`, `never`, `isEmpty`, `finiteUpperBound`, `finiteLowerBound` |
 | `CryptoLib` | `verifyEcdsaSecp256k1`, `verifySchnorrSecp256k1`, `ripemd_160` |
 | `ByteStringLib` | `take`, `lessThan`, `lessThanEquals`, `integerToByteString`, `byteStringToInteger`, `encodeUtf8`, `decodeUtf8`, `serialiseData` |

--- a/docs/src/content/docs/ai/starter-pack.md
+++ b/docs/src/content/docs/ai/starter-pack.md
@@ -313,7 +313,7 @@ All imports are from `com.bloxbean.cardano.julc.stdlib.lib.*`.
 `txOutAddress(out)`, `txOutValue(out)`, `txOutDatum(out)`, `outputsAt(outputs, addr)`, `countOutputsAt(outputs, addr)`, `uniqueOutputAt(outputs, addr)`, `outputsWithToken(outputs, policy, token)`, `valueHasToken(value, policy, token)`, `lovelacePaidTo(outputs, addr)`, `paidAtLeast(outputs, addr, amount)`, `getInlineDatum(out)`, `resolveDatum(txInfo, out)`. **Prefer field access**: `out.address()`, `out.value()`, `out.datum()`.
 
 ### MathLib
-`abs(n)`, `max(a, b)`, `min(a, b)`, `divMod(a, b)` → `Tuple2`, `quotRem(a, b)` → `Tuple2`, `pow(b, e)`, `sign(n)`, `expMod(b, e, m)`.
+`abs(n)`, `max(a, b)`, `min(a, b)`, `floorDiv(a, b)`, `floorMod(a, b)`, `divMod(a, b)` → `Tuple2`, `quotRem(a, b)` → `Tuple2`, `pow(b, e)`, `sign(n)`, `expMod(b, e, m)`.
 
 ### IntervalLib
 `between(lo, hi)`, `never()`, `isEmpty(interval)`, `finiteUpperBound(interval)`, `finiteLowerBound(interval)`, `contains(interval, point)`.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -889,7 +889,7 @@ when your validator references them.
 | `ValuesLib` | `lovelaceOf`, `assetOf`, `containsPolicy`, `geq`, `geqMultiAsset`, `leq`, `eq`, `isZero`, `singleton`, `negate`, `flatten`, `flattenTyped`, `add`, `subtract`, `countTokensWithQty`, `findTokenName` |
 | `MapLib` | `lookup`, `member`, `insert`, `delete`, `keys`, `values`, `toList`, `fromList`, `size` |
 | `OutputLib` | `txOutAddress`, `txOutValue`, `txOutDatum`, `outputsAt`, `countOutputsAt`, `uniqueOutputAt`, `outputsWithToken`, `valueHasToken`, `lovelacePaidTo`, `paidAtLeast`, `getInlineDatum`, `resolveDatum`, `findOutputWithToken`, `findInputWithToken` |
-| `MathLib` | `abs`, `max`, `min`, `divMod`, `quotRem`, `pow`, `sign`, `expMod` |
+| `MathLib` | `abs`, `max`, `min`, `floorDiv`, `floorMod`, `divMod`, `quotRem`, `pow`, `sign`, `expMod` |
 | `IntervalLib` | `contains`, `always`, `after`, `before`, `between`, `never`, `isEmpty`, `finiteUpperBound`, `finiteLowerBound` |
 | `CryptoLib` | `sha2_256`, `blake2b_256`, `sha3_256`, `blake2b_224`, `keccak_256`, `verifyEd25519Signature`, `verifyEcdsaSecp256k1`, `verifySchnorrSecp256k1`, `ripemd_160` (all hash functions also available via `Builtins.*`) |
 | `ByteStringLib` | `at`, `cons`, `slice`, `length`, `drop`, `take`, `append`, `empty`, `zeros`, `equals`, `lessThan`, `lessThanEquals`, `integerToByteString`, `byteStringToInteger`, `encodeUtf8`, `decodeUtf8`, `serialiseData`, `hexNibble`, `toHex`, `intToDecimalString`, `utf8ToInteger` |

--- a/docs/src/content/docs/guides/advanced-guide.md
+++ b/docs/src/content/docs/guides/advanced-guide.md
@@ -1506,9 +1506,9 @@ Use `import java.util.Optional` or bare `Optional` in your validator code.
 `Tuple2<A,B>` and `Tuple3<A,B,C>` provide generic tuples with auto-unwrapping field access based on type arguments.
 
 ```java
-Tuple2<BigInteger, byte[]> result = MathLib.divMod(a, b);
+Tuple2<BigInteger, BigInteger> result = MathLib.divMod(a, b);
 BigInteger quotient = result.first();   // auto-generates UnIData
-byte[] remainder = result.second();     // auto-generates UnBData
+BigInteger remainder = result.second(); // auto-generates UnIData
 
 // Construction auto-wraps
 var t = new Tuple2<BigInteger, BigInteger>(val1, val2);  // auto-wraps via IData

--- a/docs/src/content/docs/internals/compiler-design.md
+++ b/docs/src/content/docs/internals/compiler-design.md
@@ -967,7 +967,7 @@ These are `@OnchainLibrary`-annotated Java classes compiled from source:
 | `ValuesLib` | 9 | Multi-asset Value operations (add, subtract, compare) |
 | `ContextsLib` | 13 | ScriptContext/TxInfo field extraction helpers |
 | `OutputLib` | 8 | TxOut querying (outputsAt, lovelacePaidTo, etc.) |
-| `MathLib` | 8 | Math utilities (abs, pow, divMod, quotRem, expMod) |
+| `MathLib` | 10 | Math utilities (abs, pow, floorDiv, floorMod, divMod, quotRem, expMod) |
 | `IntervalLib` | 5 | Time interval operations |
 | `CryptoLib` | 3 | ECDSA, Schnorr, RIPEMD-160 |
 | `ByteStringLib` | 8 | ByteString manipulation |

--- a/docs/src/content/docs/internals/compiler-developer-guide.md
+++ b/docs/src/content/docs/internals/compiler-developer-guide.md
@@ -557,8 +557,8 @@ LoopBodyGenerator calls back to PirGenerator via 7 methods (1 already public, 6 
 | `+` | `AddInteger` | `AppendString` | `AppendByteString` |
 | `-` | `SubtractInteger` | — | — |
 | `*` | `MultiplyInteger` | — | — |
-| `/` | `DivideInteger` | — | — |
-| `%` | `ModInteger` | — | — |
+| `/` | `QuotientInteger` | — | — |
+| `%` | `RemainderInteger` | — | — |
 | `==` | `EqualsInteger` / `EqualsByteString` / `EqualsString` / `EqualsData` | | |
 | `<` | `LessThanInteger` | — | — |
 | `<=` | `LessThanEqualsInteger` | — | — |
@@ -1151,7 +1151,7 @@ Used for type inference in chained method calls. For example, `list.tail()` retu
 | `add(other)` | `AddInteger` |
 | `subtract(other)` | `SubtractInteger` |
 | `multiply(other)` | `MultiplyInteger` |
-| `divide(other)` | `DivideInteger` |
+| `divide(other)` | `QuotientInteger` |
 | `remainder(other)` | `RemainderInteger` |
 | `mod(other)` | `ModInteger` |
 | `signum()` | `if x < 0 then -1 else if x == 0 then 0 else 1` |

--- a/docs/src/content/docs/reference/api-reference.md
+++ b/docs/src/content/docs/reference/api-reference.md
@@ -56,9 +56,9 @@ Off-chain: backed by `JulcArrayImpl`, wrapping `java.util.List` with O(1) index 
 Generic tuples with auto-unwrapping field access based on type arguments.
 
 ```java
-Tuple2<BigInteger, byte[]> result = MathLib.divMod(a, b);
+Tuple2<BigInteger, BigInteger> result = MathLib.divMod(a, b);
 BigInteger quotient = result.first();   // auto-generates UnIData
-byte[] remainder = result.second();     // auto-generates UnBData
+BigInteger remainder = result.second(); // auto-generates UnIData
 
 // Construction auto-wraps
 var t = new Tuple2<BigInteger, BigInteger>(val1, val2);  // auto-wraps via IData
@@ -125,7 +125,7 @@ var items2 = PlutusData.cast(data, JulcList.class);                 // element t
 | `+` | `b1 + b2` | `AppendByteString` | For `byte[]` operands |
 | `-` | `a - b` | `SubtractInteger` | |
 | `*` | `a * b` | `MultiplyInteger` | |
-| `/` | `a / b` | `DivideInteger` | |
+| `/` | `a / b` | `QuotientInteger` | Truncates toward zero, matching Java |
 | `%` | `a % b` | `RemainderInteger` | |
 
 The `+` operator is type-aware: the compiler infers the operand type and dispatches to the correct builtin.
@@ -361,7 +361,7 @@ boolean hasSigner = ctx.txInfo().signatories().contains(datum.beneficiary());
 | `.add(other)` | `BigInteger` | `AddInteger` |
 | `.subtract(other)` | `BigInteger` | `SubtractInteger` |
 | `.multiply(other)` | `BigInteger` | `MultiplyInteger` |
-| `.divide(other)` | `BigInteger` | `DivideInteger` |
+| `.divide(other)` | `BigInteger` | `QuotientInteger` |
 | `.remainder(other)` | `BigInteger` | `RemainderInteger` |
 | `.mod(other)` | `BigInteger` | `ModInteger` |
 | `.signum()` | `BigInteger` | `IfThenElse` chain |
@@ -574,9 +574,13 @@ Import from `com.bloxbean.cardano.julc.stdlib.lib.*` in validators. See [Standar
 | `min(a, b)` | Integer, Integer | Minimum |
 | `pow(base, exp)` | Integer, Integer | Exponentiation |
 | `sign(x)` | Integer | Sign (-1, 0, or 1) |
-| `divMod(a, b)` | Integer, Integer | Returns Tuple2(quotient, remainder) |
+| `floorDiv(a, b)` | Integer, Integer | Floor division |
+| `floorMod(a, b)` | Integer, Integer | Floor modulo |
+| `divMod(a, b)` | Integer, Integer | Returns Tuple2(floor division, floor modulo) |
 | `quotRem(a, b)` | Integer, Integer | Returns Tuple2(quotient, remainder) |
 | `expMod(base, exp, mod)` | Integer, Integer, Integer | Modular exponentiation |
+
+Use `MathLib.floorDiv` and `MathLib.floorMod` for `BigInteger` floor division. `java.lang.Math.floorDiv` and `Math.floorMod` are valid for normal Java `int`/`long` calls, but the JDK does not provide `BigInteger` overloads for those methods.
 
 ### IntervalLib
 

--- a/docs/src/content/docs/stdlib/stdlib-guide.md
+++ b/docs/src/content/docs/stdlib/stdlib-guide.md
@@ -15,7 +15,7 @@ The JuLC standard library provides 13 on-chain libraries in the `com.bloxbean.ca
 | **ValuesLib** | `com.bloxbean.cardano.julc.stdlib.lib.ValuesLib` | Multi-asset Value comparison, arithmetic, and extraction |
 | **MapLib** | `com.bloxbean.cardano.julc.stdlib.lib.MapLib` | Association list (map) lookup, insert, delete, keys/values |
 | **OutputLib** | `com.bloxbean.cardano.julc.stdlib.lib.OutputLib` | Output filtering by address/token, lovelace summation, datum extraction |
-| **MathLib** | `com.bloxbean.cardano.julc.stdlib.lib.MathLib` | abs, max, min, pow, divMod, quotRem, expMod, sign |
+| **MathLib** | `com.bloxbean.cardano.julc.stdlib.lib.MathLib` | abs, max, min, pow, floorDiv, floorMod, divMod, quotRem, expMod, sign |
 | **IntervalLib** | `com.bloxbean.cardano.julc.stdlib.lib.IntervalLib` | Time interval construction, containment, bound extraction |
 | **CryptoLib** | `com.bloxbean.cardano.julc.stdlib.lib.CryptoLib` | Hash functions and signature verification |
 | **ByteStringLib** | `com.bloxbean.cardano.julc.stdlib.lib.ByteStringLib` | ByteString slicing, comparison, encoding, serialization |
@@ -148,9 +148,13 @@ The JuLC standard library provides 13 on-chain libraries in the `com.bloxbean.ca
 | `min(a, b)` | Minimum of two integers |
 | `pow(base, exp)` | Exponentiation |
 | `sign(x)` | Sign: -1, 0, or 1 |
-| `divMod(a, b)` | Division and modulo as Tuple2 |
+| `floorDiv(a, b)` | Floor division |
+| `floorMod(a, b)` | Floor modulo |
+| `divMod(a, b)` | Floor division and modulo as Tuple2 |
 | `quotRem(a, b)` | Quotient and remainder as Tuple2 |
 | `expMod(base, exp, mod)` | Modular exponentiation |
+
+Use `MathLib.floorDiv` and `MathLib.floorMod` for `BigInteger` floor division. `java.lang.Math.floorDiv` and `Math.floorMod` are valid for normal Java `int`/`long` calls, but the JDK does not provide `BigInteger` overloads for those methods.
 
 ### IntervalLib
 
@@ -812,7 +816,9 @@ class MathExample {
 
 ### Division and Modular Arithmetic
 
-`divMod` and `quotRem` return `Tuple2<BigInteger, BigInteger>`. Use `.first()` and `.second()` to access results.
+`divMod` returns floor division and modulo. `quotRem` returns Java-style truncating quotient and remainder. Both return `Tuple2<BigInteger, BigInteger>`; use `.first()` and `.second()` to access results.
+
+Compatibility note: `MathLib.divMod` is floor-based. Code that needs Java-style truncating division should use `MathLib.quotRem`.
 
 ```java
 import com.bloxbean.cardano.julc.core.types.Tuple2;
@@ -824,7 +830,7 @@ class DivModExample {
         BigInteger a = BigInteger.valueOf(17);
         BigInteger b = BigInteger.valueOf(5);
 
-        // divMod returns (quotient, remainder)
+        // divMod returns (floor division, floor modulo)
         Tuple2<BigInteger, BigInteger> dm = MathLib.divMod(a, b);
         BigInteger quotient = dm.first();    // 3
         BigInteger remainder = dm.second();  // 2

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -710,7 +710,7 @@ public class PirGenerator {
             }
             case MINUS -> builtinApp2(DefaultFun.SubtractInteger, left, right);
             case MULTIPLY -> builtinApp2(DefaultFun.MultiplyInteger, left, right);
-            case DIVIDE -> builtinApp2(DefaultFun.DivideInteger, left, right);
+            case DIVIDE -> builtinApp2(DefaultFun.QuotientInteger, left, right);
             case REMAINDER -> builtinApp2(DefaultFun.RemainderInteger, left, right);
             case EQUALS -> generateEquality(left, right, leftType, false);
             case NOT_EQUALS -> generateEquality(left, right, leftType, true);

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
@@ -151,7 +151,7 @@ public final class TypeMethodRegistry {
 
         reg.register("IntegerType", "divide",
                 (scope, args, scopeType, argTypes) ->
-                        PirHelpers.builtinApp2(DefaultFun.DivideInteger, scope, args.get(0)),
+                        PirHelpers.builtinApp2(DefaultFun.QuotientInteger, scope, args.get(0)),
                 scopeType -> new PirType.IntegerType());
 
         reg.register("IntegerType", "remainder",

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.julc.compiler;
 import com.bloxbean.cardano.julc.core.*;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import com.bloxbean.cardano.julc.vm.JulcVm;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -795,6 +796,201 @@ class StdlibCompileEvalTest {
             var program = compileValidator(source);
             var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
             assertTrue(result.isSuccess(), "divMod(10,3) should be (3,1). Got: " + result);
+        }
+
+        @Test
+        void javaOperatorDivisionTruncatesTowardZeroForNegativeOperands() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            long q1 = -7 / 2;
+                            long r1 = -7 % 2;
+                            long q2 = 7 / -2;
+                            long r2 = 7 % -2;
+                            long q3 = -7 / -2;
+                            long r3 = -7 % -2;
+                            return q1 == -3 && r1 == -1 && q1 * 2 + r1 == -7
+                                && q2 == -3 && r2 == 1 && q2 * -2 + r2 == 7
+                                && q3 == 3 && r3 == -1 && q3 * -2 + r3 == -7;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "Java / and % should use truncating semantics. Got: " + result);
+        }
+
+        @Test
+        void bigIntegerDivideAndRemainderMatchJvmForNegativeOperands() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            BigInteger a = BigInteger.valueOf(-7);
+                            BigInteger b = BigInteger.valueOf(2);
+                            BigInteger c = BigInteger.valueOf(7);
+                            BigInteger d = BigInteger.valueOf(-2);
+                            BigInteger q1 = a.divide(b);
+                            BigInteger r1 = a.remainder(b);
+                            BigInteger q2 = c.divide(d);
+                            BigInteger r2 = c.remainder(d);
+                            BigInteger q3 = a.divide(d);
+                            BigInteger r3 = a.remainder(d);
+                            BigInteger q4 = c.divide(b);
+                            BigInteger r4 = c.remainder(b);
+                            return q1.equals(BigInteger.valueOf(-3))
+                                && r1.equals(BigInteger.valueOf(-1))
+                                && q1.multiply(b).add(r1).equals(a)
+                                && q2.equals(BigInteger.valueOf(-3))
+                                && r2.equals(BigInteger.ONE)
+                                && q2.multiply(d).add(r2).equals(c)
+                                && q3.equals(BigInteger.valueOf(3))
+                                && r3.equals(BigInteger.valueOf(-1))
+                                && q3.multiply(d).add(r3).equals(a)
+                                && q4.equals(BigInteger.valueOf(3))
+                                && r4.equals(BigInteger.ONE)
+                                && q4.multiply(b).add(r4).equals(c);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "BigInteger.divide/remainder should match JVM semantics. Got: " + result);
+        }
+
+        @Test
+        void explicitFloorDivisionUsesPlutusDivideAndModSemantics() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            BigInteger a = BigInteger.valueOf(-7);
+                            BigInteger b = BigInteger.valueOf(2);
+                            BigInteger c = BigInteger.valueOf(7);
+                            BigInteger d = BigInteger.valueOf(-2);
+                            BigInteger div1 = MathLib.floorDiv(a, b);
+                            BigInteger mod1 = MathLib.floorMod(a, b);
+                            BigInteger div2 = MathLib.floorDiv(c, d);
+                            BigInteger mod2 = MathLib.floorMod(c, d);
+                            BigInteger div3 = MathLib.floorDiv(a, d);
+                            BigInteger mod3 = MathLib.floorMod(a, d);
+                            BigInteger div4 = MathLib.floorDiv(c, b);
+                            BigInteger mod4 = MathLib.floorMod(c, b);
+                            long mathDiv = Math.floorDiv(-7, 2);
+                            long mathMod = Math.floorMod(-7, 2);
+                            return div1.equals(BigInteger.valueOf(-4))
+                                && mod1.equals(BigInteger.ONE)
+                                && div1.multiply(b).add(mod1).equals(a)
+                                && div2.equals(BigInteger.valueOf(-4))
+                                && mod2.equals(BigInteger.valueOf(-1))
+                                && div2.multiply(d).add(mod2).equals(c)
+                                && div3.equals(BigInteger.valueOf(3))
+                                && mod3.equals(BigInteger.valueOf(-1))
+                                && div3.multiply(d).add(mod3).equals(a)
+                                && div4.equals(BigInteger.valueOf(3))
+                                && mod4.equals(BigInteger.ONE)
+                                && div4.multiply(b).add(mod4).equals(c)
+                                && mathDiv == -4
+                                && mathMod == 1;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "Explicit floor division/modulo should use floor semantics. Got: " + result);
+        }
+
+        @Test
+        void mathLibDivModAndQuotRemDifferForNegativeOperands() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.core.types.Tuple2;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            Tuple2 divMod = MathLib.divMod(BigInteger.valueOf(-7), BigInteger.valueOf(2));
+                            Tuple2 quotRem = MathLib.quotRem(BigInteger.valueOf(-7), BigInteger.valueOf(2));
+                            long div = Builtins.unIData(divMod.first());
+                            long mod = Builtins.unIData(divMod.second());
+                            long quot = Builtins.unIData(quotRem.first());
+                            long rem = Builtins.unIData(quotRem.second());
+                            return div == -4 && mod == 1 && quot == -3 && rem == -1;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "divMod should be floor pair and quotRem should be truncating pair. Got: " + result);
+        }
+
+        @Test
+        void divisionSemanticsMatchOnScalusVm() {
+            JulcVm scalusVm;
+            try {
+                scalusVm = JulcVm.create("Scalus");
+            } catch (IllegalStateException ex) {
+                Assumptions.assumeTrue(false, "Scalus provider not available: " + ex.getMessage());
+                return;
+            }
+
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.core.types.Tuple2;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    import com.bloxbean.cardano.julc.stdlib.lib.*;
+
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            long opQuot = -7 / 2;
+                            long opRem = -7 % 2;
+
+                            BigInteger a = BigInteger.valueOf(-7);
+                            BigInteger b = BigInteger.valueOf(2);
+                            BigInteger bigQuot = a.divide(b);
+                            BigInteger bigRem = a.remainder(b);
+                            BigInteger floorDiv = MathLib.floorDiv(a, b);
+                            BigInteger floorMod = MathLib.floorMod(a, b);
+
+                            Tuple2 divMod = MathLib.divMod(a, b);
+                            Tuple2 quotRem = MathLib.quotRem(a, b);
+
+                            return opQuot == -3
+                                && opRem == -1
+                                && bigQuot.equals(BigInteger.valueOf(-3))
+                                && bigRem.equals(BigInteger.valueOf(-1))
+                                && floorDiv.equals(BigInteger.valueOf(-4))
+                                && floorMod.equals(BigInteger.ONE)
+                                && Builtins.unIData(divMod.first()) == -4
+                                && Builtins.unIData(divMod.second()) == 1
+                                && Builtins.unIData(quotRem.first()) == -3
+                                && Builtins.unIData(quotRem.second()) == -1;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var javaResult = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(javaResult.isSuccess(), "Java VM should accept division semantics validator. Got: " + javaResult);
+            var scalusResult = scalusVm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(scalusResult.isSuccess(), "Scalus VM should accept division semantics validator. Got: " + scalusResult);
         }
 
         @Test

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/TypeMethodRegistryTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/TypeMethodRegistryTest.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
 import com.bloxbean.cardano.julc.compiler.pir.TypeMethodRegistry;
 import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -390,6 +391,16 @@ class TypeMethodRegistryTest {
     }
 
     @Test
+    void dispatchIntegerDivideUsesQuotientInteger() {
+        var scope = new PirTerm.Const(Constant.integer(BigInteger.valueOf(-7)));
+        var arg = new PirTerm.Const(Constant.integer(BigInteger.valueOf(2)));
+        var result = registry.dispatch(scope, "divide", List.of(arg),
+                new PirType.IntegerType(), List.of(new PirType.IntegerType()));
+        assertTrue(result.isPresent());
+        assertBuiltinApp(result.get(), DefaultFun.QuotientInteger);
+    }
+
+    @Test
     void dispatchIntegerSignumReturnsPresent() {
         var scope = new PirTerm.Const(Constant.integer(BigInteger.valueOf(42)));
         var result = registry.dispatch(scope, "signum", List.of(),
@@ -698,5 +709,14 @@ class TypeMethodRegistryTest {
         var result = registry.dispatch(scope, "abs", List.of(),
                 new PirType.IntegerType(), List.of());
         assertTrue(result.isPresent(), "IntegerType should dispatch to IntegerType.abs");
+    }
+
+    private void assertBuiltinApp(PirTerm term, DefaultFun expectedFun) {
+        assertInstanceOf(PirTerm.App.class, term);
+        var app = (PirTerm.App) term;
+        assertInstanceOf(PirTerm.App.class, app.function());
+        var innerApp = (PirTerm.App) app.function();
+        assertInstanceOf(PirTerm.Builtin.class, innerApp.function());
+        assertEquals(expectedFun, ((PirTerm.Builtin) innerApp.function()).fun());
     }
 }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/pir/PirGeneratorTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/pir/PirGeneratorTest.java
@@ -103,12 +103,17 @@ class PirGeneratorTest {
 
         @Test void division() {
             var t = compile("a / b");
-            assertBuiltinApp(t, DefaultFun.DivideInteger);
+            assertBuiltinApp(t, DefaultFun.QuotientInteger);
         }
 
         @Test void remainder() {
             var t = compile("a % b");
             assertBuiltinApp(t, DefaultFun.RemainderInteger);
+        }
+
+        @Test void bigIntegerDivideMethodUsesQuotient() {
+            var t = compile("a.divide(b)");
+            assertBuiltinApp(t, DefaultFun.QuotientInteger);
         }
 
         @Test void negation() {

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
@@ -583,6 +583,26 @@ public final class StdlibRegistry implements StdlibLookup {
             var lte = builtinApp2(DefaultFun.LessThanEqualsInteger, args.get(0), args.get(1));
             return new PirTerm.IfThenElse(lte, args.get(0), args.get(1));
         });
+
+        reg.register("Math", "floorDiv", args -> {
+            requireArgs("Math.floorDiv", args, 2);
+            return builtinApp2(DefaultFun.DivideInteger, args.get(0), args.get(1));
+        });
+
+        reg.register("Math", "floorMod", args -> {
+            requireArgs("Math.floorMod", args, 2);
+            return builtinApp2(DefaultFun.ModInteger, args.get(0), args.get(1));
+        });
+
+        reg.register(LIB + "MathLib", "floorDiv", args -> {
+            requireArgs("MathLib.floorDiv", args, 2);
+            return builtinApp2(DefaultFun.DivideInteger, args.get(0), args.get(1));
+        });
+
+        reg.register(LIB + "MathLib", "floorMod", args -> {
+            requireArgs("MathLib.floorMod", args, 2);
+            return builtinApp2(DefaultFun.ModInteger, args.get(0), args.get(1));
+        });
     }
 
     /**

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/MathLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/MathLib.java
@@ -45,8 +45,8 @@ public class MathLib {
      * Division by zero causes script failure on-chain (UPLC error) and ArithmeticException off-chain.
      */
     public static Tuple2<BigInteger, BigInteger> divMod(BigInteger a, BigInteger b) {
-        var div = a.divide(b);
-        var mod = a.remainder(b);
+        var div = MathLib.floorDiv(a, b);
+        var mod = MathLib.floorMod(a, b);
         return new Tuple2(Builtins.iData(div), Builtins.iData(mod));
     }
 
@@ -59,6 +59,39 @@ public class MathLib {
         var quot = a.divide(b);
         var rem = a.remainder(b);
         return new Tuple2(Builtins.iData(quot), Builtins.iData(rem));
+    }
+
+    /**
+     * Returns floor division, rounding toward negative infinity.
+     * <p>
+     * On-chain this is compiled directly to UPLC DivideInteger.
+     */
+    public static BigInteger floorDiv(BigInteger a, BigInteger b) {
+        BigInteger q = a.divide(b);
+        BigInteger r = a.remainder(b);
+        if (!r.equals(BigInteger.ZERO)
+                && ((r.compareTo(BigInteger.ZERO) < 0 && b.compareTo(BigInteger.ZERO) > 0)
+                || (r.compareTo(BigInteger.ZERO) > 0 && b.compareTo(BigInteger.ZERO) < 0))) {
+            return q.subtract(BigInteger.ONE);
+        } else {
+            return q;
+        }
+    }
+
+    /**
+     * Returns floor modulo, with the same sign as the divisor.
+     * <p>
+     * On-chain this is compiled directly to UPLC ModInteger.
+     */
+    public static BigInteger floorMod(BigInteger a, BigInteger b) {
+        BigInteger r = a.remainder(b);
+        if (!r.equals(BigInteger.ZERO)
+                && ((r.compareTo(BigInteger.ZERO) < 0 && b.compareTo(BigInteger.ZERO) > 0)
+                || (r.compareTo(BigInteger.ZERO) > 0 && b.compareTo(BigInteger.ZERO) < 0))) {
+            return r.add(b);
+        } else {
+            return r;
+        }
     }
 
     /**

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/MathLibTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/MathLibTest.java
@@ -81,6 +81,22 @@ class MathLibTest {
             assertEquals(PlutusData.integer(2), fields.get(0));  // 7 / 3 = 2
             assertEquals(PlutusData.integer(1), fields.get(1));  // 7 % 3 = 1
         }
+
+        @Test
+        void negativeDividendUsesFloorSemantics() {
+            PlutusData result = eval.call("divMod", BigInteger.valueOf(-7), BigInteger.valueOf(2)).asData();
+            var fields = ((PlutusData.ConstrData) result).fields();
+            assertEquals(PlutusData.integer(-4), fields.get(0));
+            assertEquals(PlutusData.integer(1), fields.get(1));
+        }
+
+        @Test
+        void positiveDividendNegativeDivisorUsesFloorSemantics() {
+            PlutusData result = eval.call("divMod", BigInteger.valueOf(7), BigInteger.valueOf(-2)).asData();
+            var fields = ((PlutusData.ConstrData) result).fields();
+            assertEquals(PlutusData.integer(-4), fields.get(0));
+            assertEquals(PlutusData.integer(-1), fields.get(1));
+        }
     }
 
     @Nested
@@ -100,6 +116,50 @@ class MathLibTest {
             var fields = ((PlutusData.ConstrData) result).fields();
             assertEquals(PlutusData.integer(3), fields.get(0));  // 11 / 3 = 3
             assertEquals(PlutusData.integer(2), fields.get(1));  // 11 % 3 = 2
+        }
+
+        @Test
+        void negativeDividendUsesTruncatingSemantics() {
+            PlutusData result = eval.call("quotRem", BigInteger.valueOf(-7), BigInteger.valueOf(2)).asData();
+            var fields = ((PlutusData.ConstrData) result).fields();
+            assertEquals(PlutusData.integer(-3), fields.get(0));
+            assertEquals(PlutusData.integer(-1), fields.get(1));
+        }
+
+        @Test
+        void positiveDividendNegativeDivisorUsesTruncatingSemantics() {
+            PlutusData result = eval.call("quotRem", BigInteger.valueOf(7), BigInteger.valueOf(-2)).asData();
+            var fields = ((PlutusData.ConstrData) result).fields();
+            assertEquals(PlutusData.integer(-3), fields.get(0));
+            assertEquals(PlutusData.integer(1), fields.get(1));
+        }
+    }
+
+    @Nested
+    class FloorDivMod {
+
+        @Test
+        void negativeDividendUsesFloorSemantics() {
+            assertEquals(BigInteger.valueOf(-4),
+                    eval.call("floorDiv", BigInteger.valueOf(-7), BigInteger.valueOf(2)).asInteger());
+            assertEquals(BigInteger.ONE,
+                    eval.call("floorMod", BigInteger.valueOf(-7), BigInteger.valueOf(2)).asInteger());
+        }
+
+        @Test
+        void allSignCombinationsUseFloorSemantics() {
+            assertEquals(BigInteger.valueOf(3),
+                    eval.call("floorDiv", BigInteger.valueOf(7), BigInteger.valueOf(2)).asInteger());
+            assertEquals(BigInteger.ONE,
+                    eval.call("floorMod", BigInteger.valueOf(7), BigInteger.valueOf(2)).asInteger());
+            assertEquals(BigInteger.valueOf(-4),
+                    eval.call("floorDiv", BigInteger.valueOf(7), BigInteger.valueOf(-2)).asInteger());
+            assertEquals(BigInteger.valueOf(-1),
+                    eval.call("floorMod", BigInteger.valueOf(7), BigInteger.valueOf(-2)).asInteger());
+            assertEquals(BigInteger.valueOf(3),
+                    eval.call("floorDiv", BigInteger.valueOf(-7), BigInteger.valueOf(-2)).asInteger());
+            assertEquals(BigInteger.valueOf(-1),
+                    eval.call("floorMod", BigInteger.valueOf(-7), BigInteger.valueOf(-2)).asInteger());
         }
     }
 


### PR DESCRIPTION
 Fixes #43

  ## Summary
  - Compile Java `/` and `BigInteger.divide()` to `QuotientInteger` so division truncates toward zero like Java.
  - Keep `%` and `BigInteger.remainder()` mapped to `RemainderInteger`.
  - Add explicit floor semantics via `Math.floorDiv/floorMod` and `MathLib.floorDiv/floorMod`.
  - Make `MathLib.divMod` a clean floor division/modulo pair and keep `MathLib.quotRem` truncating.
  - Update docs to clarify truncating vs floor division behavior.

  ## Tests
  - `./gradlew :julc-compiler:test --tests com.bloxbean.cardano.julc.compiler.StdlibCompileEvalTest`
  - `./gradlew :julc-compiler:test :julc-stdlib:test`
  - `git diff --check`