### PR TITLE
chore: upgrade Scalus 0.17.0 → 0.18.2

### DIFF
--- a/julc-cardano-client-lib/build.gradle
+++ b/julc-cardano-client-lib/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation project(':julc-vm-java')
     testRuntimeOnly project(':julc-vm-scalus')
-    testImplementation 'org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0'
+    testImplementation 'org.scalus:scalus-bloxbean-cardano-client-lib_3:0.18.2'
 }
 
 publishing {

--- a/julc-vm-scalus/build.gradle
+++ b/julc-vm-scalus/build.gradle
@@ -15,7 +15,7 @@ sourceSets {
 
 dependencies {
     api project(':julc-vm')
-    implementation 'org.scalus:scalus_3:0.17.0'
+    implementation 'org.scalus:scalus_3:0.18.2'
 }
 
 publishing {


### PR DESCRIPTION
Bumps the Scalus VM backend and the scalus-bloxbean test dependency to **0.18.2** (latest release,
`org.scalus`). Stacks on `fix/plutusdata-cbor-indefinite-48`.

## Scope

Two version references:
- `julc-vm-scalus`: `org.scalus:scalus_3:0.17.0 → 0.18.2`
- `julc-cardano-client-lib` (test): `org.scalus:scalus-bloxbean-cardano-client-lib_3:0.17.0 → 0.18.2`

## Verification

Behavior-compatible maintenance upgrade — the reflection-based adapter
(`DataConverter`/`TermConverter`/`ScalusVmProvider`) compiles and runs unchanged:
- `julc-vm-scalus`: **58 tests**, incl. the full IOG Plutus conformance suite
- `julc-cardano-client-lib`: **193 tests** against scalus-bloxbean 0.18.2
- full julc suite: **7662 tests, 0 failures**
- **julc-examples: 417 tests, 0 failures** against the published snapshot (incl. Yaci devnet E2E)

## Note (related, not fixed here)

0.18.2 does **not** change Scalus's `serialiseData(map)` behavior — it still sorts + dedups map
entries, diverging from the Cardano node, which preserves insertion order and duplicate keys
(verified against the Plutus `Data.hs` reference and the IOG `dataMap` conformance vector). This is
a pre-existing Scalus-upstream divergence, latent because the embedded conformance suite has no
`serialiseData(map)` vector. It will be tracked in a separate issue; the **Java VM remains the
`serialiseData` fidelity reference**. It does not affect this upgrade or the stacked PlutusData CBOR
fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)