### PR TITLE
fix: switch field-name collision reads the wrong record (#47)

### DIFF
--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -46,6 +46,18 @@ public class PirGenerator {
     private Set<String> multiAccVars = Set.of(); // non-empty when compiling multi-acc fold body
     private Set<String> hofUnwrappedVars = Set.of(); // param names unwrapped by HOF lambda Let-binding (prevents double-unwrap)
     /**
+     * Active switch-case pattern bindings, innermost last. Each entry maps the case
+     * pattern variable (e.g. {@code t} in {@code case Transfer t}) to the set of
+     * constructor field names that were destructured into scope for it. Used by
+     * {@link #resolveRecordFieldAccess} to decide whether {@code var.field()} may reuse
+     * the destructured field binding — which is sound only when {@code var} is the
+     * pattern variable that owns {@code field}, never for a different record that merely
+     * shares a field name.
+     */
+    private final java.util.Deque<PatternScope> patternScopes = new java.util.ArrayDeque<>();
+
+    private record PatternScope(String patternVar, Set<String> fieldNames) {}
+    /**
      * When true, each {@code return <boolExpr>} is compiled as
      * {@code IfThenElse(expr, True, Error)} with the Error mapped to the return statement.
      * This allows source maps to pinpoint which return statement caused a validator to fail.
@@ -1060,12 +1072,16 @@ public class PirGenerator {
         }
         if (fieldIndex < 0) return java.util.Optional.empty();
 
-        // If the field is already directly in the current scope (e.g. switch pattern destructuring),
-        // return a direct variable reference instead of generating field extraction PIR.
-        // Use lookupCurrentScope to avoid collisions with outer-scope variables of the same name
-        // (e.g. an entrypoint parameter named "datum" conflicting with TxOut.datum() field access).
-        var fieldInScope = symbolTable.lookupCurrentScope(fieldName);
-        if (fieldInScope.isPresent()) {
+        // Optimization: when var.field() targets a switch-case pattern variable, the field
+        // was already destructured into scope by its bare name, so reuse that binding instead
+        // of re-extracting from the record Data.
+        //
+        // This is sound ONLY when `varName` is the pattern variable that owns `fieldName`.
+        // A previous version fired whenever ANY in-scope variable named `fieldName` existed,
+        // which silently returned the wrong record's field when two records in the same scope
+        // shared a field name (e.g. accessing box.amount() inside `case Transfer t` where both
+        // Transfer and Box have an `amount` field) — a check-bypass miscompilation (issue #47).
+        if (ownsDestructuredField(varName, fieldName)) {
             final PirType fType = fieldType;
             return java.util.Optional.of(scope -> new PirTerm.Var(fieldName, fType));
         }
@@ -1073,6 +1089,25 @@ public class PirGenerator {
         final int idx = fieldIndex;
         final PirType fType = fieldType;
         return java.util.Optional.of(scope -> generateFieldExtraction(scope, idx, fType));
+    }
+
+    /**
+     * True iff {@code varName.fieldName()} may reuse the bare {@code fieldName} binding produced
+     * by pattern destructuring instead of re-extracting from the record Data.
+     * <p>
+     * The reuse emits {@code Var(fieldName)}, which resolves to the <em>innermost</em> binding of
+     * that name. So it is sound only when the innermost active pattern scope that binds
+     * {@code fieldName} is the one for {@code varName} — otherwise an inner case that destructured
+     * a same-named field would shadow it (e.g. an outer {@code a.amount()} must not pick up an
+     * inner {@code case D d}'s {@code amount}). {@code patternScopes} is iterated innermost-first.
+     */
+    private boolean ownsDestructuredField(String varName, String fieldName) {
+        for (var ps : patternScopes) { // innermost first
+            if (ps.fieldNames().contains(fieldName)) {
+                return ps.patternVar().equals(varName);
+            }
+        }
+        return false;
     }
 
     /**
@@ -1764,17 +1799,23 @@ public class PirGenerator {
 
                     symbolTable.pushScope();
                     // Define the field bindings in scope
+                    var fieldNames = new java.util.HashSet<String>();
                     for (var field : ctor.fields()) {
                         symbolTable.define(field.name(), field.type());
+                        fieldNames.add(field.name());
                     }
                     // Define the pattern variable (e.g. 'b' in 'case Bid b')
                     // with RecordType so b.fieldName() redirects to the bound field
                     var varRecordType = new PirType.RecordType(typeName, ctor.fields());
                     symbolTable.define(varName, varRecordType);
+                    // Record which pattern variable owns these destructured fields so that
+                    // var.field() reuse is restricted to this variable (see resolveRecordFieldAccess).
+                    patternScopes.push(new PatternScope(varName, fieldNames));
 
                     // Generate body from the entry's statements
                     PirTerm bodyTerm = generateSwitchEntryBody(entry);
 
+                    patternScopes.pop();
                     symbolTable.popScope();
                     // For DataMatch, we bind the constructor fields
                     matchEntries.add(new PatternMatchDesugarer.MatchEntry(

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/SwitchFieldCollisionTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/SwitchFieldCollisionTest.java
@@ -1,0 +1,253 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.Program;
+import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.JulcVm;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for issue #47 — switch field-name collision.
+ * <p>
+ * Inside a {@code switch} case, the compiler destructures the matched variant's fields into
+ * scope by their bare names. A previous optimization reused any in-scope variable matching the
+ * accessed field name, so accessing a field on a <em>different</em> record that happened to
+ * share a field name silently returned the destructured field instead — a check-bypass
+ * miscompilation (a limit/authorization comparison could compile to {@code x <= x}, always true).
+ * <p>
+ * These tests pin the correct behavior: {@code var.field()} always reads {@code var}'s own
+ * record, and the legitimate reuse for the pattern variable's own fields still works.
+ */
+class SwitchFieldCollisionTest {
+
+    static JulcVm vm;
+
+    @BeforeAll
+    static void setUp() {
+        vm = JulcVm.create("Java");
+    }
+
+    private Term compile(String src, String method) {
+        var result = new JulcCompiler(StdlibRegistry.defaultRegistry()).compileMethod(src, method);
+        assertFalse(result.hasErrors(), () -> "compile failed: " + result.diagnostics());
+        return result.program().term();
+    }
+
+    private static Term dataArg(PlutusData d) {
+        return Term.const_(Constant.data(d));
+    }
+
+    private BigInteger evalInt(Term compiled, Term... args) {
+        Term t = compiled;
+        for (Term a : args) t = Term.apply(t, a);
+        var r = vm.evaluate(Program.plutusV3(t));
+        assertInstanceOf(EvalResult.Success.class, r, () -> "expected success: " + r);
+        var val = ((Term.Const) ((EvalResult.Success) r).resultTerm()).value();
+        return ((Constant.IntegerConst) val).value();
+    }
+
+    private boolean evalBool(Term compiled, Term... args) {
+        Term t = compiled;
+        for (Term a : args) t = Term.apply(t, a);
+        var r = vm.evaluate(Program.plutusV3(t));
+        assertInstanceOf(EvalResult.Success.class, r, () -> "expected success: " + r);
+        var val = ((Term.Const) ((EvalResult.Success) r).resultTerm()).value();
+        return ((Constant.BoolConst) val).value();
+    }
+
+    @Test
+    void fieldAccessOnOtherRecordReadsThatRecord_notTheDestructuredField() {
+        var src = """
+                import java.math.BigInteger;
+
+                public class Bug {
+                    sealed interface Action permits Transfer, Withdraw {}
+                    record Transfer(BigInteger amount) implements Action {}
+                    record Withdraw(BigInteger fee) implements Action {}
+                    record Box(BigInteger amount) {}   // SAME field name 'amount'
+
+                    public static BigInteger check(Action action, Box box) {
+                        return switch (action) {
+                            case Transfer t -> box.amount();   // must read Box's amount, not Transfer's
+                            case Withdraw w -> BigInteger.ZERO;
+                        };
+                    }
+                }
+                """;
+        var compiled = compile(src, "check");
+        // Transfer(amount=5), Box(amount=99) -> must be 99
+        assertEquals(BigInteger.valueOf(99),
+                evalInt(compiled,
+                        dataArg(PlutusData.constr(0, PlutusData.integer(5))),
+                        dataArg(PlutusData.constr(0, PlutusData.integer(99)))));
+    }
+
+    @Test
+    void limitCheckAgainstOtherRecordIsNotBypassed() {
+        var src = """
+                import java.math.BigInteger;
+
+                public class Bug {
+                    sealed interface Action permits Transfer, Withdraw {}
+                    record Transfer(BigInteger amount) implements Action {}
+                    record Withdraw(BigInteger fee) implements Action {}
+                    record Limit(BigInteger amount) {}   // SAME field name
+
+                    // true iff the transfer is within the allowed limit
+                    public static boolean withinLimit(Action action, Limit limit) {
+                        return switch (action) {
+                            case Transfer t -> t.amount().compareTo(limit.amount()) <= 0;
+                            case Withdraw w -> true;
+                        };
+                    }
+                }
+                """;
+        var compiled = compile(src, "withinLimit");
+        // Transfer(1000) vs Limit(10): 1000 > 10 -> must be false (check must NOT be bypassed)
+        assertFalse(evalBool(compiled,
+                dataArg(PlutusData.constr(0, PlutusData.integer(1000))),
+                dataArg(PlutusData.constr(0, PlutusData.integer(10)))));
+        // Transfer(5) vs Limit(10): 5 <= 10 -> true
+        assertTrue(evalBool(compiled,
+                dataArg(PlutusData.constr(0, PlutusData.integer(5))),
+                dataArg(PlutusData.constr(0, PlutusData.integer(10)))));
+    }
+
+    @Test
+    void patternVariableOwnFieldAccessStillWorks() {
+        // The legitimate reuse: t.amount() inside `case Transfer t` reads Transfer's own field.
+        var src = """
+                import java.math.BigInteger;
+
+                public class Ok {
+                    sealed interface Action permits Transfer, Withdraw {}
+                    record Transfer(BigInteger amount) implements Action {}
+                    record Withdraw(BigInteger fee) implements Action {}
+
+                    public static BigInteger amountOf(Action action) {
+                        return switch (action) {
+                            case Transfer t -> t.amount();
+                            case Withdraw w -> w.fee();
+                        };
+                    }
+                }
+                """;
+        var compiled = compile(src, "amountOf");
+        assertEquals(BigInteger.valueOf(42),
+                evalInt(compiled, dataArg(PlutusData.constr(0, PlutusData.integer(42)))));
+        assertEquals(BigInteger.valueOf(7),
+                evalInt(compiled, dataArg(PlutusData.constr(1, PlutusData.integer(7)))));
+    }
+
+    @Test
+    void bothPatternFieldAndOtherRecordFieldUsedInSameBranch() {
+        // t.amount() (destructured reuse) AND box.amount() (extraction) in one branch.
+        var src = """
+                import java.math.BigInteger;
+
+                public class Mix {
+                    sealed interface Action permits Transfer, Withdraw {}
+                    record Transfer(BigInteger amount) implements Action {}
+                    record Withdraw(BigInteger fee) implements Action {}
+                    record Box(BigInteger amount) {}
+
+                    public static BigInteger sum(Action action, Box box) {
+                        return switch (action) {
+                            case Transfer t -> t.amount().add(box.amount());
+                            case Withdraw w -> BigInteger.ZERO;
+                        };
+                    }
+                }
+                """;
+        var compiled = compile(src, "sum");
+        // Transfer(amount=5) + Box(amount=99) = 104 (distinguishes: bug would give 5+5=10 or 99+99=198)
+        assertEquals(BigInteger.valueOf(104),
+                evalInt(compiled,
+                        dataArg(PlutusData.constr(0, PlutusData.integer(5))),
+                        dataArg(PlutusData.constr(0, PlutusData.integer(99)))));
+    }
+
+    @Test
+    void nestedSwitchWithSharedFieldNames() {
+        // Inner switch destructures 'amount' too; outer box.amount() must still read box.
+        var src = """
+                import java.math.BigInteger;
+
+                public class Nested {
+                    sealed interface Outer permits A, B {}
+                    record A(BigInteger amount) implements Outer {}
+                    record B(BigInteger amount) implements Outer {}
+                    sealed interface Inner permits C, D {}
+                    record C(BigInteger amount) implements Inner {}
+                    record D(BigInteger amount) implements Inner {}
+                    record Box(BigInteger amount) {}
+
+                    public static BigInteger pick(Outer o, Inner i, Box box) {
+                        return switch (o) {
+                            case A a -> switch (i) {
+                                case C c -> box.amount();   // must read box, not a or c
+                                case D d -> a.amount();     // must read a (outer pattern var)
+                            };
+                            case B b -> b.amount();
+                        };
+                    }
+                }
+                """;
+        var compiled = compile(src, "pick");
+        // A(amount=1), C(amount=2), Box(amount=99) -> box.amount() = 99
+        assertEquals(BigInteger.valueOf(99),
+                evalInt(compiled,
+                        dataArg(PlutusData.constr(0, PlutusData.integer(1))),
+                        dataArg(PlutusData.constr(0, PlutusData.integer(2))),
+                        dataArg(PlutusData.constr(0, PlutusData.integer(99)))));
+        // A(amount=7), D(...), Box(...) -> a.amount() = 7
+        assertEquals(BigInteger.valueOf(7),
+                evalInt(compiled,
+                        dataArg(PlutusData.constr(0, PlutusData.integer(7))),
+                        dataArg(PlutusData.constr(1, PlutusData.integer(2))),
+                        dataArg(PlutusData.constr(0, PlutusData.integer(99)))));
+    }
+
+    @Test
+    @Disabled("Separate known limitation from #47: destructured field names are injected into the "
+            + "general namespace, so a *bare* reference to a same-named method parameter resolves to "
+            + "the field instead. #47 fixes only qualified var.field() access. Tracked for a follow-up "
+            + "fix (stop injecting bare field names into the symbol-table namespace). This test flips "
+            + "green when that lands.")
+    void fieldNameShadowsMethodParameterOfSameName() {
+        // Regression for the previously-documented narrower case: a parameter named like a
+        // destructured field must not be shadowed by the field binding.
+        var src = """
+                import java.math.BigInteger;
+
+                public class Shadow {
+                    sealed interface Action permits Transfer, Withdraw {}
+                    record Transfer(BigInteger amount) implements Action {}
+                    record Withdraw(BigInteger fee) implements Action {}
+
+                    // parameter 'amount' collides with Transfer's field 'amount'
+                    public static BigInteger check(Action action, BigInteger amount) {
+                        return switch (action) {
+                            case Transfer t -> amount;   // must read the parameter, not t's field
+                            case Withdraw w -> BigInteger.ZERO;
+                        };
+                    }
+                }
+                """;
+        var compiled = compile(src, "check");
+        // Transfer(amount=5), param amount=99 -> must be 99
+        assertEquals(BigInteger.valueOf(99),
+                evalInt(compiled,
+                        dataArg(PlutusData.constr(0, PlutusData.integer(5))),
+                        dataArg(PlutusData.integer(99))));
+    }
+}


### PR DESCRIPTION
Fixes #47.

## Problem

Inside a `switch` case, the compiler destructures the matched variant's fields into scope by
their bare names. `PirGenerator.resolveRecordFieldAccess` reused **any** in-scope variable
matching the accessed field name, so `otherRecord.field()` inside a case silently returned the
destructured field whenever the two records shared a field name — a **check-bypass
miscompilation**:

```java
sealed interface Action permits Transfer, Withdraw {}
record Transfer(BigInteger amount) implements Action {}
record Withdraw(BigInteger fee) implements Action {}
record Limit(BigInteger amount) {}

static boolean withinLimit(Action action, Limit limit) {
    return switch (action) {
        case Transfer t -> t.amount().compareTo(limit.amount()) <= 0;  // limit.amount() -> t.amount()
        case Withdraw w -> true;
    };
}
// withinLimit(Transfer(1000), Limit(10)) == true   (should be false — limit bypassed)
```

The check compiled to `t.amount() <= t.amount()` (always true). Common ledger field names
(`amount`, `value`, `owner`, `address`, `datum`, `hash`) collide readily, so a should-fail
validator could silently succeed.

## Fix

Gate the destructured-field reuse on **ownership**: reuse the bare field binding only when
`varName` is the pattern variable whose destructured fields include `fieldName`, and only when
its binding is the **innermost** one for that name (so a nested case that destructured a
same-named field cannot shadow an outer pattern variable's access). For any other variable the
field is extracted from its own record `Data`, which is always correct. Active pattern scopes
(pattern var → field names) are tracked in a stack pushed/popped with the case symbol scope.

## Tests

`SwitchFieldCollisionTest` (5 active + 1 disabled):
- field access on another record reads **that** record, not the destructured field;
- limit/authorization check is **not** bypassed;
- pattern-variable own-field reuse still works (the legitimate optimization);
- mixed use in one branch (`t.amount().add(box.amount())`);
- nested switches with shared field names (innermost-wins);
- a `@Disabled` test documenting a **separate** pre-existing limitation — a *bare* reference to a
  method parameter shares a name with a destructured field and resolves to the field. This PR
  fixes only qualified `var.field()` access; the bare-name case is tracked as a follow-up.

## Verification

- Full julc suite: **7646 tests, 0 failures** (golden UPLC tests pass → legitimate codegen
  unchanged).
- **julc-examples: 417 tests, 0 failures** against the freshly published local snapshot
  (including the Yaci devnet integration tests).

Part of the security review (`adr/issues/julc-security-review.md`, finding S1). Targets
`fix/dce_45` so it stacks on the DCE soundness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)