### PR TITLE
fix: preserve PlutusData map order and duplicate keys in core encoder (#54)

### DIFF
--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborDecoder.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborDecoder.java
@@ -89,8 +89,18 @@ public final class PlutusDataCborDecoder {
                 yield new PlutusData.ListData(items);
             }
             case MAP -> {
-                var map = (Map) item;
                 var entries = new ArrayList<PlutusData.Pair>();
+                if (item instanceof PlutusDataCborEncoder.OrderedMap om) {
+                    // Order- and duplicate-preserving map produced by our own encoder
+                    // (fromDataItem(toDataItem(x)) round-trip).
+                    var keys = om.keys();
+                    var values = om.values();
+                    for (int i = 0; i < keys.size(); i++) {
+                        entries.add(new PlutusData.Pair(fromDataItem(keys.get(i)), fromDataItem(values.get(i))));
+                    }
+                    yield new PlutusData.MapData(entries);
+                }
+                var map = (Map) item;
                 Collection<DataItem> keys = map.getKeys();
                 for (var key : keys) {
                     if (key.getMajorType() == MajorType.SPECIAL) continue; // skip break codes

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborDecoder.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborDecoder.java
@@ -93,8 +93,8 @@ public final class PlutusDataCborDecoder {
                 if (item instanceof PlutusDataCborEncoder.OrderedMap om) {
                     // Order- and duplicate-preserving map produced by our own encoder
                     // (fromDataItem(toDataItem(x)) round-trip).
-                    var keys = om.keys();
-                    var values = om.values();
+                    var keys = om.orderedKeys();
+                    var values = om.orderedValues();
                     for (int i = 0; i < keys.size(); i++) {
                         entries.add(new PlutusData.Pair(fromDataItem(keys.get(i)), fromDataItem(values.get(i))));
                     }

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborEncoder.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborEncoder.java
@@ -14,7 +14,7 @@ import java.util.*;
 /**
  * Encodes {@link PlutusData} to CBOR bytes following the Cardano specification.
  * <p>
- * Uses cbor-java's high-level API with canonical encoding (RFC 7049 §3.9)
+ * Uses cbor-java's high-level API with Plutus-compatible map ordering
  * and chunked byte strings for data &gt; 64 bytes (CDDL: bounded_bytes).
  * <p>
  * Constructor encoding uses compact form:
@@ -41,6 +41,11 @@ public final class PlutusDataCborEncoder {
     /**
      * Convert PlutusData to a cbor-java DataItem tree.
      * Useful for interop with libraries that work with cbor-java DataItems.
+     *
+     * <p>For maps, {@link #encode(PlutusData)} is the authoritative Plutus serialization:
+     * it preserves entry order and duplicate keys. A standard cbor-java encoder can dispatch
+     * the returned map item without a type-cast failure, but cbor-java's map model may sort
+     * entries and collapse duplicate keys.
      */
     public static DataItem toDataItem(PlutusData data) {
         return switch (data) {
@@ -199,26 +204,40 @@ public final class PlutusDataCborEncoder {
     // --- Inner classes ---
 
     /**
-     * A CBOR map DataItem that preserves entry order and duplicate keys, unlike cbor-java's
-     * {@link Map} (which reorders and deduplicates via {@code DataItem.hashCode/equals}).
-     * Encoded as a definite-length map (major type 5) by {@link PlutusDataCborCborEncoder}.
+     * A CBOR map with two representations: the raw entry sequence used by Julc to preserve
+     * order and duplicate keys, and the inherited cbor-java {@link Map} view used for interop.
+     * The latter necessarily follows cbor-java semantics and therefore deduplicates equal keys.
+     * Julc encodes the raw entries as a definite-length map via
+     * {@link PlutusDataCborCborEncoder}.
      */
-    static final class OrderedMap extends DataItem {
-        private final List<DataItem> keys;
-        private final List<DataItem> values;
+    static final class OrderedMap extends Map {
+        private final List<DataItem> orderedKeys;
+        private final List<DataItem> orderedValues;
 
         OrderedMap(List<DataItem> keys, List<DataItem> values) {
-            super(MajorType.MAP);
-            this.keys = keys;
-            this.values = values;
+            super(keys.size());
+            if (keys.size() != values.size()) {
+                throw new IllegalArgumentException("Map keys and values must have the same size");
+            }
+
+            this.orderedKeys = List.copyOf(keys);
+            this.orderedValues = List.copyOf(values);
+
+            // Populate the ordinary cbor-java Map view so its standard CborEncoder can
+            // serialize this object without casting failures. Do not expose orderedKeys
+            // through getKeys(): its canonical encoder deduplicates serialized keys, which
+            // could otherwise make the encoded entry count disagree with the map header.
+            for (int i = 0; i < orderedKeys.size(); i++) {
+                super.put(orderedKeys.get(i), orderedValues.get(i));
+            }
         }
 
-        List<DataItem> keys() {
-            return keys;
+        List<DataItem> orderedKeys() {
+            return orderedKeys;
         }
 
-        List<DataItem> values() {
-            return values;
+        List<DataItem> orderedValues() {
+            return orderedValues;
         }
     }
 
@@ -299,10 +318,12 @@ public final class PlutusDataCborEncoder {
                     if (om.hasTag()) {
                         encode(om.getTag());
                     }
-                    writeTypeAndLength(5, om.keys.size());
-                    for (int i = 0; i < om.keys.size(); i++) {
-                        encode(om.keys.get(i));
-                        encode(om.values.get(i));
+                    var keys = om.orderedKeys();
+                    var values = om.orderedValues();
+                    writeTypeAndLength(5, keys.size());
+                    for (int i = 0; i < keys.size(); i++) {
+                        encode(keys.get(i));
+                        encode(values.get(i));
                     }
                 } catch (java.io.IOException e) {
                     throw new CborException("Failed to encode map", e);

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborEncoder.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborEncoder.java
@@ -87,41 +87,21 @@ public final class PlutusDataCborEncoder {
         return array;
     }
 
-    // --- Map (canonical key sorting) ---
+    // --- Map (order- and duplicate-preserving) ---
 
     private static DataItem mapToDataItem(PlutusData.MapData m) {
-        var entries = m.entries();
-        if (entries.size() <= 1) {
-            Map map = new Map();
-            for (var entry : entries) {
-                map.put(toDataItem(entry.key()), toDataItem(entry.value()));
-            }
-            return map;
+        // Canonical Plutus Data preserves map entry order and duplicate keys (the on-chain
+        // serialiseData folds the entry list as-is; the ledger memoizes Plutus-data bytes and
+        // does not require canonical form). Sorting/deduplication is a transaction-body concern
+        // handled by cardano-client-lib, NOT the Plutus-data encoder. cbor-java's Map reorders
+        // and drops duplicate keys, so use an order-preserving map DataItem instead.
+        var keys = new ArrayList<DataItem>(m.entries().size());
+        var values = new ArrayList<DataItem>(m.entries().size());
+        for (var entry : m.entries()) {
+            keys.add(toDataItem(entry.key()));
+            values.add(toDataItem(entry.value()));
         }
-
-        // Sort entries by their key's CBOR byte representation (RFC 7049 §3.9).
-        // We sort ourselves rather than relying on cbor-java's canonical mode because
-        // cbor-java's Map uses DataItem.hashCode/equals which can reorder or lose entries.
-        record EncodedEntry(byte[] keyBytes, DataItem key, DataItem value) {}
-        List<EncodedEntry> sortable = new ArrayList<>(entries.size());
-        for (var entry : entries) {
-            DataItem keyDi = toDataItem(entry.key());
-            DataItem valueDi = toDataItem(entry.value());
-            byte[] keyBytes = serializeDataItem(keyDi);
-            sortable.add(new EncodedEntry(keyBytes, keyDi, valueDi));
-        }
-        sortable.sort((a, b) -> {
-            if (a.keyBytes.length != b.keyBytes.length) {
-                return Integer.compare(a.keyBytes.length, b.keyBytes.length);
-            }
-            return Arrays.compareUnsigned(a.keyBytes, b.keyBytes);
-        });
-
-        Map map = new Map();
-        for (var e : sortable) {
-            map.put(e.key, e.value);
-        }
-        return map;
+        return new OrderedMap(keys, values);
     }
 
     // --- List ---
@@ -212,7 +192,31 @@ public final class PlutusDataCborEncoder {
         }
     }
 
-    // --- Inner classes for chunked byte string support ---
+    // --- Inner classes ---
+
+    /**
+     * A CBOR map DataItem that preserves entry order and duplicate keys, unlike cbor-java's
+     * {@link Map} (which reorders and deduplicates via {@code DataItem.hashCode/equals}).
+     * Encoded as a definite-length map (major type 5) by {@link PlutusDataCborCborEncoder}.
+     */
+    static final class OrderedMap extends DataItem {
+        private final List<DataItem> keys;
+        private final List<DataItem> values;
+
+        OrderedMap(List<DataItem> keys, List<DataItem> values) {
+            super(MajorType.MAP);
+            this.keys = keys;
+            this.values = values;
+        }
+
+        List<DataItem> keys() {
+            return keys;
+        }
+
+        List<DataItem> values() {
+            return values;
+        }
+    }
 
     /**
      * A ByteString that has been split into chunks for indefinite-length encoding.
@@ -284,6 +288,23 @@ public final class PlutusDataCborEncoder {
 
         @Override
         public void encode(DataItem dataItem) throws CborException {
+            if (dataItem instanceof OrderedMap om) {
+                // Definite-length map (major type 5) preserving entry order and duplicate keys,
+                // recursing through this encoder so nested items are handled.
+                try {
+                    if (om.hasTag()) {
+                        encode(om.getTag());
+                    }
+                    writeTypeAndLength(5, om.keys.size());
+                    for (int i = 0; i < om.keys.size(); i++) {
+                        encode(om.keys.get(i));
+                        encode(om.values.get(i));
+                    }
+                } catch (java.io.IOException e) {
+                    throw new CborException("Failed to encode map", e);
+                }
+                return;
+            }
             if (dataItem instanceof Array arr && arr.isChunked()) {
                 // cbor-java 0.9's ArrayEncoder emits the 0x9f indefinite-length start for a
                 // chunked array but NOT the closing 0xff break. Emit an indefinite-length array
@@ -311,6 +332,32 @@ public final class PlutusDataCborEncoder {
                 chunkedByteStringEncoder.encode((ByteString) dataItem);
             } else {
                 super.encode(dataItem);
+            }
+        }
+
+        /** Write a CBOR major-type byte and length argument (as {@code encodeTypeAndLength} would). */
+        private void writeTypeAndLength(int majorType, long length) throws java.io.IOException {
+            int mt = majorType << 5;
+            if (length < 24) {
+                out.write(mt | (int) length);
+            } else if (length < 0x100L) {
+                out.write(mt | 24);
+                out.write((int) length);
+            } else if (length < 0x10000L) {
+                out.write(mt | 25);
+                out.write((int) (length >> 8));
+                out.write((int) (length & 0xff));
+            } else if (length < 0x100000000L) {
+                out.write(mt | 26);
+                out.write((int) (length >> 24));
+                out.write((int) ((length >> 16) & 0xff));
+                out.write((int) ((length >> 8) & 0xff));
+                out.write((int) (length & 0xff));
+            } else {
+                out.write(mt | 27);
+                for (int shift = 56; shift >= 0; shift -= 8) {
+                    out.write((int) ((length >> shift) & 0xff));
+                }
             }
         }
     }

--- a/julc-core/src/test/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborTest.java
+++ b/julc-core/src/test/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborTest.java
@@ -504,60 +504,56 @@ class PlutusDataCborTest {
     }
 
     @Nested
-    class CanonicalMapKeyOrdering {
+    class MapOrderPreservation {
+        // Canonical Plutus Data preserves map entry order and duplicate keys (#54): the on-chain
+        // serialiseData folds the entry list as-is and the ledger memoizes Plutus-data bytes.
+        // Canonical key sorting is a transaction-body concern handled by cardano-client-lib, NOT
+        // the Plutus-data encoder. Golden values verified against DataSerializer (Java VM) and the
+        // Plutus Data.hs reference. A regression changes on-chain script hashes / serialiseData output.
 
         @Test
-        void mapKeysCanonicalOrder() {
-            // Encode map with keys [int(2), int(1)] — output should have int(1) first
+        void mapPreservesInsertionOrder() {
+            // keys [int(2), int(1)] stay in that order — NOT sorted to int(1) first
             var data = PlutusData.map(
                     new PlutusData.Pair(PlutusData.integer(2), PlutusData.integer(20)),
                     new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10)));
-            byte[] encoded = PlutusDataCborEncoder.encode(data);
-            String hex = HEX.formatHex(encoded);
-            // a2 = map(2), 01 0a = {1: 10}, 02 14 = {2: 20}
-            assertEquals("a2010a0214", hex,
-                    "Map keys should be canonically sorted: int(1) before int(2)");
+            // a2 = map(2), 02 14 = {2:20}, 01 0a = {1:10}
+            assertEquals("a20214010a", HEX.formatHex(PlutusDataCborEncoder.encode(data)));
         }
 
         @Test
-        void mapKeysMixedTypes() {
-            // Integer key (01) encodes to 1 byte, bytestring key (4101) encodes to 2 bytes
-            // RFC 7049 §3.9: shorter keys sort first
+        void mapMixedTypeKeysPreserveOrder() {
+            // keys [bytes(#01), int(1)] stay in insertion order — no shorter-key-first sorting
             var data = PlutusData.map(
                     new PlutusData.Pair(PlutusData.bytes(new byte[]{0x01}), PlutusData.integer(2)),
                     new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(1)));
-            byte[] encoded = PlutusDataCborEncoder.encode(data);
-            String hex = HEX.formatHex(encoded);
-            // map(2): int(1)→int(1) should come before bytes([0x01])→int(2)
-            // a2 01 01 41 01 02
-            assertEquals("a201014101" + "02", hex,
-                    "Shorter key (int) should sort before longer key (bytestring)");
+            // a2, 41 01 = bytes(#01) key, 02 = value; 01 = int(1) key, 01 = value
+            assertEquals("a24101020101", HEX.formatHex(PlutusDataCborEncoder.encode(data)));
         }
 
         @Test
-        void mapCanonicalRoundTrip() {
-            // Encode with out-of-order keys, decode, verify values preserved
+        void mapPreservesDuplicateKeys() {
+            // {1:10, 1:20} keeps BOTH entries — Plutus Data allows duplicate keys
+            var data = PlutusData.map(
+                    new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10)),
+                    new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(20)));
+            assertEquals("a2010a0114", HEX.formatHex(PlutusDataCborEncoder.encode(data)));
+        }
+
+        @Test
+        void mapRoundTripPreservesOrder() {
+            // out-of-order keys stay in input order through encode/decode (no sorting)
             var data = PlutusData.map(
                     new PlutusData.Pair(PlutusData.integer(100), PlutusData.integer(1)),
                     new PlutusData.Pair(PlutusData.integer(2), PlutusData.integer(2)),
                     new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(3)));
-            byte[] encoded = PlutusDataCborEncoder.encode(data);
-            PlutusData decoded = PlutusDataCborDecoder.decode(encoded);
-
-            // Decoded values should be present (order may differ from input)
+            var decoded = PlutusDataCborDecoder.decode(PlutusDataCborEncoder.encode(data));
             assertInstanceOf(PlutusData.MapData.class, decoded);
-            var map = (PlutusData.MapData) decoded;
-            assertEquals(3, map.entries().size());
-
-            // Verify all key-value pairs exist
-            var entries = map.entries();
-            // After canonical sorting: int(1), int(2), int(100)
-            assertEquals(PlutusData.integer(1), entries.get(0).key());
-            assertEquals(PlutusData.integer(3), entries.get(0).value());
+            var entries = ((PlutusData.MapData) decoded).entries();
+            assertEquals(3, entries.size());
+            assertEquals(PlutusData.integer(100), entries.get(0).key());  // input order preserved
             assertEquals(PlutusData.integer(2), entries.get(1).key());
-            assertEquals(PlutusData.integer(2), entries.get(1).value());
-            assertEquals(PlutusData.integer(100), entries.get(2).key());
-            assertEquals(PlutusData.integer(1), entries.get(2).value());
+            assertEquals(PlutusData.integer(1), entries.get(2).key());
         }
     }
 

--- a/julc-core/src/test/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborTest.java
+++ b/julc-core/src/test/java/com/bloxbean/cardano/julc/core/cbor/PlutusDataCborTest.java
@@ -3,12 +3,14 @@ package com.bloxbean.cardano.julc.core.cbor;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
@@ -541,6 +543,68 @@ class PlutusDataCborTest {
             var data = PlutusData.map(
                     new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10)),
                     new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(20)));
+            assertEquals("a2010a0114", HEX.formatHex(PlutusDataCborEncoder.encode(data)));
+        }
+
+        @Test
+        void nestedMapsPreserveOrderAndDuplicateKeys() {
+            var inner = PlutusData.map(
+                    new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10)),
+                    new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(20)));
+            var data = PlutusData.map(
+                    new PlutusData.Pair(PlutusData.integer(2), inner),
+                    new PlutusData.Pair(
+                            PlutusData.integer(1),
+                            PlutusData.list(PlutusData.integer(3))));
+
+            assertEquals("a202a2010a0114019f03ff", HEX.formatHex(PlutusDataCborEncoder.encode(data)));
+            assertEquals(data, PlutusDataCborDecoder.fromDataItem(PlutusDataCborEncoder.toDataItem(data)));
+        }
+
+        @Test
+        void mapLengthAboveDirectArgumentRangeIsEncodedCorrectly() {
+            var entries = new ArrayList<PlutusData.Pair>();
+            for (int i = 0; i < 30; i++) {
+                entries.add(new PlutusData.Pair(PlutusData.integer(i), PlutusData.integer(i + 1)));
+            }
+            var data = new PlutusData.MapData(entries);
+
+            byte[] encoded = PlutusDataCborEncoder.encode(data);
+            assertEquals("b81e", HEX.formatHex(Arrays.copyOf(encoded, 2)));
+            assertEquals(data, PlutusDataCborDecoder.decode(encoded));
+        }
+
+        @Test
+        void toDataItemMapIsCompatibleWithStandardCborEncoder() throws CborException {
+            var data = PlutusData.map(
+                    new PlutusData.Pair(PlutusData.integer(2), PlutusData.integer(20)),
+                    new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10)));
+
+            DataItem dataItem = PlutusDataCborEncoder.toDataItem(data);
+            assertInstanceOf(Map.class, dataItem);
+
+            // A stock cbor-java encoder uses its normal canonical Map view. This differs from
+            // Julc's authoritative Plutus encoding, but must remain valid and must not throw.
+            assertEquals("a2010a0214", HEX.formatHex(encodeWithStandardCborEncoder(dataItem)));
+            assertEquals("a20214010a", HEX.formatHex(PlutusDataCborEncoder.encode(data)));
+        }
+
+        @Test
+        void standardCborEncoderGetsValidDeduplicatedMapView() throws CborException {
+            var data = PlutusData.map(
+                    new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10)),
+                    new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(20)));
+
+            DataItem dataItem = PlutusDataCborEncoder.toDataItem(data);
+
+            // cbor-java's Map retains the last value for an equal key. Keeping this compatibility
+            // view separate prevents its canonical encoder from emitting a mismatched map length.
+            byte[] standardCbor = encodeWithStandardCborEncoder(dataItem);
+            assertEquals("a10114", HEX.formatHex(standardCbor));
+            assertDoesNotThrow(() -> PlutusDataCborDecoder.decode(standardCbor));
+
+            // Direct Julc conversion and on-chain serialization remain lossless.
+            assertEquals(data, PlutusDataCborDecoder.fromDataItem(dataItem));
             assertEquals("a2010a0114", HEX.formatHex(PlutusDataCborEncoder.encode(data)));
         }
 

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/builtins/DataSerializerTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/builtins/DataSerializerTest.java
@@ -81,6 +81,19 @@ class DataSerializerTest {
     }
 
     @Test
+    void mapPreservesOrderAndDuplicateKeys() {
+        // Plutus Data preserves map entry order and duplicate keys (definite-length map).
+        // reordered {3:30, 1:10} stays in insertion order (NOT sorted)
+        assertBytes("a203181e010a", PlutusData.map(
+                new PlutusData.Pair(PlutusData.integer(3), PlutusData.integer(30)),
+                new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10))));
+        // duplicate {1:10, 1:20} keeps BOTH entries
+        assertBytes("a2010a0114", PlutusData.map(
+                new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(10)),
+                new PlutusData.Pair(PlutusData.integer(1), PlutusData.integer(20))));
+    }
+
+    @Test
     void longByteStringInsideConstrHasBothBreaks() {
         byte[] big = new byte[100];
         for (int i = 0; i < big.length; i++) big[i] = (byte) i;


### PR DESCRIPTION
Fixes #54 (S6). Stacks on `chore/scalus-upgrade-0.18.2` (→ #48 → #50 → #47 → `fix/dce_45`).

## Problem

`PlutusDataCborEncoder.mapToDataItem` **sorted map entries by key bytes and dropped duplicate keys**
(via cbor-java's `Map`), but canonical Plutus `Data` **preserves insertion order and duplicate keys**.

## Validation (why preserve-order is correct)

| encoder | `{3:30, 1:10}` | `{1:10, 1:20}` |
|---|---|---|
| **Node** (Plutus `Data.hs`) | `a203181e010a` (preserve) | `a2010a0114` (keep dup) |
| JuLC `DataSerializer` (Java VM) | `a203181e010a` ✓ | `a2010a0114` ✓ |
| **JuLC core encoder (before)** | `a2010a03181e` ✗ | `a10114` ✗ |
| cardano-client-lib | `a2010a03181e` | `a10114` |

- **Plutus reference** `PlutusCore/Data.hs`: `Map es -> encodeMapLen (length es) <> mconcat [encode k <> encode v | (k,v) <- es]` — folds in list order, no sort, no dedup (definite-length map).
- **IOG conformance vector** `dataMap`: a `con data` map preserves input key order.
- The ledger **memoizes original Plutus-data bytes** — no canonical requirement for Plutus data.
- **cardano-client-lib sorts** via `CustomMapEncoder.encodeCanonical` **because it builds the transaction body**, where canonical CBOR is a ledger requirement (CIP-21) — a tx-body concern, not the Plutus-data encoder's.

## Why it matters

The core encoder's two production uses are both Plutus-data paths that must preserve order:
`UplcFlatEncoder.writeData` (embeds `con data` in script bytes → affects **script hash** for
structured/map params) and `Builtins.serialiseData` (off-chain builtin, must match the on-chain result).
The old sort+dedup was CCL's tx-body canonicalization leaking into a Plutus-data context.

## Fix

Encode maps structurally as-given via a new order-/duplicate-preserving `OrderedMap` DataItem
(cbor-java's `Map` reorders and deduplicates), emitted as a **definite-length** map (major type 5) by the
custom encoder, mirroring the indefinite-array handling from #48. The decoder's `fromDataItem` handles
`OrderedMap` so `fromDataItem(toDataItem(x))` round-trips.

## Verification

Byte-for-byte against the Java VM `DataSerializer` (already correct) and the Plutus `Data.hs` reference —
reordered keys, duplicate keys, mixed-type keys, nested maps, a 30-entry map (1-byte length header); order
round-trips. Rewrote the former `CanonicalMapKeyOrdering` tests (which pinned the wrong sorting) into
`MapOrderPreservation`, and added map order/dup golden vectors to `DataSerializerTest`.

- Full julc suite: **7664 tests, 0 failures**.
- **julc-examples: 417 tests, 0 failures** against the published snapshot (incl. Yaci devnet E2E).

## Follow-up (out of scope)

Decode-from-bytes preserves map **order** but still collapses **duplicate keys** (cbor-java
`LinkedHashMap`) — a narrow, read-back-only limitation noted in #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)