### PR TITLE
Implement ADR-027: stdlib intrinsics and typed-lookup hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ PlutusV3Script script = JulcScriptLoader.load(VestingValidator.class);
 
 ```java
 var stdlib = StdlibRegistry.defaultRegistry();
-var compiler = new JulcCompiler(stdlib::lookup);
+var compiler = new JulcCompiler(stdlib);
 
 var result = compiler.compile(javaSource);
 if (!result.hasErrors()) {

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -1,7 +1,7 @@
 # ADR-027: Stdlib Variadic Intrinsics, Unique Token Name Helpers, and the Typed-Lookup Bypass Fix
 
-**Date**: 2026-07-21
-**Status**: Proposed (implementation complete locally; PR to follow after ADR review)
+**Date**: 2026-07-21 (review findings folded in 2026-07-22)
+**Status**: Proposed (under review; core implementation staged locally, review follow-ups R1–R6 pending — see Implementation summary)
 
 ---
 
@@ -88,31 +88,39 @@ ADR review asked whether `JulcList.of(pub0, ..., pub4).toPlutusData()` is possib
 instead of wrapping with `Builtins.listData(...)`. It is, and it becomes the
 preferred idiom; the implementation PR will include it:
 
-- **On-chain**: one `TypeMethodRegistry` registration per container type —
-  `ListType.toPlutusData` → apply the `ListData` builtin to the scope,
-  `MapType.toPlutusData` → `MapData`. This is the same instance-dispatch path
-  `list.head()` / `list.take(n)` already use.
+- **On-chain: no compiler changes needed** (verified during review, R4). Two earlier
+  assumptions in this addendum were wrong:
+  - `PirGenerator` already auto-recognizes any no-arg `.toPlutusData()` call and
+    routes it through `PirHelpers.wrapEncode(scope, scopeType)`
+    (PirGenerator.java:1001-1004), which maps `ListType` → `ListData` and
+    `MapType` → `MapData`. No `TypeMethodRegistry` registrations are required.
+  - `MkCons` already infers as `ListType(DataType)` in `inferBuiltinReturnType`
+    (TypeInferenceHelper.java:265), so the chained scope
+    `JulcList.of(...).toPlutusData()` dispatches correctly. No inference entry is
+    required.
+
+  The first implementation step is therefore a **chained-call regression test**
+  proving `JulcList.of(...).toPlutusData()` compiles and evaluates today, locking
+  the behavior in before any JVM-side work.
 - **Off-chain**: a `toPlutusData()` default method on `JulcList` (mirroring the
   `Builtins.listData(JulcList<?>)` element-wrapping rules) so the same source is
-  javac-legal and JVM-consistent. The name matches the existing
-  `PlutusDataConvertible.toPlutusData()` convention used by ledger records;
-  `JulcList` may extend `PlutusDataConvertible`, which additionally lets
-  `Builtins.asPlutusData(Object)` accept lists.
+  javac-legal and JVM-consistent. **Module boundary (R3)**:
+  `PlutusDataConvertible` lives in `julc-ledger-api`, which declares
+  `api project(':julc-core')` — so `JulcList` (julc-core) CANNOT extend it without
+  a circular dependency. Instead, introduce a core-level conversion interface
+  (e.g. `com.bloxbean.cardano.julc.core.ToPlutusData`) that
+  `PlutusDataConvertible` extends; the element-wrapping table lives in julc-core
+  and `Builtins.listData(JulcList<?>)` delegates to it. `Builtins.asPlutusData`
+  then accepts both.
+- **`JulcMap.toPlutusData()` off-chain spec (R3)**: on-chain assoc maps (pair
+  lists) may legally contain duplicate keys, and `JulcMap`'s `keys()` + `get()`
+  surface collapses duplicates (`get` returns the first match). The off-chain
+  implementation must therefore traverse entries losslessly via `head()`/`tail()`
+  (or an internal entries view), preserving order and duplicates, wrapping each
+  key/value with the same element rules.
 - **Bonus**: the method works on *any* `JulcList`/`JulcMap` value, not just `of(...)`
   literals — it retires the `Builtins.listData((PlutusData)(Object) list)` re-wrap
   cast idiom found in the survey (`CfIdentityValidator`).
-
-Implementation notes to verify:
-
-1. **Chained-scope type inference**: dispatching `JulcList.of(...).toPlutusData()`
-   requires the `MkCons` chain to infer as `ListType`. If `MkCons` is missing from
-   `inferBuiltinReturnType`, the scope falls back to `DataType` and dispatch misses —
-   same bug class as the earlier `UnIData`/`UnBData` inference fixes; add the table
-   entry if needed.
-2. **JVM wrapping location**: `JulcList` lives in `julc-core`, which cannot call
-   `julc-stdlib`'s `Builtins` — the default method needs its own copy of the (small)
-   element-wrapping table, or the helper moves to `julc-core` and `Builtins.listData`
-   delegates to it.
 
 Both spellings coexist: `Builtins.listData(...)` stays as the builtin-parity form;
 docs and examples lead with `.toPlutusData()`.
@@ -136,6 +144,14 @@ PlutusData publicInputs = JulcList.of(pub0, pub1, pub2, pub3, pub4).toPlutusData
 
 Pattern 2 becomes `Builtins.blake2b_256(Builtins.concat(a, b, c))`.
 
+**Review finding (R5) — enforce minimum arity in the registry**: the Java API
+documents arity ≥ 2 (enforced by javac at Gradle-build call sites), but the PIR
+registration currently accepts 0 args (→ empty bytes) and 1 arg (→ identity).
+Source-string compilation paths (`JulcEval.forSource`, CLI check, playground)
+never run javac, so a 1-arg `concat` would silently no-op there. The registry
+builder will reject fewer than 2 arguments (same `requireArgs` convention as other
+registrations), with negative compilation tests.
+
 ### D3. `ValuesLib.refBytes(ref)` + `ValuesLib.uniqueTokenName(ref)`
 
 Plain Java-source stdlib methods (ordinary subset logic — no registry work needed):
@@ -154,12 +170,24 @@ public static byte[] uniqueTokenName(TxOutRef ref) {
 Design choices, made deliberately and documented in javadoc + stdlib guide:
 
 - **blake2b_256** — cheapest Plutus hash; output is exactly 32 bytes, the maximum
-  asset-name length.
+  asset-name length. Precise claim (R6): the name is **collision-resistant and
+  deterministically tied to the consumed reference**, not mathematically
+  "guaranteed unique" — uniqueness in practice relies on the minting policy
+  actually enforcing that the seed `TxOutRef` is spent in the minting
+  transaction. Javadoc and stdlib-guide wording to be aligned accordingly.
 - **Fixed 2-byte big-endian index** (`integerToByteString(true, 2, index)`) instead
-  of minimal-width (`width 0`): minimal-width encodes index 0 as *empty bytes*
-  (with a historical JVM/UPLC divergence on that exact case), whereas width 2 is
-  deterministic, JVM/UPLC-identical, and index > 65535 (impossible for real tx
-  outputs) fails loudly.
+  of minimal-width (`width 0`): minimal-width encodes index 0 as *empty bytes*,
+  whereas width 2 is deterministic and JVM/UPLC-identical for all valid indices
+  (0–65535); index > 65535 (impossible for real tx outputs) fails loudly on-chain.
+- **Review finding (R1) — JVM overflow check missing**: the UPLC builtin errors
+  when the value does not fit the requested width, but the JVM
+  `Builtins.integerToByteString` (Builtins.java:333) only pads *undersized*
+  values and never rejects *oversized* ones — `(true, 2, 65536)` returns 3 bytes
+  on the JVM while the VM throws. So the JVM/UPLC-parity claim above currently
+  holds only for indices ≤ 65535. Fix in the implementation PR: throw when
+  `raw.length > width` (width > 0), plus **direct-JVM** tests — the existing
+  `ValuesLibTest` coverage exercises only the UPLC path via `JulcEval`, which is
+  why this went unnoticed.
 - **`refBytes` exposed separately** so protocols that need a different hash keep the
   concat-and-encode part: `CryptoLib.sha2_256(ValuesLib.refBytes(ref))`. The three
   existing julc-examples derivations are protocol-fixed and are NOT migrated; the
@@ -223,13 +251,25 @@ warned about in a different subsystem.
 ### Fix
 
 Mechanical: `new JulcCompiler(stdlib::lookup)` → `new JulcCompiler(stdlib)` at all
-~40 sites (`StdlibRegistry` implements `StdlibLookup`; passing the object preserves
-the override). `CompositeStdlibLookup` already propagated the 4-arg call correctly.
+~40 **code** sites (`StdlibRegistry` implements `StdlibLookup`; passing the object
+preserves the override). `CompositeStdlibLookup` already propagated the 4-arg call
+correctly.
+
+**Review finding (R2) — documentation still teaches the broken pattern**: the
+migration covered `.java` sources only; `README.md:235` and
+`docs/src/content/docs/getting-started.md:1112` still show
+`new JulcCompiler(stdlib::lookup)`, and `getting-started.md:1168` shows
+`ValidatorTest.compile(javaSource, stdlib::lookup)`. Every user who copies these
+snippets reproduces the bug. Fix in the implementation PR: correct the three
+snippets and add an automated guard — either a repo grep check in CI
+(`JulcCompiler(.*::lookup` must not match) or the interface hardening below.
 
 **Rule going forward: never pass `registry::lookup` where a `StdlibLookup` is
 expected — pass the registry object.** A future hardening option is to remove
 `@FunctionalInterface` and make the 4-arg method abstract so the method-reference
-form no longer compiles; deferred because it is a breaking interface change.
+form no longer compiles; deferred because it is a breaking interface change, but
+worth deciding now while the project is pre-1.0 (it would make R2's guard
+unnecessary by construction).
 
 ### Second latent bug exposed by the fix
 
@@ -278,11 +318,18 @@ addresses.
 | ~14 test classes (julc-compiler, julc-e2e-tests, julc-plugin-test) | `::lookup` → registry object |
 | `docs/.../stdlib/stdlib-guide.md` | ValuesLib quick-ref rows; "Building Lists", "Unique Token Names" sections; `concat` in ByteStringLib example |
 
-Pending (D1 addendum, to land in the implementation PR):
-`JulcList.toPlutusData()` / `JulcMap.toPlutusData()` — TypeMethodRegistry
-registrations (`ListType`/`MapType` → `ListData`/`MapData`), `JulcList` default
-method + element wrapping in `julc-core`, `MkCons` entry in
-`inferBuiltinReturnType` if missing, docs updated to lead with this form.
+### Review follow-ups (2026-07-22), to land in the implementation PR
+
+| # | Item |
+|---|---|
+| R1 | JVM `Builtins.integerToByteString`: throw when the value does not fit `width` (currently pads undersized but silently returns oversized — JVM/UPLC divergence for index > 65535). Add direct-JVM tests for `refBytes`/`uniqueTokenName` alongside the existing UPLC-path tests. |
+| R2 | Fix `stdlib::lookup` snippets in `README.md:235`, `getting-started.md:1112`, `:1168`; add a CI grep guard for `JulcCompiler(.*::lookup` — or resolve via R2b: remove `@FunctionalInterface` from `StdlibLookup` and make the 4-arg method abstract (breaking; decide while pre-1.0). |
+| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating; `JulcMap.toPlutusData()` iterates entries losslessly via `head()`/`tail()` (duplicate keys preserved). |
+| R4 | `.toPlutusData()` on-chain: NO compiler changes (PirGenerator.java:1001 wrapEncode fallback + MkCons ListType inference already cover it) — add the chained-call regression test first; drop the previously proposed TypeMethodRegistry registrations. |
+| R5 | `Builtins.concat` PIR registration: require ≥ 2 args (source-string paths bypass javac); negative compilation tests. |
+| R6 | Wording: javadoc + stdlib-guide say "collision-resistant, deterministically tied to the consumed ref" instead of "guaranteed unique"; note the policy must enforce the ref is spent. |
+
+Docs updated to lead with `.toPlutusData()` once R3/R4 land.
 
 ## Tests
 

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -114,10 +114,23 @@ preferred idiom; the implementation PR will include it:
   then accepts both.
 - **`JulcMap.toPlutusData()` off-chain spec (R3)**: on-chain assoc maps (pair
   lists) may legally contain duplicate keys, and `JulcMap`'s `keys()` + `get()`
-  surface collapses duplicates (`get` returns the first match). The off-chain
-  implementation must therefore traverse entries losslessly via `head()`/`tail()`
-  (or an internal entries view), preserving order and duplicates, wrapping each
-  key/value with the same element rules.
+  surface collapses duplicates (`get` returns the first match). Decision
+  (review, 2026-07-22): add the lossless iteration primitive
+
+  ```java
+  /** All entries in order, duplicates preserved. On-chain: identity — the map IS a pair list. */
+  JulcList<Tuple2<K, V>> entries();
+  ```
+
+  On-chain it compiles to identity typed `ListType(PairType(K,V))` (one
+  `TypeMethodRegistry` registration); off-chain `JulcAssocMap` returns its
+  ordered internal pair list. `toPlutusData()` walks `entries()`, wrapping each
+  key/value with the element rules — order and duplicates preserved by
+  construction. `entries()` has standalone user value too: it retires the
+  `Object`-typed `head()`/`tail()` cast traversal. A callback-style
+  `iterate(...)` was rejected (lambdas do not compile on-chain); making
+  `JulcMap` `Iterable` is deferred (it interacts with the existing
+  for-each-on-MapType desugaring).
 - **Bonus**: the method works on *any* `JulcList`/`JulcMap` value, not just `of(...)`
   literals — it retires the `Builtins.listData((PlutusData)(Object) list)` re-wrap
   cast idiom found in the survey (`CfIdentityValidator`).
@@ -324,7 +337,7 @@ addresses.
 |---|---|
 | R1 | JVM `Builtins.integerToByteString`: throw when the value does not fit `width` (currently pads undersized but silently returns oversized — JVM/UPLC divergence for index > 65535). Add direct-JVM tests for `refBytes`/`uniqueTokenName` alongside the existing UPLC-path tests. |
 | R2 | Fix `stdlib::lookup` snippets in `README.md:235`, `getting-started.md:1112`, `:1168`; add a CI grep guard for `JulcCompiler(.*::lookup` — or resolve via R2b: remove `@FunctionalInterface` from `StdlibLookup` and make the 4-arg method abstract (breaking; decide while pre-1.0). |
-| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating; `JulcMap.toPlutusData()` iterates entries losslessly via `head()`/`tail()` (duplicate keys preserved). |
+| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating; new `JulcMap.entries()` → `JulcList<Tuple2<K,V>>` as the lossless iteration primitive (on-chain identity + one TypeMethodRegistry registration; off-chain JulcAssocMap's ordered pair list); `JulcMap.toPlutusData()` walks `entries()` (order + duplicate keys preserved). |
 | R4 | `.toPlutusData()` on-chain: NO compiler changes (PirGenerator.java:1001 wrapEncode fallback + MkCons ListType inference already cover it) — add the chained-call regression test first; drop the previously proposed TypeMethodRegistry registrations. |
 | R5 | `Builtins.concat` PIR registration: require ≥ 2 args (source-string paths bypass javac); negative compilation tests. |
 | R6 | Wording: javadoc + stdlib-guide say "collision-resistant, deterministically tied to the consumed ref" instead of "guaranteed unique"; note the policy must enforce the ref is spent. |

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -35,6 +35,12 @@ A survey of julc-examples found this at three independent on-chain sites
 different variant (sha2_256 vs sha3_256, minimal-width vs 2-byte vs decimal-string
 index encoding).
 
+> Survey source: `github.com/bloxbean/julc-examples`, local branch
+> `fix/julc_pre13_changes` @ `f9a067e` (ahead of `origin/main`). Reviewer
+> checkouts of julc-examples may differ in content; any `stdlib::lookup` usages
+> present in other snapshots of that repo become compile errors when it
+> upgrades to a JuLC with R2's hardened `StdlibLookup`, so they self-surface.
+
 ### Compiler constraints that shaped the design
 
 - **No varargs**: `LibraryCompiler.computeMethodType` models a varargs parameter as
@@ -128,33 +134,19 @@ preferred idiom; the implementation PR will include it:
   type cannot carry both representations: the compiler lowers `t.first()` from
   the static type alone, so either lowering crashes on the other's values.
 
-  **Decision (review, 2026-07-22): introduce `JulcPair<K,V>`**, a core-level
-  Java type whose contract is *always a native UPLC pair*:
+  **Decision (2026-07-22): the iteration surface is split out to
+  [ADR-028](028-julcpair-native-pair-type.md)** — a dedicated `JulcPair<K,V>`
+  native-pair type with `JulcMap.entries()`, a retyped `head()`, and an
+  explicit allowlist of `JulcList` operations on native-pair lists. ADR-028 is
+  design-only and will be implemented in a separate, later PR; no `entries()`
+  method ships with this ADR.
 
-  ```java
-  /** Native-pair view. On-chain: .key()/.value() → FstPair/SndPair (+ wrapDecode per K/V). */
-  public interface JulcPair<K, V> { K key(); V value(); }
-  ```
-
-  - `JulcMap.entries()` returns `JulcList<JulcPair<K,V>>` — on-chain identity
-    (the map IS a pair list), typed `ListType(PairType(K,V))`; off-chain
-    `JulcAssocMap` exposes its ordered internal pair list. Order and duplicate
-    keys preserved.
-  - `JulcMap.head()` is retyped from `Object` to `JulcPair<K,V>` — fixing the
-    existing cast-based traversal (`MapType.head()` already returns `PairType`
-    at the PIR level; the Java-side type was the gap).
-  - **Audit required**: `JulcList` operations on native-pair lists. Safe:
-    structural ops (`head`, `tail`, `size`, `isEmpty`, `take`, `drop`;
-    `MkCons`-based prepend of a pair). Unsafe and to be rejected or excluded:
-    Data-assuming ops (`contains`/`equalsData`, `toPlutusData`/`ListData`
-    wrapping, element auto-wrap) — native pairs are not Data.
-  - `JulcMap.toPlutusData()`: declared on the interface; on-chain the existing
-    `wrapEncode` fallback already maps `MapType` → `MapData` (no compiler
-    change, same as lists); off-chain `JulcAssocMap` implements it by walking
-    its entries and wrapping each key/value with the element rules.
-  - A callback-style `iterate(...)` remains rejected (lambdas do not compile
-    on-chain); making `JulcMap` `Iterable` is deferred (it interacts with the
-    existing for-each-on-MapType desugaring).
+  Within THIS ADR's scope, `JulcMap.toPlutusData()` needs no public iteration
+  API at all: it is declared on the interface; on-chain the existing
+  `wrapEncode` fallback already maps `MapType` → `MapData` (no compiler
+  change, same as lists); off-chain `JulcAssocMap` implements it by walking
+  its **private** ordered entry list, wrapping each key/value with the element
+  rules — order and duplicate keys preserved without exposing new API.
 - **Bonus**: the method works on *any* `JulcList`/`JulcMap` value, not just `of(...)`
   literals — it retires the `Builtins.listData((PlutusData)(Object) list)` re-wrap
   cast idiom found in the survey (`CfIdentityValidator`).
@@ -306,19 +298,45 @@ snippets reproduces the bug.
 
 **Decision (review, 2026-07-22): harden the interface now.** Remove
 `@FunctionalInterface` from `StdlibLookup` and make the 4-arg `lookup` abstract,
-so `::lookup` (and any lambda) stops compiling **anywhere** a `StdlibLookup` is
-expected — the entire bug class becomes a compile error, at every current and
-future API, with no CI guard to maintain. (A grep guard was rejected: a pattern
-like `JulcCompiler(.*::lookup` would already have missed the
-`ValidatorTest.compile(..., stdlib::lookup)` form.) Migration cost is zero
-today: a repo-wide grep confirms no lambda or method-reference implementations
-of `StdlibLookup` exist, and all three implementing classes (`StdlibRegistry`,
+so `::lookup` (and any lambda, and any partial implementation) stops compiling
+**anywhere** a `StdlibLookup` is expected — the entire bug class becomes a
+compile error, at every current and future API, with no CI guard to maintain.
+(A grep guard was rejected: a pattern like `JulcCompiler(.*::lookup` would
+already have missed the `ValidatorTest.compile(..., stdlib::lookup)` form.)
+
+Migration cost in-repo: no lambda or method-reference implementations of
+`StdlibLookup` exist; the three implementing **classes** (`StdlibRegistry`,
 `LibraryMethodRegistry`, `CompositeStdlibLookup`) already override both
-methods. The three documentation snippets are corrected as part of the same
-change. Pre-1.0 is the time for this breaking interface change.
+methods. Review round 3 found a **fourth, anonymous implementation** that does
+not — see "Third bypass" below — which the hardening flushes out at compile
+time, exactly the class of omission it exists to catch. The three
+documentation snippets are corrected as part of the same change. Pre-1.0 is
+the time for this breaking interface change.
 
 **Rule going forward: pass the registry object, never a method reference** —
 enforced by the compiler once R2 lands.
+
+### Third bypass found in review: the `@NewType` adapter (live bug)
+
+`JulcCompiler.wrapWithNewTypeLookup` (JulcCompiler.java:952-970) wraps the
+stdlib lookup in an **anonymous `StdlibLookup`** that overrides only the
+**3-arg** method (plus `hasMethodsForClass`). It is applied — in both the
+`compile()` and `compileMethod()` paths (JulcCompiler.java:245, 670) —
+whenever the compilation declares at least one `@NewType`.
+
+Consequence: for any `@NewType`-containing compilation, the inherited default
+4-arg lookup delegates to the adapter's 3-arg method, which delegates to the
+base registry's **untyped** lookup — reintroducing the exact bypass this ADR
+fixes, scoped to those compilations. All typed coercions (Optional.of,
+`JulcList.of` auto-wrap, MapLib key wrapping, …) silently degrade there today.
+
+Fix (implementation PR): add a typed 4-arg override to the adapter that
+handles `NewType.of` identity and otherwise delegates
+`base.lookup(className, methodName, args, argTypes)`. Regression test: a
+compilation combining an `@NewType` declaration with a construct requiring
+typed coercion (e.g. `JulcList.of(BigInteger)` or `MapLib.insert` with a
+primitive key). Note this also means R2's hardening would not compile until
+this adapter is fixed — the two land together.
 
 ### Second latent bug exposed by the fix
 
@@ -340,15 +358,22 @@ applied to the container argument of `ListsLib.prepend`, `ListsLib.contains`,
 `MapLib.insert`, `member`, `lookup`, `delete`. Static lib calls now accept both
 typed (`JulcMap`/`JulcList` variables) and raw-Data (`redeemer`) arguments.
 
-### Compatibility note
+### Compatibility notes
 
-Builds through the Gradle plugin / annotation processor now emit different (correct)
-UPLC for constructs that previously hit the untyped path — e.g.
-`ListsLib.prepend(list, bigInteger)` now wraps the element with `IData`. Previously
-those constructs produced ill-typed terms that failed at eval time, so this is
-strictly a fix, but **compiled script hashes may change** for validators using the
-affected constructs. Anyone pinning script hashes should recompile and re-derive
-addresses.
+- **Script hashes**: builds through the Gradle plugin / annotation processor now
+  emit different (correct) UPLC for constructs that previously hit the untyped
+  path — e.g. `ListsLib.prepend(list, bigInteger)` now wraps the element with
+  `IData`. Previously those constructs produced ill-typed terms that failed at
+  eval time, so this is strictly a fix, but **compiled script hashes may
+  change** for validators using the affected constructs. Anyone pinning script
+  hashes should recompile and re-derive addresses.
+- **Java source compatibility (R2, intentional)**: making the 4-arg `lookup`
+  abstract breaks any **external** lambda, method-reference, or partial
+  implementation of `StdlibLookup` at compile time — by design, since every
+  such implementation silently drops typed coercions. External implementors
+  must override both methods (typically by delegating the 3-arg form to the
+  4-arg one with null types, or vice versa). Acceptable pre-1.0;
+  release-noted.
 
 ---
 
@@ -372,8 +397,8 @@ addresses.
 | # | Item |
 |---|---|
 | R1 | JVM `Builtins.integerToByteString`: validate the full VM contract — `0 ≤ width ≤ 8192` before casting/allocating, throw when the value does not fit a positive width (currently: oversized values silently returned, negative width treated as minimal, long→int cast overflow). Direct-JVM tests for width −1/8192/8193, oversize value, plus `refBytes`/`uniqueTokenName` JVM-vs-UPLC parity. |
-| R2 | **Decided: harden `StdlibLookup`** — drop `@FunctionalInterface`, make the 4-arg `lookup` abstract; `::lookup`/lambda forms stop compiling everywhere (zero migration cost: no such implementations exist; all three implementing classes already override both methods). Fix the three doc snippets (`README.md:235`, `getting-started.md:1112`, `:1168`) in the same change. No CI grep guard needed. |
-| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating. **Decided: new `JulcPair<K,V>`** core type mapped to native `PairType` (`.key()`/`.value()` → FstPair/SndPair); `JulcMap.entries()` → `JulcList<JulcPair<K,V>>` (on-chain identity), `JulcMap.head()` retyped `Object` → `JulcPair<K,V>`; audit `JulcList` ops on native-pair lists (structural ops safe; Data-assuming ops rejected); `JulcMap.toPlutusData()` on the interface, `JulcAssocMap` impl walks entries (order + duplicate keys preserved). |
+| R2 | **Decided: harden `StdlibLookup`** — drop `@FunctionalInterface`, make the 4-arg `lookup` abstract; `::lookup`/lambda/partial forms stop compiling everywhere. In-repo migration: the three implementing classes already override both methods; **fix the anonymous `wrapWithNewTypeLookup` adapter** (JulcCompiler.java:953 — currently a LIVE typed-lookup bypass for `@NewType` compilations; add the typed override + `@NewType`-plus-typed-coercion regression test). Fix the three doc snippets (`README.md:235`, `getting-started.md:1112`, `:1168`) in the same change. No CI grep guard needed. |
+| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating; `JulcMap.toPlutusData()` on the interface, `JulcAssocMap` impl walks its private ordered entries (order + duplicate keys preserved; no public iteration API). Iteration surface (`JulcPair`, `entries()`, typed `head()`) split out to [ADR-028](028-julcpair-native-pair-type.md) — separate design + later PR. |
 | R4 | `.toPlutusData()` on-chain: NO compiler changes (PirGenerator.java:1001 wrapEncode fallback + MkCons ListType inference already cover it) — add the chained-call regression test first; drop the previously proposed TypeMethodRegistry registrations. |
 | R5 | `Builtins.concat` PIR registration: require ≥ 2 args (source-string paths bypass javac); negative compilation tests. |
 | R6 | Wording: javadoc + stdlib-guide say "collision-resistant, deterministically tied to the consumed ref" instead of "guaranteed unique"; note the policy must enforce the ref is spent. |
@@ -423,8 +448,11 @@ their own verification in the implementation PR.
 ## Consequences (once R1–R6 land with the implementation PR)
 
 - The three verbose idioms have one-line replacements; docs lead with them.
-- Typed-lookup coercions are active in every compilation path for the first time;
-  the `::lookup` anti-pattern becomes a **compile error** (R2 hardening).
+- Typed-lookup coercions are active in every compilation path for the first time
+  — including `@NewType` compilations once the adapter fix lands; the
+  `::lookup` anti-pattern (and any partial `StdlibLookup` implementation)
+  becomes a **compile error** (R2 hardening).
 - Static `MapLib`/`ListsLib` calls uniformly accept raw-Data and typed containers.
-- `JulcPair` gives map iteration a real Java type (`entries()`, typed `head()`).
-- Script-hash compatibility caveat above applies to the affected constructs.
+- Map iteration surface (`JulcPair`/`entries()`) deferred to
+  [ADR-028](028-julcpair-native-pair-type.md).
+- Script-hash and Java-compatibility caveats above apply.

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -82,6 +82,45 @@ PlutusData inputs = Builtins.listData(JulcList.of(pkh, recipient));
 PlutusData publicInputs = Builtins.listData(JulcList.of(pub0, pub1, pub2, pub3, pub4));
 ```
 
+#### D1 addendum (review, 2026-07-22): `.toPlutusData()` as the preferred surface
+
+ADR review asked whether `JulcList.of(pub0, ..., pub4).toPlutusData()` is possible
+instead of wrapping with `Builtins.listData(...)`. It is, and it becomes the
+preferred idiom; the implementation PR will include it:
+
+- **On-chain**: one `TypeMethodRegistry` registration per container type —
+  `ListType.toPlutusData` → apply the `ListData` builtin to the scope,
+  `MapType.toPlutusData` → `MapData`. This is the same instance-dispatch path
+  `list.head()` / `list.take(n)` already use.
+- **Off-chain**: a `toPlutusData()` default method on `JulcList` (mirroring the
+  `Builtins.listData(JulcList<?>)` element-wrapping rules) so the same source is
+  javac-legal and JVM-consistent. The name matches the existing
+  `PlutusDataConvertible.toPlutusData()` convention used by ledger records;
+  `JulcList` may extend `PlutusDataConvertible`, which additionally lets
+  `Builtins.asPlutusData(Object)` accept lists.
+- **Bonus**: the method works on *any* `JulcList`/`JulcMap` value, not just `of(...)`
+  literals — it retires the `Builtins.listData((PlutusData)(Object) list)` re-wrap
+  cast idiom found in the survey (`CfIdentityValidator`).
+
+Implementation notes to verify:
+
+1. **Chained-scope type inference**: dispatching `JulcList.of(...).toPlutusData()`
+   requires the `MkCons` chain to infer as `ListType`. If `MkCons` is missing from
+   `inferBuiltinReturnType`, the scope falls back to `DataType` and dispatch misses —
+   same bug class as the earlier `UnIData`/`UnBData` inference fixes; add the table
+   entry if needed.
+2. **JVM wrapping location**: `JulcList` lives in `julc-core`, which cannot call
+   `julc-stdlib`'s `Builtins` — the default method needs its own copy of the (small)
+   element-wrapping table, or the helper moves to `julc-core` and `Builtins.listData`
+   delegates to it.
+
+Both spellings coexist: `Builtins.listData(...)` stays as the builtin-parity form;
+docs and examples lead with `.toPlutusData()`.
+
+```java
+PlutusData publicInputs = JulcList.of(pub0, pub1, pub2, pub3, pub4).toPlutusData();
+```
+
 ### D2. Variadic `Builtins.concat(byte[], byte[], byte[]...)`
 
 - **PIR side**: registered in `StdlibRegistry.registerBuiltins` special-cases as a
@@ -238,6 +277,12 @@ addresses.
 | `julc-playground/.../JulcPlaygroundServer.java` | `::lookup` → registry object (production fix) |
 | ~14 test classes (julc-compiler, julc-e2e-tests, julc-plugin-test) | `::lookup` → registry object |
 | `docs/.../stdlib/stdlib-guide.md` | ValuesLib quick-ref rows; "Building Lists", "Unique Token Names" sections; `concat` in ByteStringLib example |
+
+Pending (D1 addendum, to land in the implementation PR):
+`JulcList.toPlutusData()` / `JulcMap.toPlutusData()` — TypeMethodRegistry
+registrations (`ListType`/`MapType` → `ListData`/`MapData`), `JulcList` default
+method + element wrapping in `julc-core`, `MkCons` entry in
+`inferBuiltinReturnType` if missing, docs updated to lead with this form.
 
 ## Tests
 

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -35,11 +35,14 @@ A survey of julc-examples found this at three independent on-chain sites
 different variant (sha2_256 vs sha3_256, minimal-width vs 2-byte vs decimal-string
 index encoding).
 
-> Survey source: `github.com/bloxbean/julc-examples`, local branch
-> `fix/julc_pre13_changes` @ `f9a067e` (ahead of `origin/main`). Reviewer
-> checkouts of julc-examples may differ in content; any `stdlib::lookup` usages
-> present in other snapshots of that repo become compile errors when it
-> upgrades to a JuLC with R2's hardened `StdlibLookup`, so they self-surface.
+> Naming note — there are TWO julc-examples trees, and this ADR references
+> both: (1) the **external repo** `github.com/bloxbean/julc-examples` (branch
+> `fix/julc_pre13_changes` @ `f9a067e`) — source of the idiom survey above
+> (`UVerifyProxy`, `UVerifyTxLib`, `CfProxyValidator`); (2) the **in-repo
+> Gradle module** `julc-examples/` (settings.gradle) — location of the three
+> `ValidatorTest.compile(source, stdlib::lookup)` test sites and the README
+> snippet cited under R2. Earlier review rounds talked past each other by each
+> searching only one of the two trees.
 
 ### Compiler constraints that shaped the design
 
@@ -277,24 +280,29 @@ paths, plus the test harnesses that masked the gap:
 | `julc-playground/JulcPlaygroundServer.java:43` | Playground compilations |
 | `julc-e2e-tests`, `julc-plugin-test`, ~12 julc-compiler test classes | Test harnesses exercised the untyped path, masking the gap |
 
-The testkit paths (`ValidatorTest`, `SourceDiscovery`, `JulcEval`) passed the
-registry object correctly, which is why in-repo stdlib tests never caught it — the
-exact "works via JulcCompiler directly, broken under Gradle" split ADR-023/024
-warned about in a different subsystem.
+The default testkit paths (`ValidatorTest`, `SourceDiscovery`, `JulcEval`) passed
+the registry object correctly, which is why in-repo stdlib tests never caught it
+— the exact "works via JulcCompiler directly, broken under Gradle" split
+ADR-023/024 warned about in a different subsystem. Explicit callers of
+`ValidatorTest.compile(source, stdlib::lookup)` still reproduce the bypass.
 
 ### Fix
 
 Mechanical: `new JulcCompiler(stdlib::lookup)` → `new JulcCompiler(stdlib)` at all
-~40 **code** sites (`StdlibRegistry` implements `StdlibLookup`; passing the object
-preserves the override). `CompositeStdlibLookup` already propagated the 4-arg call
-correctly.
+~40 direct-constructor sites (`StdlibRegistry` implements `StdlibLookup`; passing
+the object preserves the override). `CompositeStdlibLookup` already propagated
+the 4-arg call correctly.
 
-**Review finding (R2) — documentation still teaches the broken pattern**: the
-migration covered `.java` sources only; `README.md:235` and
-`docs/src/content/docs/getting-started.md:1112` still show
-`new JulcCompiler(stdlib::lookup)`, and `getting-started.md:1168` shows
-`ValidatorTest.compile(javaSource, stdlib::lookup)`. Every user who copies these
-snippets reproduces the bug.
+**Review finding (R2) — remaining method-reference sites**: documentation still
+teaches the broken pattern: `README.md:235` and
+`docs/src/content/docs/getting-started.md:1112` show
+`new JulcCompiler(stdlib::lookup)`, while `getting-started.md:1168` and
+`julc-examples/README.md:35` show
+`ValidatorTest.compile(javaSource, stdlib::lookup)`. Three tracked example tests
+also pass the method reference through that overload:
+`RealisticMintingTest.java:66`, `OutputValueCheckTest.java:95`, and
+`RealisticVestingTest.java:77`. Every copied snippet or example still reproduces
+the bypass until R2 lands.
 
 **Decision (review, 2026-07-22): harden the interface now.** Remove
 `@FunctionalInterface` from `StdlibLookup` and make the 4-arg `lookup` abstract,
@@ -304,14 +312,15 @@ compile error, at every current and future API, with no CI guard to maintain.
 (A grep guard was rejected: a pattern like `JulcCompiler(.*::lookup` would
 already have missed the `ValidatorTest.compile(..., stdlib::lookup)` form.)
 
-Migration cost in-repo: no lambda or method-reference implementations of
-`StdlibLookup` exist; the three implementing **classes** (`StdlibRegistry`,
-`LibraryMethodRegistry`, `CompositeStdlibLookup`) already override both
-methods. Review round 3 found a **fourth, anonymous implementation** that does
-not — see "Third bypass" below — which the hardening flushes out at compile
-time, exactly the class of omission it exists to catch. The three
-documentation snippets are corrected as part of the same change. Pre-1.0 is
-the time for this breaking interface change.
+Migration cost in-repo is small and mechanically enforced. The three named
+implementing classes (`StdlibRegistry`, `LibraryMethodRegistry`,
+`CompositeStdlibLookup`) already override both methods. Review round 3 found a
+**fourth, anonymous implementation** that does not — see "Third bypass" below
+— which the hardening flushes out at compile time, exactly the class of
+omission it exists to catch. The three tracked julc-examples method-reference
+call sites likewise become compile errors and must pass the registry object.
+The four documentation snippets above are corrected as part of the same
+change. Pre-1.0 is the time for this breaking interface change.
 
 **Rule going forward: pass the registry object, never a method reference** —
 enforced by the compiler once R2 lands.
@@ -371,8 +380,16 @@ typed (`JulcMap`/`JulcList` variables) and raw-Data (`redeemer`) arguments.
   abstract breaks any **external** lambda, method-reference, or partial
   implementation of `StdlibLookup` at compile time — by design, since every
   such implementation silently drops typed coercions. External implementors
-  must override both methods (typically by delegating the 3-arg form to the
-  4-arg one with null types, or vice versa). Acceptable pre-1.0;
+  must override both methods. An implementation that shares behavior should
+  pass an explicit `PirType.DataType` entry for each argument when adapting an
+  untyped call to the typed form; `null` is not a portable `argTypes` contract
+  because not every lookup implementation accepts it. Acceptable pre-1.0;
+  release-noted.
+- **Java source/runtime compatibility (R3)**: declaring
+  `JulcMap.toPlutusData()` requires external `JulcMap` implementations to
+  implement the new method; invoking it against an older compiled
+  implementation may produce `AbstractMethodError`. `JulcAssocMap` is the sole
+  in-repo implementation and is updated in the same PR. Acceptable pre-1.0;
   release-noted.
 
 ---
@@ -397,7 +414,7 @@ typed (`JulcMap`/`JulcList` variables) and raw-Data (`redeemer`) arguments.
 | # | Item |
 |---|---|
 | R1 | JVM `Builtins.integerToByteString`: validate the full VM contract — `0 ≤ width ≤ 8192` before casting/allocating, throw when the value does not fit a positive width (currently: oversized values silently returned, negative width treated as minimal, long→int cast overflow). Direct-JVM tests for width −1/8192/8193, oversize value, plus `refBytes`/`uniqueTokenName` JVM-vs-UPLC parity. |
-| R2 | **Decided: harden `StdlibLookup`** — drop `@FunctionalInterface`, make the 4-arg `lookup` abstract; `::lookup`/lambda/partial forms stop compiling everywhere. In-repo migration: the three implementing classes already override both methods; **fix the anonymous `wrapWithNewTypeLookup` adapter** (JulcCompiler.java:953 — currently a LIVE typed-lookup bypass for `@NewType` compilations; add the typed override + `@NewType`-plus-typed-coercion regression test). Fix the three doc snippets (`README.md:235`, `getting-started.md:1112`, `:1168`) in the same change. No CI grep guard needed. |
+| R2 | **Decided: harden `StdlibLookup`** — drop `@FunctionalInterface`, make the 4-arg `lookup` abstract; `::lookup`/lambda/partial forms stop compiling everywhere. In-repo migration: the three named implementing classes already override both methods; **fix the anonymous `wrapWithNewTypeLookup` adapter** (JulcCompiler.java:953 — currently a LIVE typed-lookup bypass for `@NewType` compilations; add the typed override + `@NewType`-plus-typed-coercion regression test). Replace the method reference in the three tracked julc-examples tests and correct four documentation snippets (`README.md:235`, `getting-started.md:1112`, `:1168`, `julc-examples/README.md:35`). No CI grep guard needed. |
 | R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating; `JulcMap.toPlutusData()` on the interface, `JulcAssocMap` impl walks its private ordered entries (order + duplicate keys preserved; no public iteration API). Iteration surface (`JulcPair`, `entries()`, typed `head()`) split out to [ADR-028](028-julcpair-native-pair-type.md) — separate design + later PR. |
 | R4 | `.toPlutusData()` on-chain: NO compiler changes (PirGenerator.java:1001 wrapEncode fallback + MkCons ListType inference already cover it) — add the chained-call regression test first; drop the previously proposed TypeMethodRegistry registrations. |
 | R5 | `Builtins.concat` PIR registration: require ≥ 2 args (source-string paths bypass javac); negative compilation tests. |
@@ -438,8 +455,10 @@ their own verification in the implementation PR.
   registrations exist in `TypeMethodRegistry` (no dispatch collisions); no
   width>0 JVM callers of `integerToByteString` rely on the lenient behavior
   (R1 throw affects only values already broken on-chain); every existing
-  `concat` call passes ≥ 2 args (R5); no lambda/method-ref `StdlibLookup`
-  implementations exist (R2 hardening is non-breaking in-repo).
+  `concat` call passes ≥ 2 args (R5); the three named `StdlibLookup`
+  implementations already implement both lookup forms, while the anonymous
+  `@NewType` adapter and three tracked julc-examples method-reference callers
+  are the known compile-time migrations forced by R2.
 - Operational note: the `julc-smoke-gradle-stdlib-usage` skill's sample validator
   uses stale `OutputLib.outputsAt(TxInfo, ...)` signatures (current API:
   `outputsAt(JulcList<TxOut>, Address)`). The JuLC compilation succeeded; only

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -1,0 +1,276 @@
+# ADR-027: Stdlib Variadic Intrinsics, Unique Token Name Helpers, and the Typed-Lookup Bypass Fix
+
+**Date**: 2026-07-21
+**Status**: Proposed (implementation complete locally; PR to follow after ADR review)
+
+---
+
+## Context
+
+User-written on-chain code kept repeating three verbose, error-prone idioms:
+
+**1. Fixed-size Data-list construction via nested `mkCons` chains** (e.g. ZK public
+inputs, script parameter lists):
+
+```java
+PlutusData publicInputs = Builtins.listData(Builtins.mkCons(
+        Builtins.iData(pub0),
+        Builtins.mkCons(Builtins.iData(pub1),
+                Builtins.mkCons(Builtins.iData(pub2), Builtins.mkNilData()))));
+```
+
+**2. Nested 2-arg `appendByteString` calls to concatenate 3+ bytestrings**:
+
+```java
+Builtins.blake2b_256(
+        Builtins.appendByteString(
+                Builtins.appendByteString(ref.txId().hash(),
+                        Builtins.integerToByteString(true, 8L, ref.index())),
+                recipientPkh));
+```
+
+**3. Unique-token-name derivation from a `TxOutRef`** — `hash(txId ++ indexBytes)`.
+A survey of julc-examples found this at three independent on-chain sites
+(`UVerifyProxy`, `UVerifyTxLib`, `CfProxyValidator`), each hand-rolling a slightly
+different variant (sha2_256 vs sha3_256, minimal-width vs 2-byte vs decimal-string
+index encoding).
+
+### Compiler constraints that shaped the design
+
+- **No varargs**: `LibraryCompiler.computeMethodType` models a varargs parameter as
+  arity-1 of the element type; array creation/access is rejected by `SubsetValidator`
+  (only `new byte[]{literals}` is allowed). A Java-source `of(PlutusData... items)`
+  cannot work.
+- **No overloading**: `StdlibRegistry`, `LibraryMethodRegistry`, and
+  `TypeMethodRegistry` all key methods by `"ClassName.methodName"` — a second
+  registration silently overwrites the first. `concat(a,b)` + `concat(a,b,c)` cannot
+  coexist as Java-source overloads.
+- **Variadic IS possible at the PIR layer**: `StdlibRegistry` builders receive the
+  already-compiled `List<PirTerm>` args of any arity (the pattern `JulcList.of` was
+  already registered with, though undocumented and without element wrapping).
+
+---
+
+## Decisions
+
+### D1. `JulcList.of(...)` auto-wraps elements (typed-lookup branch)
+
+`JulcList.of` was already reachable from on-chain code as a variadic PIR intrinsic,
+but it consed elements raw — `JulcList.of(bigInt1, bigInt2)` produced an ill-typed
+`MkCons(Integer, Data[])` that failed at eval, and the `JulcList` javadoc wrongly
+claimed the factories were "off-chain only". Rather than add a new API, we fixed the
+existing one:
+
+- **New typed branch in `StdlibRegistry.lookup(className, method, args, argTypes)`**:
+  each element passes through `PirHelpers.wrapEncode(arg, argType)` before `MkCons` —
+  `BigInteger` → `IData`, `byte[]` → `BData`, `boolean` → `ConstrData(0/1)`,
+  `String` → `BData(EncodeUtf8)`, `PlutusData`/records → pass-through. This is the
+  same mechanism `list.prepend(elem)` already used.
+- **`isJulcListClass()`** accepts both `"JulcList"` and the FQCN, future-proofing
+  against `knownFqcns` changes.
+- **New JVM overload `Builtins.listData(JulcList<?>)`** so
+  `Builtins.listData(JulcList.of(pkh, recipient))` is javac-legal and behaves
+  identically off-chain (element wrapping via a private `elementToData`, throwing
+  `IllegalArgumentException` for unsupported element types).
+- **Javadoc corrected** in `JulcList.java`: the factories ARE the on-chain
+  intrinsics; auto-wrap rules documented.
+
+Pattern 1 becomes:
+
+```java
+PlutusData inputs = Builtins.listData(JulcList.of(pkh, recipient));
+PlutusData publicInputs = Builtins.listData(JulcList.of(pub0, pub1, pub2, pub3, pub4));
+```
+
+### D2. Variadic `Builtins.concat(byte[], byte[], byte[]...)`
+
+- **PIR side**: registered in `StdlibRegistry.registerBuiltins` special-cases as a
+  right-fold of `AppendByteString` over any arity.
+- **JVM side**: a real varargs implementation in `Builtins.java` (javac enforces
+  arity ≥ 2 at call sites).
+- **Why `Builtins` and not `ByteStringLib`**: `ByteStringLib` is `@OnchainLibrary`,
+  so `LibraryCompiler` compiles every static method — a varargs body with array
+  iteration would break stdlib compilation (see constraints above). `Builtins` is
+  never source-compiled; all its calls resolve through registry keys.
+  `ByteStringLib.append(a, b)` stays for the 2-arg case and its javadoc now points
+  to `concat` for 3+ parts.
+
+Pattern 2 becomes `Builtins.blake2b_256(Builtins.concat(a, b, c))`.
+
+### D3. `ValuesLib.refBytes(ref)` + `ValuesLib.uniqueTokenName(ref)`
+
+Plain Java-source stdlib methods (ordinary subset logic — no registry work needed):
+
+```java
+public static byte[] refBytes(TxOutRef ref) {
+    byte[] idxBytes = Builtins.integerToByteString(true, 2, ref.index());
+    return Builtins.appendByteString(ref.txId().hash(), idxBytes);
+}
+
+public static byte[] uniqueTokenName(TxOutRef ref) {
+    return Builtins.blake2b_256(refBytes(ref));
+}
+```
+
+Design choices, made deliberately and documented in javadoc + stdlib guide:
+
+- **blake2b_256** — cheapest Plutus hash; output is exactly 32 bytes, the maximum
+  asset-name length.
+- **Fixed 2-byte big-endian index** (`integerToByteString(true, 2, index)`) instead
+  of minimal-width (`width 0`): minimal-width encodes index 0 as *empty bytes*
+  (with a historical JVM/UPLC divergence on that exact case), whereas width 2 is
+  deterministic, JVM/UPLC-identical, and index > 65535 (impossible for real tx
+  outputs) fails loudly.
+- **`refBytes` exposed separately** so protocols that need a different hash keep the
+  concat-and-encode part: `CryptoLib.sha2_256(ValuesLib.refBytes(ref))`. The three
+  existing julc-examples derivations are protocol-fixed and are NOT migrated; the
+  helpers target new contracts.
+- **Hosted in `ValuesLib`** (token domain, already ledger-aware) — avoids adding a
+  new lib class to the 5 class-list registration sites (`STDLIB_FQCNS`,
+  `stdlibClassFqcns`, `StdlibCatalog`, REPL, tools).
+
+### D4. Rejected alternatives
+
+- `ListsLib.of(...)` as Java-source varargs — impossible (no varargs support).
+- `ByteStringLib.concat3/concat4` distinct-name methods — works but scales badly;
+  the PIR variadic builder covers every arity with one registration.
+- A dedicated `TokenLib` — unnecessary surface; `ValuesLib` is the natural home.
+
+---
+
+## Regression found: the `::lookup` typed-lookup bypass (production bug)
+
+### Symptom
+
+The first version of the auto-wrap tests passed under `JulcEval` (julc-stdlib
+harness) but failed under `StdlibCompileEvalTest` (julc-compiler harness) with
+`MkCons: element type Integer[] does not match list element type Data[]` — elements
+were not being wrapped even though the typed branch existed.
+
+### Root cause
+
+`StdlibLookup` is a `@FunctionalInterface` whose single abstract method is the
+**3-arg** `lookup(className, method, args)`; the **4-arg** typed
+`lookup(..., argTypes)` is a default method that delegates to the 3-arg one.
+`StdlibRegistry` overrides the 4-arg default with the typed coercion logic.
+
+Constructing the compiler as `new JulcCompiler(stdlib::lookup)` creates a **lambda
+that implements only the 3-arg SAM**. The lambda inherits the interface's default
+4-arg method — which delegates to the 3-arg — so `StdlibRegistry`'s typed override
+is silently discarded. Every typed coercion registered there never ran:
+
+- `Optional.of(x)` element-type encoding
+- `ListsLib.prepend` / `ListsLib.contains` element wrapping
+- `MapLib.insert` / `member` / `lookup` / `delete` key/value wrapping
+- (and the new `JulcList.of` auto-wrap)
+
+### Blast radius
+
+`grep 'JulcCompiler(.*::lookup'` found **~40 call sites**, including four
+**production** paths:
+
+| Site | Impact |
+|---|---|
+| `julc-gradle-plugin/CompileJulcTask.java:60` | ALL user Gradle builds compiled without typed coercions |
+| `julc-annotation-processor/JulcAnnotationProcessor.java:190` | ALL annotation-processor builds (the primary user path) |
+| `julc-playground/JulcPlaygroundServer.java:43` | Playground compilations |
+| `julc-e2e-tests`, `julc-plugin-test`, ~12 julc-compiler test classes | Test harnesses exercised the untyped path, masking the gap |
+
+The testkit paths (`ValidatorTest`, `SourceDiscovery`, `JulcEval`) passed the
+registry object correctly, which is why in-repo stdlib tests never caught it — the
+exact "works via JulcCompiler directly, broken under Gradle" split ADR-023/024
+warned about in a different subsystem.
+
+### Fix
+
+Mechanical: `new JulcCompiler(stdlib::lookup)` → `new JulcCompiler(stdlib)` at all
+~40 sites (`StdlibRegistry` implements `StdlibLookup`; passing the object preserves
+the override). `CompositeStdlibLookup` already propagated the 4-arg call correctly.
+
+**Rule going forward: never pass `registry::lookup` where a `StdlibLookup` is
+expected — pass the registry object.** A future hardening option is to remove
+`@FunctionalInterface` and make the 4-arg method abstract so the method-reference
+form no longer compiles; deferred because it is a breaking interface change.
+
+### Second latent bug exposed by the fix
+
+With the typed path now active in the julc-compiler harness, one pre-existing test
+regressed: `StdlibCompileEvalTest$MapLibEval.memberTrue` —
+`MapLib.member(redeemer, key)` where the map argument is raw `PlutusData`. The
+typed MapLib/ListsLib branches assumed the container argument was already a UPLC
+pair list / list (the `MapType`/`ListType` variable convention), and crashed with
+`NullList: expected list, got Data` on raw `MapData` Data.
+
+Fix: two coercion helpers in `StdlibRegistry` —
+
+```java
+asPairList(map, type)  // DataType → UnMapData(map), MapType → pass-through
+asUplcList(list, type) // DataType → UnListData(list), ListType → pass-through
+```
+
+applied to the container argument of `ListsLib.prepend`, `ListsLib.contains`,
+`MapLib.insert`, `member`, `lookup`, `delete`. Static lib calls now accept both
+typed (`JulcMap`/`JulcList` variables) and raw-Data (`redeemer`) arguments.
+
+### Compatibility note
+
+Builds through the Gradle plugin / annotation processor now emit different (correct)
+UPLC for constructs that previously hit the untyped path — e.g.
+`ListsLib.prepend(list, bigInteger)` now wraps the element with `IData`. Previously
+those constructs produced ill-typed terms that failed at eval time, so this is
+strictly a fix, but **compiled script hashes may change** for validators using the
+affected constructs. Anyone pinning script hashes should recompile and re-derive
+addresses.
+
+---
+
+## Implementation summary
+
+| File | Change |
+|---|---|
+| `julc-stdlib/.../StdlibRegistry.java` | `JulcList.of` typed auto-wrap branch; variadic `Builtins.concat` registration; `asPairList`/`asUplcList` helpers applied to 6 typed branches; `isJulcListClass` |
+| `julc-stdlib/.../Builtins.java` | `concat(byte[], byte[], byte[]...)` JVM impl; `listData(JulcList<?>)` overload + `elementToData` |
+| `julc-stdlib/.../lib/ValuesLib.java` | `refBytes(TxOutRef)`, `uniqueTokenName(TxOutRef)` (+ `TxOutRef` import) |
+| `julc-stdlib/.../lib/ByteStringLib.java` | `append` javadoc cross-reference to `concat` |
+| `julc-core/.../types/JulcList.java` | Factory javadoc corrected (on-chain intrinsics, auto-wrap rules) |
+| `julc-gradle-plugin/.../CompileJulcTask.java` | `::lookup` → registry object (production fix) |
+| `julc-annotation-processor/.../JulcAnnotationProcessor.java` | `::lookup` → registry object (production fix) |
+| `julc-playground/.../JulcPlaygroundServer.java` | `::lookup` → registry object (production fix) |
+| ~14 test classes (julc-compiler, julc-e2e-tests, julc-plugin-test) | `::lookup` → registry object |
+| `docs/.../stdlib/stdlib-guide.md` | ValuesLib quick-ref rows; "Building Lists", "Unique Token Names" sections; `concat` in ByteStringLib example |
+
+## Tests
+
+- **`StdlibCompileEvalTest$JulcListTests`** (+4): auto-wrap for `BigInteger` and
+  `byte[]` elements; `listData(JulcList.of(a,b))` equals a hand-built `ListData`
+  end-to-end; 5-element ZK-public-inputs shape.
+- **`VariadicIntrinsicsTest`** (new, julc-stdlib, 13 tests): `concat` with 2/3/5
+  parts, empty parts, equivalence vs nested `appendByteString`, JVM parity;
+  `listData(JulcList.of(...))` composition on-chain + JVM, mixed-element JVM
+  wrapping, unsupported-element error. Uses `JulcEval.forSource` (PIR intrinsics
+  are not reachable via `forClass`).
+- **`ValuesLibTest$UniqueTokenNameTests`** (+9): `refBytes` byte-exact for indices
+  0/1/256/65535 (index 0 is the parity-critical case), failure for 65536;
+  `uniqueTokenName` == `blake2b_256(refBytes)` (cross-checked through a
+  `CryptoLib` eval), 32-byte length, differs by index and by txId.
+
+## Verification
+
+- Full repo test suite green (`./gradlew test`, all modules, incl. the previously
+  bypassed harnesses now exercising the typed path).
+- `julc-test-quick` composite gate: publish-local → gradle-plugin smoke →
+  stdlib-usage smoke → error-paths (6 negative subcases) — **all PASS** against the
+  freshly published `0.1.0-pre14` artifacts.
+- Operational note: the `julc-smoke-gradle-stdlib-usage` skill's sample validator
+  uses stale `OutputLib.outputsAt(TxInfo, ...)` signatures (current API:
+  `outputsAt(JulcList<TxOut>, Address)`). The JuLC compilation succeeded; only
+  javac rejected the sample. The skill fixture should be updated.
+
+## Consequences
+
+- The three verbose idioms have one-line replacements; docs lead with them.
+- Typed-lookup coercions are active in every compilation path for the first time;
+  the `::lookup` anti-pattern is documented (and a compile-time guard via making
+  the 4-arg method abstract remains an option).
+- Static `MapLib`/`ListsLib` calls uniformly accept raw-Data and typed containers.
+- Script-hash compatibility caveat above applies to the affected constructs.

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -112,25 +112,49 @@ preferred idiom; the implementation PR will include it:
   `PlutusDataConvertible` extends; the element-wrapping table lives in julc-core
   and `Builtins.listData(JulcList<?>)` delegates to it. `Builtins.asPlutusData`
   then accepts both.
-- **`JulcMap.toPlutusData()` off-chain spec (R3)**: on-chain assoc maps (pair
+- **`JulcMap` iteration + `toPlutusData()` (R3)**: on-chain assoc maps (pair
   lists) may legally contain duplicate keys, and `JulcMap`'s `keys()` + `get()`
-  surface collapses duplicates (`get` returns the first match). Decision
-  (review, 2026-07-22): add the lossless iteration primitive
+  surface collapses duplicates (`get` returns the first match).
+
+  An earlier revision of this addendum specified
+  `entries(): JulcList<Tuple2<K,V>>` as an *identity* operation — **retracted as
+  unimplementable**: `Tuple2` is registered as a `RecordType`
+  (TypeResolver.java:316), i.e. its on-chain representation is
+  `ConstrData(0, [first, second])` — a Data value accessed via `UnConstrData` —
+  and that contract is already load-bearing (`MathLib.divMod`/`quotRem`
+  construct it). Map entries, by contrast, are **native UPLC pairs**
+  (`PairType`, accessed via `FstPair`/`SndPair` — see the `MapType.head()`
+  registration, TypeMethodRegistry.java:678: "returns native pair"). One Java
+  type cannot carry both representations: the compiler lowers `t.first()` from
+  the static type alone, so either lowering crashes on the other's values.
+
+  **Decision (review, 2026-07-22): introduce `JulcPair<K,V>`**, a core-level
+  Java type whose contract is *always a native UPLC pair*:
 
   ```java
-  /** All entries in order, duplicates preserved. On-chain: identity — the map IS a pair list. */
-  JulcList<Tuple2<K, V>> entries();
+  /** Native-pair view. On-chain: .key()/.value() → FstPair/SndPair (+ wrapDecode per K/V). */
+  public interface JulcPair<K, V> { K key(); V value(); }
   ```
 
-  On-chain it compiles to identity typed `ListType(PairType(K,V))` (one
-  `TypeMethodRegistry` registration); off-chain `JulcAssocMap` returns its
-  ordered internal pair list. `toPlutusData()` walks `entries()`, wrapping each
-  key/value with the element rules — order and duplicates preserved by
-  construction. `entries()` has standalone user value too: it retires the
-  `Object`-typed `head()`/`tail()` cast traversal. A callback-style
-  `iterate(...)` was rejected (lambdas do not compile on-chain); making
-  `JulcMap` `Iterable` is deferred (it interacts with the existing
-  for-each-on-MapType desugaring).
+  - `JulcMap.entries()` returns `JulcList<JulcPair<K,V>>` — on-chain identity
+    (the map IS a pair list), typed `ListType(PairType(K,V))`; off-chain
+    `JulcAssocMap` exposes its ordered internal pair list. Order and duplicate
+    keys preserved.
+  - `JulcMap.head()` is retyped from `Object` to `JulcPair<K,V>` — fixing the
+    existing cast-based traversal (`MapType.head()` already returns `PairType`
+    at the PIR level; the Java-side type was the gap).
+  - **Audit required**: `JulcList` operations on native-pair lists. Safe:
+    structural ops (`head`, `tail`, `size`, `isEmpty`, `take`, `drop`;
+    `MkCons`-based prepend of a pair). Unsafe and to be rejected or excluded:
+    Data-assuming ops (`contains`/`equalsData`, `toPlutusData`/`ListData`
+    wrapping, element auto-wrap) — native pairs are not Data.
+  - `JulcMap.toPlutusData()`: declared on the interface; on-chain the existing
+    `wrapEncode` fallback already maps `MapType` → `MapData` (no compiler
+    change, same as lists); off-chain `JulcAssocMap` implements it by walking
+    its entries and wrapping each key/value with the element rules.
+  - A callback-style `iterate(...)` remains rejected (lambdas do not compile
+    on-chain); making `JulcMap` `Iterable` is deferred (it interacts with the
+    existing for-each-on-MapType desugaring).
 - **Bonus**: the method works on *any* `JulcList`/`JulcMap` value, not just `of(...)`
   literals — it retires the `Builtins.listData((PlutusData)(Object) list)` re-wrap
   cast idiom found in the survey (`CfIdentityValidator`).
@@ -145,7 +169,7 @@ PlutusData publicInputs = JulcList.of(pub0, pub1, pub2, pub3, pub4).toPlutusData
 ### D2. Variadic `Builtins.concat(byte[], byte[], byte[]...)`
 
 - **PIR side**: registered in `StdlibRegistry.registerBuiltins` special-cases as a
-  right-fold of `AppendByteString` over any arity.
+  right-fold of `AppendByteString` over the call-site arity (≥ 2, per R5 below).
 - **JVM side**: a real varargs implementation in `Builtins.java` (javac enforces
   arity ≥ 2 at call sites).
 - **Why `Builtins` and not `ByteStringLib`**: `ByteStringLib` is `@OnchainLibrary`,
@@ -192,15 +216,20 @@ Design choices, made deliberately and documented in javadoc + stdlib guide:
   of minimal-width (`width 0`): minimal-width encodes index 0 as *empty bytes*,
   whereas width 2 is deterministic and JVM/UPLC-identical for all valid indices
   (0–65535); index > 65535 (impossible for real tx outputs) fails loudly on-chain.
-- **Review finding (R1) — JVM overflow check missing**: the UPLC builtin errors
-  when the value does not fit the requested width, but the JVM
-  `Builtins.integerToByteString` (Builtins.java:333) only pads *undersized*
-  values and never rejects *oversized* ones — `(true, 2, 65536)` returns 3 bytes
-  on the JVM while the VM throws. So the JVM/UPLC-parity claim above currently
-  holds only for indices ≤ 65535. Fix in the implementation PR: throw when
-  `raw.length > width` (width > 0), plus **direct-JVM** tests — the existing
-  `ValuesLibTest` coverage exercises only the UPLC path via `JulcEval`, which is
-  why this went unnoticed.
+- **Review finding (R1) — JVM width validation incomplete**: the VM validates
+  the full contract (BitwiseBuiltins.java:33): negative value → error, negative
+  width → error, width > 8192 → error, value not fitting a positive width →
+  error. The JVM `Builtins.integerToByteString` (Builtins.java:333) checks only
+  the negative *value*; it pads undersized values but (a) silently returns
+  *oversized* ones — `(true, 2, 65536)` returns 3 bytes while the VM throws —
+  (b) treats negative width like width 0 instead of throwing, and (c) casts
+  `long` width straight to `int` (overflow for huge widths, no 8192 cap). So
+  the JVM/UPLC-parity claim above currently holds only for indices ≤ 65535 with
+  sane widths. Fix in the implementation PR: validate `0 ≤ width ≤ 8192` before
+  casting/allocating and throw when the value does not fit a positive width;
+  **direct-JVM** tests for width −1, 8192, 8193, and an oversize value — the
+  existing `ValuesLibTest` coverage exercises only the UPLC path via
+  `JulcEval`, which is why this went unnoticed.
 - **`refBytes` exposed separately** so protocols that need a different hash keep the
   concat-and-encode part: `CryptoLib.sha2_256(ValuesLib.refBytes(ref))`. The three
   existing julc-examples derivations are protocol-fixed and are NOT migrated; the
@@ -246,8 +275,8 @@ is silently discarded. Every typed coercion registered there never ran:
 
 ### Blast radius
 
-`grep 'JulcCompiler(.*::lookup'` found **~40 call sites**, including four
-**production** paths:
+`grep 'JulcCompiler(.*::lookup'` found **~40 call sites**: three **production**
+paths, plus the test harnesses that masked the gap:
 
 | Site | Impact |
 |---|---|
@@ -273,16 +302,23 @@ migration covered `.java` sources only; `README.md:235` and
 `docs/src/content/docs/getting-started.md:1112` still show
 `new JulcCompiler(stdlib::lookup)`, and `getting-started.md:1168` shows
 `ValidatorTest.compile(javaSource, stdlib::lookup)`. Every user who copies these
-snippets reproduces the bug. Fix in the implementation PR: correct the three
-snippets and add an automated guard — either a repo grep check in CI
-(`JulcCompiler(.*::lookup` must not match) or the interface hardening below.
+snippets reproduces the bug.
 
-**Rule going forward: never pass `registry::lookup` where a `StdlibLookup` is
-expected — pass the registry object.** A future hardening option is to remove
-`@FunctionalInterface` and make the 4-arg method abstract so the method-reference
-form no longer compiles; deferred because it is a breaking interface change, but
-worth deciding now while the project is pre-1.0 (it would make R2's guard
-unnecessary by construction).
+**Decision (review, 2026-07-22): harden the interface now.** Remove
+`@FunctionalInterface` from `StdlibLookup` and make the 4-arg `lookup` abstract,
+so `::lookup` (and any lambda) stops compiling **anywhere** a `StdlibLookup` is
+expected — the entire bug class becomes a compile error, at every current and
+future API, with no CI guard to maintain. (A grep guard was rejected: a pattern
+like `JulcCompiler(.*::lookup` would already have missed the
+`ValidatorTest.compile(..., stdlib::lookup)` form.) Migration cost is zero
+today: a repo-wide grep confirms no lambda or method-reference implementations
+of `StdlibLookup` exist, and all three implementing classes (`StdlibRegistry`,
+`LibraryMethodRegistry`, `CompositeStdlibLookup`) already override both
+methods. The three documentation snippets are corrected as part of the same
+change. Pre-1.0 is the time for this breaking interface change.
+
+**Rule going forward: pass the registry object, never a method reference** —
+enforced by the compiler once R2 lands.
 
 ### Second latent bug exposed by the fix
 
@@ -335,9 +371,9 @@ addresses.
 
 | # | Item |
 |---|---|
-| R1 | JVM `Builtins.integerToByteString`: throw when the value does not fit `width` (currently pads undersized but silently returns oversized — JVM/UPLC divergence for index > 65535). Add direct-JVM tests for `refBytes`/`uniqueTokenName` alongside the existing UPLC-path tests. |
-| R2 | Fix `stdlib::lookup` snippets in `README.md:235`, `getting-started.md:1112`, `:1168`; add a CI grep guard for `JulcCompiler(.*::lookup` — or resolve via R2b: remove `@FunctionalInterface` from `StdlibLookup` and make the 4-arg method abstract (breaking; decide while pre-1.0). |
-| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating; new `JulcMap.entries()` → `JulcList<Tuple2<K,V>>` as the lossless iteration primitive (on-chain identity + one TypeMethodRegistry registration; off-chain JulcAssocMap's ordered pair list); `JulcMap.toPlutusData()` walks `entries()` (order + duplicate keys preserved). |
+| R1 | JVM `Builtins.integerToByteString`: validate the full VM contract — `0 ≤ width ≤ 8192` before casting/allocating, throw when the value does not fit a positive width (currently: oversized values silently returned, negative width treated as minimal, long→int cast overflow). Direct-JVM tests for width −1/8192/8193, oversize value, plus `refBytes`/`uniqueTokenName` JVM-vs-UPLC parity. |
+| R2 | **Decided: harden `StdlibLookup`** — drop `@FunctionalInterface`, make the 4-arg `lookup` abstract; `::lookup`/lambda forms stop compiling everywhere (zero migration cost: no such implementations exist; all three implementing classes already override both methods). Fix the three doc snippets (`README.md:235`, `getting-started.md:1112`, `:1168`) in the same change. No CI grep guard needed. |
+| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating. **Decided: new `JulcPair<K,V>`** core type mapped to native `PairType` (`.key()`/`.value()` → FstPair/SndPair); `JulcMap.entries()` → `JulcList<JulcPair<K,V>>` (on-chain identity), `JulcMap.head()` retyped `Object` → `JulcPair<K,V>`; audit `JulcList` ops on native-pair lists (structural ops safe; Data-assuming ops rejected); `JulcMap.toPlutusData()` on the interface, `JulcAssocMap` impl walks entries (order + duplicate keys preserved). |
 | R4 | `.toPlutusData()` on-chain: NO compiler changes (PirGenerator.java:1001 wrapEncode fallback + MkCons ListType inference already cover it) — add the chained-call regression test first; drop the previously proposed TypeMethodRegistry registrations. |
 | R5 | `Builtins.concat` PIR registration: require ≥ 2 args (source-string paths bypass javac); negative compilation tests. |
 | R6 | Wording: javadoc + stdlib-guide say "collision-resistant, deterministically tied to the consumed ref" instead of "guaranteed unique"; note the policy must enforce the ref is spent. |
@@ -359,23 +395,36 @@ Docs updated to lead with `.toPlutusData()` once R3/R4 land.
   `uniqueTokenName` == `blake2b_256(refBytes)` (cross-checked through a
   `CryptoLib` eval), 32-byte length, differs by index and by txId.
 
-## Verification
+## Verification (staged implementation only — pre-R1–R6)
+
+The checks below cover the staged core implementation; the R1–R6 follow-ups get
+their own verification in the implementation PR.
 
 - Full repo test suite green (`./gradlew test`, all modules, incl. the previously
   bypassed harnesses now exercising the typed path).
 - `julc-test-quick` composite gate: publish-local → gradle-plugin smoke →
   stdlib-usage smoke → error-paths (6 negative subcases) — **all PASS** against the
   freshly published `0.1.0-pre14` artifacts.
+- R4 verified empirically: chained `JulcList.of(...).toPlutusData()` and
+  variable `.toPlutusData()` compile and evaluate correctly today (scratch test
+  through `JulcEval.forSource`, to be added permanently in the implementation PR).
+- Follow-up regression pre-checks: `JulcAssocMap` is the sole `JulcMap`
+  implementor (R3 additions touch one class); no `"entries"`/`"toPlutusData"`
+  registrations exist in `TypeMethodRegistry` (no dispatch collisions); no
+  width>0 JVM callers of `integerToByteString` rely on the lenient behavior
+  (R1 throw affects only values already broken on-chain); every existing
+  `concat` call passes ≥ 2 args (R5); no lambda/method-ref `StdlibLookup`
+  implementations exist (R2 hardening is non-breaking in-repo).
 - Operational note: the `julc-smoke-gradle-stdlib-usage` skill's sample validator
   uses stale `OutputLib.outputsAt(TxInfo, ...)` signatures (current API:
   `outputsAt(JulcList<TxOut>, Address)`). The JuLC compilation succeeded; only
   javac rejected the sample. The skill fixture should be updated.
 
-## Consequences
+## Consequences (once R1–R6 land with the implementation PR)
 
 - The three verbose idioms have one-line replacements; docs lead with them.
 - Typed-lookup coercions are active in every compilation path for the first time;
-  the `::lookup` anti-pattern is documented (and a compile-time guard via making
-  the 4-arg method abstract remains an option).
+  the `::lookup` anti-pattern becomes a **compile error** (R2 hardening).
 - Static `MapLib`/`ListsLib` calls uniformly accept raw-Data and typed containers.
+- `JulcPair` gives map iteration a real Java type (`entries()`, typed `head()`).
 - Script-hash compatibility caveat above applies to the affected constructs.

--- a/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
+++ b/adr/027-stdlib-variadic-intrinsics-typed-lookup-fix.md
@@ -1,7 +1,7 @@
 # ADR-027: Stdlib Variadic Intrinsics, Unique Token Name Helpers, and the Typed-Lookup Bypass Fix
 
 **Date**: 2026-07-21 (review findings folded in 2026-07-22)
-**Status**: Proposed (under review; core implementation staged locally, review follow-ups R1–R6 pending — see Implementation summary)
+**Status**: Accepted and implemented (2026-07-23)
 
 ---
 
@@ -36,8 +36,10 @@ different variant (sha2_256 vs sha3_256, minimal-width vs 2-byte vs decimal-stri
 index encoding).
 
 > Naming note — there are TWO julc-examples trees, and this ADR references
-> both: (1) the **external repo** `github.com/bloxbean/julc-examples` (branch
-> `fix/julc_pre13_changes` @ `f9a067e`) — source of the idiom survey above
+> both: (1) the **external repo**
+> [`github.com/bloxbean/julc-examples`](https://github.com/bloxbean/julc-examples)
+> (`main` @ `5ead7918d14635c9238f1699e3a58a8aa4d7b054`, verified 2026-07-23) —
+> source of the idiom survey above
 > (`UVerifyProxy`, `UVerifyTxLib`, `CfProxyValidator`); (2) the **in-repo
 > Gradle module** `julc-examples/` (settings.gradle) — location of the three
 > `ValidatorTest.compile(source, stdlib::lookup)` test sites and the README
@@ -79,8 +81,8 @@ existing one:
   against `knownFqcns` changes.
 - **New JVM overload `Builtins.listData(JulcList<?>)`** so
   `Builtins.listData(JulcList.of(pkh, recipient))` is javac-legal and behaves
-  identically off-chain (element wrapping via a private `elementToData`, throwing
-  `IllegalArgumentException` for unsupported element types).
+  identically off-chain (delegating to the shared core conversion table, which
+  throws `IllegalArgumentException` for unsupported element types).
 - **Javadoc corrected** in `JulcList.java`: the factories ARE the on-chain
   intrinsics; auto-wrap rules documented.
 
@@ -95,7 +97,7 @@ PlutusData publicInputs = Builtins.listData(JulcList.of(pub0, pub1, pub2, pub3, 
 
 ADR review asked whether `JulcList.of(pub0, ..., pub4).toPlutusData()` is possible
 instead of wrapping with `Builtins.listData(...)`. It is, and it becomes the
-preferred idiom; the implementation PR will include it:
+preferred idiom; the implementation includes it:
 
 - **On-chain: no compiler changes needed** (verified during review, R4). Two earlier
   assumptions in this addendum were wrong:
@@ -177,12 +179,11 @@ PlutusData publicInputs = JulcList.of(pub0, pub1, pub2, pub3, pub4).toPlutusData
 Pattern 2 becomes `Builtins.blake2b_256(Builtins.concat(a, b, c))`.
 
 **Review finding (R5) — enforce minimum arity in the registry**: the Java API
-documents arity ≥ 2 (enforced by javac at Gradle-build call sites), but the PIR
-registration currently accepts 0 args (→ empty bytes) and 1 arg (→ identity).
+documents arity ≥ 2 (enforced by javac at Gradle-build call sites), but the
+staged PIR registration accepted 0 args (→ empty bytes) and 1 arg (→ identity).
 Source-string compilation paths (`JulcEval.forSource`, CLI check, playground)
-never run javac, so a 1-arg `concat` would silently no-op there. The registry
-builder will reject fewer than 2 arguments (same `requireArgs` convention as other
-registrations), with negative compilation tests.
+never run javac, so a 1-arg `concat` would silently no-op there. The final
+registry builder rejects fewer than 2 arguments, with negative compilation tests.
 
 ### D3. `ValuesLib.refBytes(ref)` + `ValuesLib.uniqueTokenName(ref)`
 
@@ -218,10 +219,10 @@ Design choices, made deliberately and documented in javadoc + stdlib guide:
   the negative *value*; it pads undersized values but (a) silently returns
   *oversized* ones — `(true, 2, 65536)` returns 3 bytes while the VM throws —
   (b) treats negative width like width 0 instead of throwing, and (c) casts
-  `long` width straight to `int` (overflow for huge widths, no 8192 cap). So
-  the JVM/UPLC-parity claim above currently holds only for indices ≤ 65535 with
-  sane widths. Fix in the implementation PR: validate `0 ≤ width ≤ 8192` before
-  casting/allocating and throw when the value does not fit a positive width;
+  `long` width straight to `int` (overflow for huge widths, no 8192 cap). At
+  review time, the JVM/UPLC-parity claim therefore held only for indices ≤ 65535
+  with sane widths. The implementation validates `0 ≤ width ≤ 8192` before
+  casting/allocating and throws when the value does not fit a positive width;
   **direct-JVM** tests for width −1, 8192, 8193, and an oversize value — the
   existing `ValuesLibTest` coverage exercises only the UPLC path via
   `JulcEval`, which is why this went unnoticed.
@@ -280,11 +281,12 @@ paths, plus the test harnesses that masked the gap:
 | `julc-playground/JulcPlaygroundServer.java:43` | Playground compilations |
 | `julc-e2e-tests`, `julc-plugin-test`, ~12 julc-compiler test classes | Test harnesses exercised the untyped path, masking the gap |
 
-The default testkit paths (`ValidatorTest`, `SourceDiscovery`, `JulcEval`) passed
+At review time, the default testkit paths (`ValidatorTest`, `SourceDiscovery`,
+`JulcEval`) passed
 the registry object correctly, which is why in-repo stdlib tests never caught it
 — the exact "works via JulcCompiler directly, broken under Gradle" split
 ADR-023/024 warned about in a different subsystem. Explicit callers of
-`ValidatorTest.compile(source, stdlib::lookup)` still reproduce the bypass.
+`ValidatorTest.compile(source, stdlib::lookup)` still reproduced the bypass.
 
 ### Fix
 
@@ -294,15 +296,15 @@ the object preserves the override). `CompositeStdlibLookup` already propagated
 the 4-arg call correctly.
 
 **Review finding (R2) — remaining method-reference sites**: documentation still
-teaches the broken pattern: `README.md:235` and
+taught the broken pattern at review time: `README.md:235` and
 `docs/src/content/docs/getting-started.md:1112` show
 `new JulcCompiler(stdlib::lookup)`, while `getting-started.md:1168` and
 `julc-examples/README.md:35` show
 `ValidatorTest.compile(javaSource, stdlib::lookup)`. Three tracked example tests
 also pass the method reference through that overload:
 `RealisticMintingTest.java:66`, `OutputValueCheckTest.java:95`, and
-`RealisticVestingTest.java:77`. Every copied snippet or example still reproduces
-the bypass until R2 lands.
+`RealisticVestingTest.java:77`. Before R2 landed, every copied snippet or example
+reproduced the bypass.
 
 **Decision (review, 2026-07-22): harden the interface now.** Remove
 `@FunctionalInterface` from `StdlibLookup` and make the 4-arg `lookup` abstract,
@@ -315,17 +317,17 @@ already have missed the `ValidatorTest.compile(..., stdlib::lookup)` form.)
 Migration cost in-repo is small and mechanically enforced. The three named
 implementing classes (`StdlibRegistry`, `LibraryMethodRegistry`,
 `CompositeStdlibLookup`) already override both methods. Review round 3 found a
-**fourth, anonymous implementation** that does not — see "Third bypass" below
-— which the hardening flushes out at compile time, exactly the class of
-omission it exists to catch. The three tracked julc-examples method-reference
-call sites likewise become compile errors and must pass the registry object.
-The four documentation snippets above are corrected as part of the same
-change. Pre-1.0 is the time for this breaking interface change.
+**fourth, anonymous implementation** that did not — see "Third bypass" below.
+The hardened interface also exposed two test-fixture lambdas missed by the
+original grep audit; both are now explicit implementations of the typed and
+untyped forms. The three tracked julc-examples method-reference call sites now
+pass the registry object, and the four documentation snippets above are
+corrected. Pre-1.0 is the time for this breaking interface change.
 
 **Rule going forward: pass the registry object, never a method reference** —
-enforced by the compiler once R2 lands.
+now enforced by the compiler.
 
-### Third bypass found in review: the `@NewType` adapter (live bug)
+### Third bypass found in review: the `@NewType` adapter
 
 `JulcCompiler.wrapWithNewTypeLookup` (JulcCompiler.java:952-970) wraps the
 stdlib lookup in an **anonymous `StdlibLookup`** that overrides only the
@@ -333,19 +335,19 @@ stdlib lookup in an **anonymous `StdlibLookup`** that overrides only the
 `compile()` and `compileMethod()` paths (JulcCompiler.java:245, 670) —
 whenever the compilation declares at least one `@NewType`.
 
-Consequence: for any `@NewType`-containing compilation, the inherited default
-4-arg lookup delegates to the adapter's 3-arg method, which delegates to the
+Before the fix, for any `@NewType`-containing compilation, the inherited default
+4-arg lookup delegated to the adapter's 3-arg method, which delegated to the
 base registry's **untyped** lookup — reintroducing the exact bypass this ADR
 fixes, scoped to those compilations. All typed coercions (Optional.of,
-`JulcList.of` auto-wrap, MapLib key wrapping, …) silently degrade there today.
+`JulcList.of` auto-wrap, MapLib key wrapping, …) silently degraded there.
 
-Fix (implementation PR): add a typed 4-arg override to the adapter that
+The implementation adds a typed 4-arg override to the adapter that
 handles `NewType.of` identity and otherwise delegates
 `base.lookup(className, methodName, args, argTypes)`. Regression test: a
 compilation combining an `@NewType` declaration with a construct requiring
 typed coercion (e.g. `JulcList.of(BigInteger)` or `MapLib.insert` with a
-primitive key). Note this also means R2's hardening would not compile until
-this adapter is fixed — the two land together.
+primitive key). R2's hardening and this adapter fix landed together because the
+hardened interface makes an adapter without both lookup forms fail compilation.
 
 ### Second latent bug exposed by the fix
 
@@ -399,78 +401,80 @@ typed (`JulcMap`/`JulcList` variables) and raw-Data (`redeemer`) arguments.
 | File | Change |
 |---|---|
 | `julc-stdlib/.../StdlibRegistry.java` | `JulcList.of` typed auto-wrap branch; variadic `Builtins.concat` registration; `asPairList`/`asUplcList` helpers applied to 6 typed branches; `isJulcListClass` |
-| `julc-stdlib/.../Builtins.java` | `concat(byte[], byte[], byte[]...)` JVM impl; `listData(JulcList<?>)` overload + `elementToData` |
+| `julc-stdlib/.../Builtins.java` | Overflow-checked `concat(byte[], byte[], byte[]...)`; strict `integerToByteString` width/fit checks; `listData(JulcList<?>)` delegates to the core converter; object overloads accept `ToPlutusData` |
 | `julc-stdlib/.../lib/ValuesLib.java` | `refBytes(TxOutRef)`, `uniqueTokenName(TxOutRef)` (+ `TxOutRef` import) |
 | `julc-stdlib/.../lib/ByteStringLib.java` | `append` javadoc cross-reference to `concat` |
-| `julc-core/.../types/JulcList.java` | Factory javadoc corrected (on-chain intrinsics, auto-wrap rules) |
+| `julc-core/.../ToPlutusData.java`, `PlutusDataConversions.java` | Core conversion contract and one shared, recursive element-encoding table |
+| `julc-core/.../types/JulcList.java` | `toPlutusData()` default method; factory javadoc corrected (on-chain intrinsics, auto-wrap rules) |
+| `julc-core/.../types/JulcMap.java`, `JulcAssocMap.java` | `toPlutusData()` contract and ordered, duplicate-preserving implementation over private entries |
+| `julc-ledger-api/.../PlutusDataConvertible.java` | Extends the core `ToPlutusData` contract |
+| `julc-compiler/.../StdlibLookup.java` | Typed 4-arg lookup is abstract; lambdas/method references/partial implementations no longer compile |
+| `julc-compiler/.../JulcCompiler.java` | `@NewType` adapter propagates typed lookup |
 | `julc-gradle-plugin/.../CompileJulcTask.java` | `::lookup` → registry object (production fix) |
 | `julc-annotation-processor/.../JulcAnnotationProcessor.java` | `::lookup` → registry object (production fix) |
 | `julc-playground/.../JulcPlaygroundServer.java` | `::lookup` → registry object (production fix) |
-| ~14 test classes (julc-compiler, julc-e2e-tests, julc-plugin-test) | `::lookup` → registry object |
+| test/example call sites | `::lookup` → registry object; two custom lookup lambdas made explicit |
+| `julc-testkit/.../ArgConverter.java` | Delegates to the core conversion table, including `JulcList`/`JulcMap` |
+| `julc-vm-java/.../BitwiseBuiltins.java` | Validates arbitrary-precision widths before narrowing, closing a discovered `BigInteger.intValue()` overflow bypass |
 | `docs/.../stdlib/stdlib-guide.md` | ValuesLib quick-ref rows; "Building Lists", "Unique Token Names" sections; `concat` in ByteStringLib example |
 
-### Review follow-ups (2026-07-22), to land in the implementation PR
+### Review follow-ups (implemented 2026-07-23)
 
 | # | Item |
 |---|---|
-| R1 | JVM `Builtins.integerToByteString`: validate the full VM contract — `0 ≤ width ≤ 8192` before casting/allocating, throw when the value does not fit a positive width (currently: oversized values silently returned, negative width treated as minimal, long→int cast overflow). Direct-JVM tests for width −1/8192/8193, oversize value, plus `refBytes`/`uniqueTokenName` JVM-vs-UPLC parity. |
-| R2 | **Decided: harden `StdlibLookup`** — drop `@FunctionalInterface`, make the 4-arg `lookup` abstract; `::lookup`/lambda/partial forms stop compiling everywhere. In-repo migration: the three named implementing classes already override both methods; **fix the anonymous `wrapWithNewTypeLookup` adapter** (JulcCompiler.java:953 — currently a LIVE typed-lookup bypass for `@NewType` compilations; add the typed override + `@NewType`-plus-typed-coercion regression test). Replace the method reference in the three tracked julc-examples tests and correct four documentation snippets (`README.md:235`, `getting-started.md:1112`, `:1168`, `julc-examples/README.md:35`). No CI grep guard needed. |
-| R3 | `.toPlutusData()` JVM side: core-level conversion interface in `julc-core` (extended by ledger-api's `PlutusDataConvertible` — direct extension is a circular dependency); element-wrapping table in julc-core with `Builtins.listData(JulcList<?>)` delegating; `JulcMap.toPlutusData()` on the interface, `JulcAssocMap` impl walks its private ordered entries (order + duplicate keys preserved; no public iteration API). Iteration surface (`JulcPair`, `entries()`, typed `head()`) split out to [ADR-028](028-julcpair-native-pair-type.md) — separate design + later PR. |
-| R4 | `.toPlutusData()` on-chain: NO compiler changes (PirGenerator.java:1001 wrapEncode fallback + MkCons ListType inference already cover it) — add the chained-call regression test first; drop the previously proposed TypeMethodRegistry registrations. |
-| R5 | `Builtins.concat` PIR registration: require ≥ 2 args (source-string paths bypass javac); negative compilation tests. |
-| R6 | Wording: javadoc + stdlib-guide say "collision-resistant, deterministically tied to the consumed ref" instead of "guaranteed unique"; note the policy must enforce the ref is spent. |
+| R1 | Implemented full JVM `integerToByteString` contract: `0 ≤ width ≤ 8192`, bounded/unbounded output-size checks, and JVM-vs-UPLC parity tests. |
+| R2 | Hardened `StdlibLookup`, fixed the `@NewType` adapter, migrated all call sites/docs, and converted the two test-fixture lambdas exposed by compilation. |
+| R3 | Added the core conversion interface/table plus list/map conversion; map order and duplicates are preserved. `JulcPair` remains solely in [ADR-028](028-julcpair-native-pair-type.md). |
+| R4 | Added chained, variable-list, and variable-map `.toPlutusData()` regressions; no type-method registrations or other compiler changes were needed. |
+| R5 | Enforced `concat` arity ≥ 2 in the PIR registry with zero/one-argument source-compilation tests. |
+| R6 | Aligned javadoc and guide wording on collision resistance and policy enforcement. |
 
-Docs updated to lead with `.toPlutusData()` once R3/R4 land.
+Docs now lead with `.toPlutusData()`.
 
 ## Tests
 
 - **`StdlibCompileEvalTest$JulcListTests`** (+4): auto-wrap for `BigInteger` and
   `byte[]` elements; `listData(JulcList.of(a,b))` equals a hand-built `ListData`
   end-to-end; 5-element ZK-public-inputs shape.
-- **`VariadicIntrinsicsTest`** (new, julc-stdlib, 13 tests): `concat` with 2/3/5
-  parts, empty parts, equivalence vs nested `appendByteString`, JVM parity;
-  `listData(JulcList.of(...))` composition on-chain + JVM, mixed-element JVM
-  wrapping, unsupported-element error. Uses `JulcEval.forSource` (PIR intrinsics
-  are not reachable via `forClass`).
-- **`ValuesLibTest$UniqueTokenNameTests`** (+9): `refBytes` byte-exact for indices
+- **`VariadicIntrinsicsTest`** (new, julc-stdlib, 18 tests): `concat` with 2/3/5
+  parts, empty parts, equivalence vs nested `appendByteString`, JVM parity, and
+  zero/one-argument rejection; list/map `.toPlutusData()` on chained and variable
+  values; `listData(JulcList.of(...))` composition on-chain + JVM, mixed-element
+  JVM wrapping, unsupported-element error. Uses `JulcEval.forSource` (PIR
+  intrinsics are not reachable via `forClass`).
+- **`ValuesLibTest$UniqueTokenNameTests`** (+11): `refBytes` byte-exact for indices
   0/1/256/65535 (index 0 is the parity-critical case), failure for 65536;
   `uniqueTokenName` == `blake2b_256(refBytes)` (cross-checked through a
-  `CryptoLib` eval), 32-byte length, differs by index and by txId.
+  `CryptoLib` eval), 32-byte length, differs by index and by txId, and direct
+  JVM-vs-UPLC parity.
+- **Core conversion tests** (+6): supported scalar types, UTF-8 strings, nested
+  lists/maps, unsupported values, and duplicate-key/order preservation.
+- **Security and lookup tests**: 9 direct-JVM builtin tests, an
+  `@NewType`-plus-typed-coercion regression, testkit collection conversion, and
+  2 VM arbitrary-width narrowing regressions.
 
-## Verification (staged implementation only — pre-R1–R6)
+## Verification (post-implementation)
 
-The checks below cover the staged core implementation; the R1–R6 follow-ups get
-their own verification in the implementation PR.
+- `./gradlew test` — **PASS** across all enabled modules (111 tasks; explicit
+  network E2E modules remain skipped by their normal opt-in configuration).
+- Focused core/compiler/stdlib/testkit/VM ADR tests — **PASS**.
+- Official Plutus UPLC conformance runner — **999/999 PASS**, including all 32
+  `integerToByteString` cases.
+- Every bundled `integerToByteString` `.uplc` input and `.uplc.expected` result
+  was Git-blob compared with current
+  [`IntersectMBO/plutus`](https://github.com/IntersectMBO/plutus/tree/master/plutus-conformance/test-cases/uplc/evaluation/builtin/semantics/integerToByteString)
+  master (`6e7944f422f9a22fb3e78a8e2cfa25adc373522b`); all match. Upstream's
+  2026-07-22 update added flat-format companions without changing these UPLC
+  vectors.
+- `git diff --check` — **PASS**.
 
-- Full repo test suite green (`./gradlew test`, all modules, incl. the previously
-  bypassed harnesses now exercising the typed path).
-- `julc-test-quick` composite gate: publish-local → gradle-plugin smoke →
-  stdlib-usage smoke → error-paths (6 negative subcases) — **all PASS** against the
-  freshly published `0.1.0-pre14` artifacts.
-- R4 verified empirically: chained `JulcList.of(...).toPlutusData()` and
-  variable `.toPlutusData()` compile and evaluate correctly today (scratch test
-  through `JulcEval.forSource`, to be added permanently in the implementation PR).
-- Follow-up regression pre-checks: `JulcAssocMap` is the sole `JulcMap`
-  implementor (R3 additions touch one class); no `"entries"`/`"toPlutusData"`
-  registrations exist in `TypeMethodRegistry` (no dispatch collisions); no
-  width>0 JVM callers of `integerToByteString` rely on the lenient behavior
-  (R1 throw affects only values already broken on-chain); every existing
-  `concat` call passes ≥ 2 args (R5); the three named `StdlibLookup`
-  implementations already implement both lookup forms, while the anonymous
-  `@NewType` adapter and three tracked julc-examples method-reference callers
-  are the known compile-time migrations forced by R2.
-- Operational note: the `julc-smoke-gradle-stdlib-usage` skill's sample validator
-  uses stale `OutputLib.outputsAt(TxInfo, ...)` signatures (current API:
-  `outputsAt(JulcList<TxOut>, Address)`). The JuLC compilation succeeded; only
-  javac rejected the sample. The skill fixture should be updated.
-
-## Consequences (once R1–R6 land with the implementation PR)
+## Consequences
 
 - The three verbose idioms have one-line replacements; docs lead with them.
-- Typed-lookup coercions are active in every compilation path for the first time
-  — including `@NewType` compilations once the adapter fix lands; the
+- Typed-lookup coercions are active in every compilation path for the first time,
+  including `@NewType` compilations; the
   `::lookup` anti-pattern (and any partial `StdlibLookup` implementation)
-  becomes a **compile error** (R2 hardening).
+  is a **compile error** (R2 hardening).
 - Static `MapLib`/`ListsLib` calls uniformly accept raw-Data and typed containers.
 - Map iteration surface (`JulcPair`/`entries()`) deferred to
   [ADR-028](028-julcpair-native-pair-type.md).

--- a/adr/028-julcpair-native-pair-type.md
+++ b/adr/028-julcpair-native-pair-type.md
@@ -1,0 +1,122 @@
+# ADR-028: `JulcPair` — a Native-Pair Java Type for Map Iteration
+
+**Date**: 2026-07-22
+**Status**: Proposed (design only — implementation in a separate, later PR)
+**Extracted from**: ADR-027 review round 2; split out so ADR-027's scope stays
+limited to the stdlib conveniences and the typed-lookup fix.
+
+---
+
+## Context
+
+ADR-027's review established that JuLC has two "pair-like" runtime shapes that
+must not share a Java type:
+
+- **`Tuple2<A,B>`** is registered as a `RecordType`
+  (TypeResolver.java:316) — its on-chain representation is **Data**:
+  `Constr 0 [a', b']`, constructed via `ConstrData`, read via `UnConstrData` +
+  fields-list traversal, accessors `.first()`/`.second()`. This contract is
+  load-bearing (`MathLib.divMod`/`quotRem` construct it; Tuple2 values can live
+  in Data lists, be `equalsData`-compared, serialised, stored in datums).
+- **Map entries** are **native UPLC pairs** (`pair⟨data,data⟩`) — builtin CEK
+  values, NOT Data. Read via `FstPair`/`SndPair`; cannot be consed into Data
+  lists, `equalsData`-compared, or serialised. Data-ness exists only at the
+  container level (`MapData` wraps the whole pair list). The
+  `MapType.head()` registration (TypeMethodRegistry.java:678) already returns
+  `PairType` at the PIR level — but `JulcMap.head()` is typed `Object` on the
+  Java side because no Java type for native pairs exists.
+
+The compiler lowers accessor calls from the static Java type alone, so one type
+cannot carry both representations: typing map entries as `Tuple2` would emit
+`UnConstrData` against a native pair (crash), and vice versa.
+
+`JulcMap` also has no lossless iteration surface: `keys()` + `get()` collapses
+duplicate keys (legal in on-chain assoc maps; `get` returns the first match),
+and `head()`/`tail()` requires `Object` casts.
+
+## Decision
+
+Introduce a dedicated core-level type whose contract is *always a native UPLC
+pair*:
+
+```java
+package com.bloxbean.cardano.julc.core.types;
+
+/** Native-pair view of a map entry.
+ *  On-chain: .key()/.value() → FstPair/SndPair (+ wrapDecode per K/V type). */
+public interface JulcPair<K, V> {
+    K key();
+    V value();
+}
+```
+
+- **`JulcMap.entries()`** returns `JulcList<JulcPair<K,V>>` — on-chain
+  **identity** (the map already IS a pair list), typed
+  `ListType(PairType(K,V))`; off-chain `JulcAssocMap` exposes its ordered
+  internal pair list. Order and duplicate keys preserved.
+- **`JulcMap.head()`** is retyped from `Object` to `JulcPair<K,V>`, eliminating
+  the cast-based traversal (the PIR side already returns `PairType`; the Java
+  type was the gap).
+- On-chain accessor lowering: `p.key()` → `wrapDecode(FstPair(p), K)`,
+  `p.value()` → `wrapDecode(SndPair(p), V)` — one builtin per access, cheaper
+  than Tuple2's `UnConstrData` + traversal.
+- Off-chain: a `JulcPairImpl` record backing `JulcAssocMap` entries.
+
+## List-operation contract for `JulcList<JulcPair<K,V>>` (ListType(PairType))
+
+Native pairs are not Data, so `JulcList` operations must be explicitly
+classified. The contract is an **allowlist: operations not listed as supported
+are rejected at compile time** with a clear diagnostic (not left to fail at
+eval).
+
+| Category | Operations | Status |
+|---|---|---|
+| Structural | `head`, `tail`, `size`, `isEmpty`, `take`, `drop`, `get`, `nth`, `reverse`, `concat` (pair-list + pair-list), `prepend` (of a `JulcPair`, via `MkCons`) | **Supported** — operate on list spines / move pair values without assuming Data elements |
+| Conversion | `toArray` | To validate during implementation (`ListToArray` on a pair list; PV11) — supported only if the VM accepts it |
+| Data-assuming | `contains` (`EqualsData`), `containsInt`/`containsBytes`, `hasDuplicate*`, `toPlutusData`/`ListData` wrapping, element auto-wrap (`JulcList.of` of a pair) | **Rejected at compile time** — no valid lowering for native pairs |
+| Higher-order | `filter` (predicate over the pair) | Likely supported — elements pass through unchanged; validate |
+| Higher-order | `find` | **Rejected as-is** — current lowering wraps the result in a Data-encoded `Optional` (`ConstrData(0,[x])`), invalid for a native pair; needs a dedicated design if wanted |
+| Higher-order | `map` | Depends on the lambda result type: pair → Data-encodable result is fine (result list is a normal Data list); pair → pair needs `MkPairData` reconstruction; classify during implementation, reject unsupported shapes |
+| Higher-order | `any`, `all`, `foldl`, `zip` | Classify during implementation with the same rule: safe iff no Data-encoding of a native pair is implied |
+
+## Required negative tests (compile-time rejection, clear diagnostics)
+
+- `map.entries().toPlutusData()`
+- `map.entries().contains(pair)`
+- `JulcList.of(map.head())` (auto-wrap of a native pair)
+- `ListsLib.find(map.entries(), p -> ...)` (Data-encoded Optional of a pair)
+- `map.entries().map(p -> p)` (pair → pair without reconstruction)
+
+Positive tests: `entries()` identity round-trip (order + duplicate keys),
+`head()`/`key()`/`value()` typed access for each K/V primitive combination,
+structural ops on entries, `filter` + `size` composition.
+
+## Compatibility
+
+- **`JulcMap.head()` descriptor change**: `Object head()` →
+  `JulcPair<K,V> head()` changes the JVM method descriptor — source- and
+  binary-incompatible for external callers of `head()`. Acceptable pre-1.0;
+  release-noted. (Erasure keeps it source-compatible for callers that assigned
+  to `Object`, but binary compatibility is not preserved.)
+- `entries()` is additive; `JulcAssocMap` is the sole `JulcMap` implementor
+  in-repo.
+
+## Rejected alternatives (from ADR-027 review)
+
+- `entries(): JulcList<Tuple2<K,V>>` as identity — unimplementable
+  (representation mismatch above).
+- `entries()` converting each native pair to a Data-encoded `Tuple2` — works
+  and composes with all list ops, but costs O(n) `ConstrData` construction per
+  call and hides the native representation; may be revisited as a separate
+  `entriesAsTuples()` if demand appears.
+- Callback-style `iterate(...)` — lambdas do not compile on-chain.
+- Making `JulcMap` `Iterable` — deferred; interacts with the existing
+  for-each-on-MapType desugaring.
+
+## Out of scope
+
+`JulcMap.toPlutusData()` does NOT depend on this ADR: on-chain the
+`wrapEncode` fallback already maps `MapType` → `MapData`; off-chain
+`JulcAssocMap` walks its private ordered entries. That lands with ADR-027's
+implementation PR. This ADR is only about giving users a typed, lossless
+iteration surface.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -1109,7 +1109,7 @@ import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 
 // With stdlib support (recommended)
 var stdlib = StdlibRegistry.defaultRegistry();
-var compiler = new JulcCompiler(stdlib::lookup);
+var compiler = new JulcCompiler(stdlib);
 
 CompileResult result = compiler.compile(javaSource);
 if (result.hasErrors()) {
@@ -1165,7 +1165,7 @@ var program = ValidatorTest.compile(javaSource);
 
 // Compile with stdlib
 var stdlib = StdlibRegistry.defaultRegistry();
-var program = ValidatorTest.compile(javaSource, stdlib::lookup);
+var program = ValidatorTest.compile(javaSource, stdlib);
 
 // Compile a validator class with auto-discovered dependencies
 var result = ValidatorTest.compileValidator(MyValidator.class);

--- a/docs/src/content/docs/stdlib/stdlib-guide.md
+++ b/docs/src/content/docs/stdlib/stdlib-guide.md
@@ -105,6 +105,8 @@ The JuLC standard library provides 13 on-chain libraries in the `com.bloxbean.ca
 | `subtract(a, b)` | Subtract value b from value a |
 | `countTokensWithQty(mint, policy, qty)` | Count tokens with exact quantity under policy |
 | `findTokenName(mint, policy, qty)` | Find token name with exact quantity under policy |
+| `refBytes(ref)` | Seed bytes for a TxOutRef: `txId ++ 2-byte index` |
+| `uniqueTokenName(ref)` | Collision-resistant token name: `blake2b_256(refBytes(ref))` |
 
 ### MapLib
 
@@ -374,6 +376,23 @@ class ListExample {
 }
 ```
 
+### Building Lists
+
+`JulcList.of(...)` builds a fixed-size list from any number of elements. Elements are auto-wrapped to Data (`BigInteger` → IntData, `byte[]` → BytesData, `boolean` → Constr, `String` → UTF-8 BytesData, `PlutusData` → as-is). Call `.toPlutusData()` when a `PlutusData` list is needed:
+
+```java
+// Before: manual mkCons chain
+PlutusData inputs = Builtins.listData(
+        Builtins.mkCons(Builtins.iData(pkh),
+                Builtins.mkCons(Builtins.iData(recipient), Builtins.mkNilData())));
+
+// After: JulcList.of with auto-wrapping
+PlutusData inputs = JulcList.of(pkh, recipient).toPlutusData();
+
+// Works for any arity — e.g. ZK public inputs
+PlutusData publicInputs = JulcList.of(pub0, pub1, pub2, pub3, pub4).toPlutusData();
+```
+
 ### Search Operations
 
 ```java
@@ -585,6 +604,34 @@ class TokenLeakCheck {
 ```
 
 > **Tip:** Use `flattenTyped()` instead of `flatten()` whenever you need to inspect individual assets. The raw `flatten()` returns `PlutusData.ListData` requiring manual `Builtins.constrFields()` + `headList`/`tailList` destructuring.
+
+### Unique Token Names
+
+One-shot minting policies and NFT state threads commonly derive a token name from
+a `TxOutRef`. Hashing the reference produces a collision-resistant, deterministic
+32-byte name (the maximum asset-name length). Uniqueness in practice also requires
+the minting policy to enforce that the seed reference is consumed:
+
+```java
+@MintingValidator
+class OneShotMint {
+    @Entrypoint
+    static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+        TxOutRef seed = /* the UTxO this policy requires to be spent */;
+        byte[] expectedName = ValuesLib.uniqueTokenName(seed);
+        // ... check the minted token name equals expectedName
+        return true;
+    }
+}
+```
+
+The canonical derivation is `blake2b_256(txId ++ integerToByteString(true, 2, index))`. For a different hash algorithm, apply it to the seed bytes yourself:
+
+```java
+byte[] name = CryptoLib.sha2_256(ValuesLib.refBytes(seed));
+```
+
+The index is encoded as fixed 2-byte big-endian so index 0 still contributes bytes (a minimal-width encoding would drop it) and the result is identical on-chain and off-chain.
 
 ---
 
@@ -1017,6 +1064,8 @@ class ByteStringExample {
         // Construction
         byte[] withPrefix = ByteStringLib.cons(0xFF, data);
         byte[] combined = ByteStringLib.append(firstTwo, lastThree);
+        // Concatenate 3+ parts without nesting append calls
+        byte[] joined = Builtins.concat(firstTwo, lastThree, withPrefix);
         byte[] emptyBs = ByteStringLib.empty();
         byte[] zeroes = ByteStringLib.zeros(32);
 

--- a/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
+++ b/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
@@ -187,7 +187,7 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
             if (sourceMapEnabled) {
                 options.setSourceMapEnabled(true);
             }
-            var compiler = new JulcCompiler(stdlib::lookup, options);
+            var compiler = new JulcCompiler(stdlib, options);
             var result = compiler.compile(source, librarySources);
 
             if (result.hasErrors()) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
@@ -963,6 +963,23 @@ public class JulcCompiler {
             }
 
             @Override
+            public java.util.Optional<PirTerm> lookup(
+                    String className,
+                    String methodName,
+                    java.util.List<PirTerm> args,
+                    java.util.List<PirType> argTypes) {
+                if (methodName.equals("of") && newTypeNames.contains(className)) {
+                    if (args.size() != 1) {
+                        throw new CompilerException(className + ".of() requires exactly 1 argument, got " + args.size());
+                    }
+                    return java.util.Optional.of(args.get(0));
+                }
+                return base != null
+                        ? base.lookup(className, methodName, args, argTypes)
+                        : java.util.Optional.empty();
+            }
+
+            @Override
             public boolean hasMethodsForClass(String className) {
                 return base != null && base.hasMethodsForClass(className);
             }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/StdlibLookup.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/StdlibLookup.java
@@ -4,12 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Functional interface for resolving stdlib method calls to PIR terms.
+ * Interface for resolving stdlib method calls to PIR terms.
  * <p>
  * Defined in the compiler module to avoid circular dependency with plutus-stdlib.
  * Implementations are provided by the stdlib module via StdlibRegistry.
  */
-@FunctionalInterface
 public interface StdlibLookup {
     /**
      * Look up a stdlib method and produce a PIR term for the given arguments.
@@ -23,8 +22,8 @@ public interface StdlibLookup {
 
     /**
      * Look up a stdlib method with arg type information for proper coercion.
-     * Default delegates to untyped lookup. Override to insert decode/encode coercions
-     * when caller arg types don't match callee parameter types.
+     * Implementations must handle this form explicitly so typed decode/encode
+     * coercions cannot be silently discarded by a lambda or method reference.
      *
      * @param className  the simple class name
      * @param methodName the method name
@@ -32,10 +31,8 @@ public interface StdlibLookup {
      * @param argTypes   the PIR types of each argument at the call site
      * @return the PIR term if found, empty otherwise
      */
-    default Optional<PirTerm> lookup(String className, String methodName,
-                                      List<PirTerm> args, List<PirType> argTypes) {
-        return lookup(className, methodName, args);
-    }
+    Optional<PirTerm> lookup(String className, String methodName,
+                             List<PirTerm> args, List<PirType> argTypes);
 
     /**
      * Check if this lookup has any methods registered for the given class name.

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ByteStringLibTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ByteStringLibTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ByteStringLibTest {
 
     private static final StdlibRegistry STDLIB = StdlibRegistry.defaultRegistry();
-    private final JulcCompiler compiler = new JulcCompiler(STDLIB::lookup);
+    private final JulcCompiler compiler = new JulcCompiler(STDLIB);
     private final JulcVm vm = JulcVm.create();
 
     private Program compile(String source) {

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/GoldenUplcTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/GoldenUplcTest.java
@@ -75,7 +75,7 @@ class GoldenUplcTest {
     @Test
     void golden_forEachSingleAcc() throws IOException {
         verifyGolden("foreach-single-acc",
-                new JulcCompiler(STDLIB::lookup).compile(FOREACH_SINGLE_ACC).program());
+                new JulcCompiler(STDLIB).compile(FOREACH_SINGLE_ACC).program());
     }
 
     // --- 3. While loop with break ---
@@ -155,7 +155,7 @@ class GoldenUplcTest {
 
     @Test
     void golden_hofMap() throws IOException {
-        verifyGolden("hof-map", new JulcCompiler(STDLIB::lookup).compile(HOF_MAP).program());
+        verifyGolden("hof-map", new JulcCompiler(STDLIB).compile(HOF_MAP).program());
     }
 
     // --- 6. HOF lambda (list.filter) ---
@@ -178,7 +178,7 @@ class GoldenUplcTest {
 
     @Test
     void golden_hofFilter() throws IOException {
-        verifyGolden("hof-filter", new JulcCompiler(STDLIB::lookup).compile(HOF_FILTER).program());
+        verifyGolden("hof-filter", new JulcCompiler(STDLIB).compile(HOF_FILTER).program());
     }
 
     // --- 7. Multi-accumulator while ---

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LedgerTypeAccessTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LedgerTypeAccessTest.java
@@ -80,49 +80,123 @@ class LedgerTypeAccessTest {
      * Stdlib lookup that provides ContextsLib functions for backward-compat tests.
      */
     static StdlibLookup testStdlibLookup() {
-        return (className, methodName, args) -> {
-            if ("ContextsLib".equals(className) && "getTxInfo".equals(methodName) && args.size() == 1) {
-                var fields = new PirTerm.App(
-                        new PirTerm.Builtin(DefaultFun.SndPair),
-                        new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnConstrData), args.get(0)));
-                return Optional.of(new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), fields));
+        return new StdlibLookup() {
+            @Override
+            public Optional<PirTerm> lookup(
+                    String className, String methodName, List<PirTerm> args) {
+                return resolve(className, methodName, args);
             }
-            if ("ContextsLib".equals(className) && "signedBy".equals(methodName) && args.size() == 2) {
-                // Inline signedBy: extract signatories (field 8 of TxInfo), recursive search
-                var txInfoVar = new PirTerm.Var("txInfo_sb", new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType());
-                var pkhVar = new PirTerm.Var("pkh_sb", new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType());
-                var fieldsExpr = new PirTerm.App(new PirTerm.Builtin(DefaultFun.SndPair),
-                        new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnConstrData), txInfoVar));
-                // Index 8 = signatories
-                PirTerm sigsData = fieldsExpr;
-                for (int i = 0; i < 8; i++) sigsData = new PirTerm.App(new PirTerm.Builtin(DefaultFun.TailList), sigsData);
-                sigsData = new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), sigsData);
-                var sigsExpr = new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnListData), sigsData);
-                var pkhBs = new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnBData), pkhVar);
-                // Recursive search
-                var sigListVar = new PirTerm.Var("sigList_sb", new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType()));
-                var targetVar = new PirTerm.Var("target_sb", new com.bloxbean.cardano.julc.compiler.pir.PirType.ByteStringType());
-                var goVar = new PirTerm.Var("go_sb", new com.bloxbean.cardano.julc.compiler.pir.PirType.FunType(
-                        new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType()),
-                        new com.bloxbean.cardano.julc.compiler.pir.PirType.BoolType()));
-                var nullCheck = new PirTerm.App(new PirTerm.Builtin(DefaultFun.NullList), sigListVar);
-                var headElem = new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), sigListVar);
-                var tailExpr2 = new PirTerm.App(new PirTerm.Builtin(DefaultFun.TailList), sigListVar);
-                var headBs = new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnBData), headElem);
-                var equalCheck = new PirTerm.App(new PirTerm.App(new PirTerm.Builtin(DefaultFun.EqualsByteString), targetVar), headBs);
-                var recurse = new PirTerm.App(goVar, tailExpr2);
-                var ifFound = new PirTerm.IfThenElse(equalCheck, new PirTerm.Const(Constant.bool(true)), recurse);
-                var body = new PirTerm.IfThenElse(nullCheck, new PirTerm.Const(Constant.bool(false)), ifFound);
-                var goBody = new PirTerm.Lam("sigList_sb", new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType()), body);
-                var sigsVar = new PirTerm.Var("sigs_sb", new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType()));
-                var search = new PirTerm.LetRec(java.util.List.of(new PirTerm.Binding("go_sb", goBody)),
-                        new PirTerm.App(goVar, sigsVar));
-                return Optional.of(new PirTerm.Let("txInfo_sb", args.get(0),
-                        new PirTerm.Let("pkh_sb", args.get(1),
-                                new PirTerm.Let("sigs_sb", sigsExpr,
-                                        new PirTerm.Let("target_sb", pkhBs, search)))));
+
+            @Override
+            public Optional<PirTerm> lookup(
+                    String className,
+                    String methodName,
+                    List<PirTerm> args,
+                    List<PirType> argTypes) {
+                return resolve(className, methodName, args);
             }
-            return Optional.empty();
+
+            private Optional<PirTerm> resolve(
+                    String className, String methodName, List<PirTerm> args) {
+                if ("ContextsLib".equals(className)
+                        && "getTxInfo".equals(methodName)
+                        && args.size() == 1) {
+                    var fields = new PirTerm.App(
+                            new PirTerm.Builtin(DefaultFun.SndPair),
+                            new PirTerm.App(
+                                    new PirTerm.Builtin(DefaultFun.UnConstrData), args.get(0)));
+                    return Optional.of(
+                            new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), fields));
+                }
+                if ("ContextsLib".equals(className)
+                        && "signedBy".equals(methodName)
+                        && args.size() == 2) {
+                    // Inline signedBy: extract signatories (field 8 of TxInfo), recursive search
+                    var txInfoVar = new PirTerm.Var(
+                            "txInfo_sb",
+                            new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType());
+                    var pkhVar = new PirTerm.Var(
+                            "pkh_sb",
+                            new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType());
+                    var fieldsExpr = new PirTerm.App(
+                            new PirTerm.Builtin(DefaultFun.SndPair),
+                            new PirTerm.App(
+                                    new PirTerm.Builtin(DefaultFun.UnConstrData), txInfoVar));
+                    // Index 8 = signatories
+                    PirTerm sigsData = fieldsExpr;
+                    for (int i = 0; i < 8; i++) {
+                        sigsData =
+                                new PirTerm.App(
+                                        new PirTerm.Builtin(DefaultFun.TailList), sigsData);
+                    }
+                    sigsData =
+                            new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), sigsData);
+                    var sigsExpr =
+                            new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnListData), sigsData);
+                    var pkhBs =
+                            new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnBData), pkhVar);
+                    // Recursive search
+                    var sigListVar = new PirTerm.Var(
+                            "sigList_sb",
+                            new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(
+                                    new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType()));
+                    var targetVar = new PirTerm.Var(
+                            "target_sb",
+                            new com.bloxbean.cardano.julc.compiler.pir.PirType.ByteStringType());
+                    var goVar = new PirTerm.Var(
+                            "go_sb",
+                            new com.bloxbean.cardano.julc.compiler.pir.PirType.FunType(
+                                    new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(
+                                            new com.bloxbean.cardano.julc.compiler.pir.PirType
+                                                    .DataType()),
+                                    new com.bloxbean.cardano.julc.compiler.pir.PirType.BoolType()));
+                    var nullCheck =
+                            new PirTerm.App(
+                                    new PirTerm.Builtin(DefaultFun.NullList), sigListVar);
+                    var headElem =
+                            new PirTerm.App(
+                                    new PirTerm.Builtin(DefaultFun.HeadList), sigListVar);
+                    var tailExpr2 =
+                            new PirTerm.App(
+                                    new PirTerm.Builtin(DefaultFun.TailList), sigListVar);
+                    var headBs =
+                            new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnBData), headElem);
+                    var equalCheck = new PirTerm.App(
+                            new PirTerm.App(
+                                    new PirTerm.Builtin(DefaultFun.EqualsByteString), targetVar),
+                            headBs);
+                    var recurse = new PirTerm.App(goVar, tailExpr2);
+                    var ifFound = new PirTerm.IfThenElse(
+                            equalCheck, new PirTerm.Const(Constant.bool(true)), recurse);
+                    var body = new PirTerm.IfThenElse(
+                            nullCheck, new PirTerm.Const(Constant.bool(false)), ifFound);
+                    var goBody = new PirTerm.Lam(
+                            "sigList_sb",
+                            new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(
+                                    new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType()),
+                            body);
+                    var sigsVar = new PirTerm.Var(
+                            "sigs_sb",
+                            new com.bloxbean.cardano.julc.compiler.pir.PirType.ListType(
+                                    new com.bloxbean.cardano.julc.compiler.pir.PirType.DataType()));
+                    var search = new PirTerm.LetRec(
+                            java.util.List.of(new PirTerm.Binding("go_sb", goBody)),
+                            new PirTerm.App(goVar, sigsVar));
+                    return Optional.of(
+                            new PirTerm.Let(
+                                    "txInfo_sb",
+                                    args.get(0),
+                                    new PirTerm.Let(
+                                            "pkh_sb",
+                                            args.get(1),
+                                            new PirTerm.Let(
+                                                    "sigs_sb",
+                                                    sigsExpr,
+                                                    new PirTerm.Let(
+                                                            "target_sb", pkhBs, search)))));
+                }
+                return Optional.empty();
+            }
         };
     }
 
@@ -604,7 +678,7 @@ class LedgerTypeAccessTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(validator, List.of(libSource));
             assertFalse(result.hasErrors(), "Compilation should succeed: " + result);
 
@@ -656,7 +730,7 @@ class LedgerTypeAccessTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(validator, List.of(libSource));
             assertFalse(result.hasErrors(), "Compilation should succeed: " + result);
 
@@ -709,7 +783,7 @@ class LedgerTypeAccessTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(validator, List.of(libSource));
             assertFalse(result.hasErrors(), "Compilation should succeed: " + result);
 

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/NewTypeTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/NewTypeTest.java
@@ -25,7 +25,7 @@ class NewTypeTest {
     }
 
     static Program compileValidator(String source) {
-        var compiler = new JulcCompiler(STDLIB::lookup);
+        var compiler = new JulcCompiler(STDLIB);
         var result = compiler.compile(source);
         assertFalse(result.hasErrors(), "Compilation failed: " + result);
         assertNotNull(result.program(), "Program should not be null");
@@ -253,6 +253,64 @@ class NewTypeTest {
         }
 
         @Test
+        void newTypeLookupAdapterPreservesTypedStdlibCoercions() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+                    import com.bloxbean.cardano.julc.stdlib.annotation.NewType;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                    @SpendingValidator
+                    class TestValidator {
+                        @NewType
+                        record Marker(byte[] value) {}
+
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            PlutusData actual = JulcList.of(
+                                    BigInteger.valueOf(42)).toPlutusData();
+                            return Builtins.equalsData(actual, redeemer);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.list(PlutusData.integer(42));
+            var ctx = PlutusData.constr(
+                    0, PlutusData.integer(0), redeemer, PlutusData.integer(0));
+
+            var result = vm.evaluateWithArgs(program, List.of(ctx));
+
+            assertTrue(result.isSuccess(),
+                    "@NewType adapter must preserve JulcList.of typed encoding. Got: " + result);
+        }
+
+        @Test
+        void rejectsNewTypeOfWithWrongArity() {
+            var source = """
+                    import java.math.BigInteger;
+                    import com.bloxbean.cardano.julc.stdlib.annotation.NewType;
+
+                    @SpendingValidator
+                    class TestValidator {
+                        @NewType
+                        record Nonce(BigInteger raw) {}
+
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, PlutusData ctx) {
+                            var n = Nonce.of(BigInteger.ONE, BigInteger.TWO);
+                            return true;
+                        }
+                    }
+                    """;
+            var ex = assertThrows(CompilerException.class, () -> {
+                var compiler = new JulcCompiler(STDLIB);
+                compiler.compile(source);
+            }, "NewType.of() with two arguments should be rejected");
+            assertTrue(ex.getMessage().contains("requires exactly 1 argument"),
+                    "Error should name the arity rule. Got: " + ex.getMessage());
+        }
+
+        @Test
         void rejectsMultiFieldNewType() {
             var source = """
                     import com.bloxbean.cardano.julc.stdlib.annotation.NewType;
@@ -269,7 +327,7 @@ class NewTypeTest {
                     }
                     """;
             assertThrows(CompilerException.class, () -> {
-                var compiler = new JulcCompiler(STDLIB::lookup);
+                var compiler = new JulcCompiler(STDLIB);
                 compiler.compile(source);
             }, "@NewType with multiple fields should be rejected");
         }
@@ -292,7 +350,7 @@ class NewTypeTest {
                     }
                     """;
             assertThrows(CompilerException.class, () -> {
-                var compiler = new JulcCompiler(STDLIB::lookup);
+                var compiler = new JulcCompiler(STDLIB);
                 compiler.compile(source);
             }, "@NewType with non-primitive field type should be rejected");
         }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/PlutusDataConversionTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/PlutusDataConversionTest.java
@@ -28,7 +28,7 @@ class PlutusDataConversionTest {
     }
 
     static Program compileValidator(String source) {
-        var compiler = new JulcCompiler(STDLIB::lookup);
+        var compiler = new JulcCompiler(STDLIB);
         var result = compiler.compile(source);
         assertFalse(result.hasErrors(), "Compilation failed: " + result);
         assertNotNull(result.program(), "Program should not be null");

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/PostLoopVariableTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/PostLoopVariableTest.java
@@ -35,7 +35,7 @@ class PostLoopVariableTest {
     }
 
     static Program compileWithLedger(String source) {
-        var compiler = new JulcCompiler(stdlib::lookup);
+        var compiler = new JulcCompiler(stdlib);
         var result = compiler.compile(source);
         assertFalse(result.hasErrors(), "Compilation failed: " + result.diagnostics());
         assertNotNull(result.program(), "Program should not be null");

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ReturnInLoopTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/ReturnInLoopTest.java
@@ -27,7 +27,7 @@ class ReturnInLoopTest {
     }
 
     static Program compileValidator(String source) {
-        var compiler = new JulcCompiler(stdlib::lookup);
+        var compiler = new JulcCompiler(stdlib);
         var result = compiler.compile(source);
         assertFalse(result.hasErrors(), "Compilation failed: " + result.diagnostics());
         assertNotNull(result.program(), "Program should not be null");
@@ -63,7 +63,7 @@ class ReturnInLoopTest {
                     }
                 }
                 """;
-            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib::lookup).compile(source));
+            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib).compile(source));
             assertTrue(ex.getMessage().contains("return"),
                     "Should mention 'return'. Got: " + ex.getMessage());
             assertTrue(ex.getMessage().contains("while"),
@@ -92,7 +92,7 @@ class ReturnInLoopTest {
                     }
                 }
                 """;
-            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib::lookup).compile(source));
+            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib).compile(source));
             assertTrue(ex.getMessage().contains("return"),
                     "Should mention 'return'. Got: " + ex.getMessage());
         }
@@ -120,7 +120,7 @@ class ReturnInLoopTest {
                     }
                 }
                 """;
-            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib::lookup).compile(source));
+            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib).compile(source));
             assertTrue(ex.getMessage().contains("return"),
                     "Should mention 'return'. Got: " + ex.getMessage());
         }
@@ -151,7 +151,7 @@ class ReturnInLoopTest {
                 """;
             // The inner while has return, so it should be caught
             // containsReturn stops at nested loops, so the INNER generateWhileStmt catches it
-            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib::lookup).compile(source));
+            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib).compile(source));
             assertTrue(ex.getMessage().contains("return"),
                     "Should catch return in inner while. Got: " + ex.getMessage());
         }
@@ -231,7 +231,7 @@ class ReturnInLoopTest {
                     }
                 }
                 """;
-            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib::lookup).compile(source));
+            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib).compile(source));
             assertTrue(ex.getMessage().contains("return"),
                     "Should mention 'return'. Got: " + ex.getMessage());
             assertTrue(ex.getMessage().contains("for-each"),
@@ -260,7 +260,7 @@ class ReturnInLoopTest {
                     }
                 }
                 """;
-            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib::lookup).compile(source));
+            var ex = assertThrows(CompilerException.class, () -> new JulcCompiler(stdlib).compile(source));
             assertTrue(ex.getMessage().contains("return"),
                     "Should mention 'return'. Got: " + ex.getMessage());
         }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibCompileEvalTest.java
@@ -208,7 +208,7 @@ class StdlibCompileEvalTest {
     // ---- Compilation helpers ----
 
     static Program compileValidator(String source) {
-        var compiler = new JulcCompiler(STDLIB::lookup);
+        var compiler = new JulcCompiler(STDLIB);
         var result = compiler.compile(source);
         assertFalse(result.hasErrors(), "Compilation failed: " + result);
         assertNotNull(result.program(), "Program should not be null");
@@ -216,7 +216,7 @@ class StdlibCompileEvalTest {
     }
 
     static Program compileValidatorWithLibs(String validator, String... libs) {
-        var compiler = new JulcCompiler(STDLIB::lookup);
+        var compiler = new JulcCompiler(STDLIB);
         var result = compiler.compile(validator, List.of(libs));
         assertFalse(result.hasErrors(), "Compilation failed: " + result);
         assertNotNull(result.program(), "Program should not be null");
@@ -2069,7 +2069,7 @@ class StdlibCompileEvalTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(validator, List.of(userLib));
             assertFalse(result.hasErrors(), "Compilation should succeed: " + result);
             var evalResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(PlutusData.constr(0))));
@@ -2103,7 +2103,7 @@ class StdlibCompileEvalTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(validator, List.of(userLib));
             assertFalse(result.hasErrors(), "Compilation should succeed: " + result);
             var evalResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(PlutusData.integer(0))));
@@ -2148,7 +2148,7 @@ class StdlibCompileEvalTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(validator, List.of(helperLib, middleLib));
             assertFalse(result.hasErrors(), "Compilation should succeed: " + result);
             var evalResult = vm.evaluateWithArgs(result.program(), List.of(mockCtx(PlutusData.integer(0))));
@@ -3029,6 +3029,98 @@ class StdlibCompileEvalTest {
             var program = compileValidator(source);
             var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
             assertTrue(result.isSuccess(), "JulcList.empty().prepend() should create single-element list. Got: " + result);
+        }
+
+        @Test
+        void julcListOfAutoWrapsBigIntegers() {
+            var source = """
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                            JulcList<BigInteger> nums = JulcList.of(BigInteger.valueOf(10), BigInteger.valueOf(20));
+                            return nums.size() == 2 && nums.head() == 10 && nums.get(1) == 20;
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "JulcList.of(BigInteger...) should auto-wrap elements with IData. Got: " + result);
+        }
+
+        @Test
+        void julcListOfAutoWrapsByteStrings() {
+            var source = """
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                            byte[] a = new byte[]{1, 2, 3};
+                            byte[] b = new byte[]{4, 5};
+                            JulcList<byte[]> items = JulcList.of(a, b);
+                            return items.size() == 2 && Builtins.equalsByteString(items.head(), a);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(PlutusData.integer(0))));
+            assertTrue(result.isSuccess(), "JulcList.of(byte[]...) should auto-wrap elements with BData. Got: " + result);
+        }
+
+        @Test
+        void listDataOfJulcListReplacesMkConsChain() {
+            // The old verbose pattern:
+            //   Builtins.listData(Builtins.mkCons(Builtins.iData(pkh),
+            //       Builtins.mkCons(Builtins.iData(recipient), Builtins.mkNilData())))
+            // is now: Builtins.listData(JulcList.of(pkh, recipient))
+            var source = """
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                            BigInteger pkh = BigInteger.valueOf(7);
+                            BigInteger recipient = BigInteger.valueOf(9);
+                            PlutusData built = Builtins.listData(JulcList.of(pkh, recipient));
+                            return Builtins.equalsData(built, redeemer);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.list(PlutusData.integer(7), PlutusData.integer(9));
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(redeemer)));
+            assertTrue(result.isSuccess(),
+                    "listData(JulcList.of(a, b)) should equal a hand-built ListData. Got: " + result);
+        }
+
+        @Test
+        void julcListOfFiveElementsAsPublicInputs() {
+            // ZK public-inputs style: a 5-element integer list built without mkCons chains
+            var source = """
+                    import com.bloxbean.cardano.julc.core.types.JulcList;
+                    import com.bloxbean.cardano.julc.stdlib.Builtins;
+                    @SpendingValidator
+                    class TestValidator {
+                        @Entrypoint
+                        static boolean validate(PlutusData redeemer, ScriptContext ctx) {
+                            PlutusData publicInputs = Builtins.listData(JulcList.of(
+                                    BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3),
+                                    BigInteger.valueOf(4), BigInteger.valueOf(5)));
+                            return Builtins.equalsData(publicInputs, redeemer);
+                        }
+                    }
+                    """;
+            var program = compileValidator(source);
+            var redeemer = PlutusData.list(
+                    PlutusData.integer(1), PlutusData.integer(2), PlutusData.integer(3),
+                    PlutusData.integer(4), PlutusData.integer(5));
+            var result = vm.evaluateWithArgs(program, List.of(mockCtx(redeemer)));
+            assertTrue(result.isSuccess(),
+                    "5-element JulcList.of should match a hand-built 5-element ListData. Got: " + result);
         }
     }
 
@@ -4293,7 +4385,7 @@ class StdlibCompileEvalTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var compiled = compiler.compile(source);
             assertFalse(compiled.hasErrors(), "Compilation failed: " + compiled);
             assertTrue(compiled.isParameterized(), "Should be parameterized");
@@ -4334,7 +4426,7 @@ class StdlibCompileEvalTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var compiled = compiler.compile(source);
             assertFalse(compiled.hasErrors(), "Compilation failed: " + compiled);
 

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibIntegrationTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/StdlibIntegrationTest.java
@@ -35,23 +35,41 @@ class StdlibIntegrationTest {
      * Built without depending on plutus-stdlib — tests compiler plumbing only.
      */
     static StdlibLookup testStdlibLookup() {
-        return (className, methodName, args) -> {
-            if ("ContextsLib".equals(className) && "getTxInfo".equals(methodName) && args.size() == 1) {
-                // getTxInfo(ctx) = HeadList(SndPair(UnConstrData(ctx)))
-                var fields = new PirTerm.App(
-                        new PirTerm.Builtin(DefaultFun.SndPair),
-                        new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnConstrData), args.get(0)));
-                return Optional.of(new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), fields));
+        return new StdlibLookup() {
+            @Override
+            public Optional<PirTerm> lookup(
+                    String className, String methodName, List<PirTerm> args) {
+                return resolve(className, methodName, args);
             }
-            if ("ContextsLib".equals(className) && "getRedeemer".equals(methodName) && args.size() == 1) {
-                // getRedeemer(ctx) = HeadList(TailList(SndPair(UnConstrData(ctx))))
-                var fields = new PirTerm.App(
-                        new PirTerm.Builtin(DefaultFun.SndPair),
-                        new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnConstrData), args.get(0)));
-                var tail = new PirTerm.App(new PirTerm.Builtin(DefaultFun.TailList), fields);
-                return Optional.of(new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), tail));
+
+            @Override
+            public Optional<PirTerm> lookup(
+                    String className,
+                    String methodName,
+                    List<PirTerm> args,
+                    List<PirType> argTypes) {
+                return resolve(className, methodName, args);
             }
-            return Optional.empty();
+
+            private Optional<PirTerm> resolve(
+                    String className, String methodName, List<PirTerm> args) {
+                if ("ContextsLib".equals(className) && "getTxInfo".equals(methodName) && args.size() == 1) {
+                    // getTxInfo(ctx) = HeadList(SndPair(UnConstrData(ctx)))
+                    var fields = new PirTerm.App(
+                            new PirTerm.Builtin(DefaultFun.SndPair),
+                            new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnConstrData), args.get(0)));
+                    return Optional.of(new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), fields));
+                }
+                if ("ContextsLib".equals(className) && "getRedeemer".equals(methodName) && args.size() == 1) {
+                    // getRedeemer(ctx) = HeadList(TailList(SndPair(UnConstrData(ctx))))
+                    var fields = new PirTerm.App(
+                            new PirTerm.Builtin(DefaultFun.SndPair),
+                            new PirTerm.App(new PirTerm.Builtin(DefaultFun.UnConstrData), args.get(0)));
+                    var tail = new PirTerm.App(new PirTerm.Builtin(DefaultFun.TailList), fields);
+                    return Optional.of(new PirTerm.App(new PirTerm.Builtin(DefaultFun.HeadList), tail));
+                }
+                return Optional.empty();
+            }
         };
     }
 
@@ -76,7 +94,7 @@ class StdlibIntegrationTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(source);
             assertNotNull(result.program());
             assertFalse(result.hasErrors());
@@ -96,7 +114,7 @@ class StdlibIntegrationTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var result = compiler.compile(source);
             assertNotNull(result.program());
         }
@@ -116,7 +134,7 @@ class StdlibIntegrationTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var program = compiler.compile(source).program();
 
             // Build a valid ScriptContext: Constr(0, [txInfo, redeemer, scriptInfo])
@@ -422,7 +440,7 @@ class StdlibIntegrationTest {
     class JavaApiDelegation {
 
         private static final StdlibRegistry STDLIB = StdlibRegistry.defaultRegistry();
-        private final JulcCompiler stdlibCompiler = new JulcCompiler(STDLIB::lookup);
+        private final JulcCompiler stdlibCompiler = new JulcCompiler(STDLIB);
 
         private PlutusData mockCtx(PlutusData redeemer) {
             return PlutusData.constr(0,

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/TypeMethodsTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/TypeMethodsTest.java
@@ -1494,7 +1494,7 @@ class TypeMethodsTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var program = compiler.compile(source).program();
 
             // cred = Constr(0, [BData(bytes)])
@@ -1527,7 +1527,7 @@ class TypeMethodsTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var program = compiler.compile(source).program();
 
             // wrapped = Constr(0, [IData(42)])
@@ -1559,7 +1559,7 @@ class TypeMethodsTest {
                         }
                     }
                     """;
-            var compiler = new JulcCompiler(STDLIB::lookup);
+            var compiler = new JulcCompiler(STDLIB);
             var program = compiler.compile(source).program();
 
             var cred = PlutusData.constr(0, PlutusData.bytes(new byte[]{1, 2, 3}));

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/PlutusDataConversions.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/PlutusDataConversions.java
@@ -1,0 +1,78 @@
+package com.bloxbean.cardano.julc.core;
+
+import com.bloxbean.cardano.julc.core.types.JulcList;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Canonical off-chain conversions used by JuLC collection APIs and stdlib
+ * builtin shims.
+ */
+public final class PlutusDataConversions {
+
+    private PlutusDataConversions() {
+    }
+
+    /**
+     * Convert a supported JuLC value to Plutus Data.
+     *
+     * @throws IllegalArgumentException if the value is null, unsupported, or a
+     *                                  custom converter returns null
+     */
+    public static PlutusData toPlutusData(Object value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Cannot convert null to PlutusData");
+        }
+        if (value instanceof PlutusData data) {
+            return data;
+        }
+        // JulcList implements ToPlutusData; handle it first to avoid calling its
+        // default method recursively.
+        if (value instanceof JulcList<?> list) {
+            return listToPlutusData(list);
+        }
+        if (value instanceof ToPlutusData convertible) {
+            var converted = convertible.toPlutusData();
+            if (converted == null) {
+                throw new IllegalArgumentException(
+                        "toPlutusData() returned null for " + value.getClass().getName());
+            }
+            return converted;
+        }
+        if (value instanceof BigInteger integer) {
+            return new PlutusData.IntData(integer);
+        }
+        if (value instanceof Long integer) {
+            return new PlutusData.IntData(BigInteger.valueOf(integer));
+        }
+        if (value instanceof Integer integer) {
+            return new PlutusData.IntData(BigInteger.valueOf(integer));
+        }
+        if (value instanceof byte[] bytes) {
+            return new PlutusData.BytesData(bytes);
+        }
+        if (value instanceof Boolean bool) {
+            return new PlutusData.ConstrData(bool ? 1 : 0, List.of());
+        }
+        if (value instanceof String string) {
+            return new PlutusData.BytesData(string.getBytes(StandardCharsets.UTF_8));
+        }
+        throw new IllegalArgumentException(
+                "Unsupported PlutusData conversion type: " + value.getClass().getName());
+    }
+
+    /** Convert a JuLC list, recursively converting every element. */
+    public static PlutusData.ListData listToPlutusData(JulcList<?> list) {
+        if (list == null) {
+            throw new IllegalArgumentException("Cannot convert null JulcList to PlutusData");
+        }
+        var items = new ArrayList<PlutusData>();
+        for (var item : list) {
+            items.add(toPlutusData(item));
+        }
+        return new PlutusData.ListData(items);
+    }
+}

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/ToPlutusData.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/ToPlutusData.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.julc.core;
+
+/**
+ * A value that has a canonical off-chain representation as {@link PlutusData}.
+ * <p>
+ * This interface lives in {@code julc-core} so core collection types can expose
+ * conversion without depending on the ledger API.
+ */
+public interface ToPlutusData {
+
+    /** Convert this value to its canonical Plutus Data representation. */
+    PlutusData toPlutusData();
+}

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcAssocMap.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcAssocMap.java
@@ -1,5 +1,8 @@
 package com.bloxbean.cardano.julc.core.types;
 
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.PlutusDataConversions;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -102,6 +105,17 @@ public final class JulcAssocMap<K, V> implements JulcMap<K, V> {
             result.add(entry.value());
         }
         return new JulcArrayList<>(result);
+    }
+
+    @Override
+    public PlutusData.MapData toPlutusData() {
+        var result = new ArrayList<PlutusData.Pair>(entries.size());
+        for (var entry : entries) {
+            result.add(new PlutusData.Pair(
+                    PlutusDataConversions.toPlutusData(entry.key()),
+                    PlutusDataConversions.toPlutusData(entry.value())));
+        }
+        return new PlutusData.MapData(result);
     }
 
     @Override

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcList.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcList.java
@@ -1,5 +1,9 @@
 package com.bloxbean.cardano.julc.core.types;
 
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.PlutusDataConversions;
+import com.bloxbean.cardano.julc.core.ToPlutusData;
+
 /**
  * Immutable list interface for on-chain and off-chain use.
  * <p>
@@ -14,7 +18,7 @@ package com.bloxbean.cardano.julc.core.types;
  *
  * @param <T> the element type
  */
-public interface JulcList<T> extends Iterable<T> {
+public interface JulcList<T> extends Iterable<T>, ToPlutusData {
 
     // --- Element access ---
 
@@ -76,19 +80,39 @@ public interface JulcList<T> extends Iterable<T> {
 
     // --- Conversion ---
 
+    /**
+     * Convert this list to Plutus Data, recursively applying JuLC's canonical
+     * element-wrapping rules.
+     */
+    @Override
+    default PlutusData.ListData toPlutusData() {
+        return PlutusDataConversions.listToPlutusData(this);
+    }
+
     /** Convert this list to an immutable array for O(1) access. PV11 only on-chain. */
     default JulcArray<T> toArray() {
         return JulcArray.fromList(this);
     }
 
-    // --- Factory methods (off-chain only — on-chain use compiler intrinsics) ---
+    // --- Factory methods (work both on-chain and off-chain) ---
+    // On-chain the compiler replaces these with intrinsics (StdlibRegistry):
+    // empty() → MkNilData, of(a, b, c) → MkCons chain with each element
+    // auto-wrapped to Data (BigInteger → IData, byte[] → BData, boolean → Constr,
+    // String → BData(utf8), PlutusData → as-is).
 
     /** Create an empty list. */
     static <T> JulcList<T> empty() {
         return new JulcArrayList<>(java.util.List.of());
     }
 
-    /** Create a list from the given elements. */
+    /**
+     * Create a list from the given elements.
+     * <p>
+     * On-chain, replaces manual {@code mkCons} chains:
+     * {@code JulcList.of(pkh, recipient)} instead of
+     * {@code Builtins.mkCons(Builtins.iData(pkh), Builtins.mkCons(Builtins.iData(recipient), Builtins.mkNilData()))}.
+     * Call {@link #toPlutusData()} when a {@code PlutusData} list is needed.
+     */
     @SafeVarargs
     static <T> JulcList<T> of(T... elements) {
         return new JulcArrayList<>(java.util.List.of(elements));

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcMap.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcMap.java
@@ -1,5 +1,8 @@
 package com.bloxbean.cardano.julc.core.types;
 
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.ToPlutusData;
+
 /**
  * Immutable association map interface for on-chain and off-chain use.
  * <p>
@@ -12,7 +15,7 @@ package com.bloxbean.cardano.julc.core.types;
  * @param <K> the key type
  * @param <V> the value type
  */
-public interface JulcMap<K, V> {
+public interface JulcMap<K, V> extends ToPlutusData {
 
     // --- Factory methods (off-chain only — on-chain use compiler intrinsics) ---
 
@@ -78,6 +81,15 @@ public interface JulcMap<K, V> {
 
     /** Return all values as a list. */
     JulcList<V> values();
+
+    // --- Conversion ---
+
+    /**
+     * Convert this association map to Plutus Data without collapsing duplicate
+     * keys or changing entry order.
+     */
+    @Override
+    PlutusData.MapData toPlutusData();
 
     // --- Query ---
 

--- a/julc-core/src/test/java/com/bloxbean/cardano/julc/core/types/JulcArrayListTest.java
+++ b/julc-core/src/test/java/com/bloxbean/cardano/julc/core/types/JulcArrayListTest.java
@@ -1,8 +1,11 @@
 package com.bloxbean.cardano.julc.core.types;
 
+import com.bloxbean.cardano.julc.core.PlutusData;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +34,55 @@ class JulcArrayListTest {
         JulcList<Integer> list = JulcList.of(42);
         assertEquals(1, list.size());
         assertEquals(42, list.head());
+    }
+
+    // --- Plutus Data conversion ---
+
+    @Nested
+    class PlutusDataConversion {
+        @Test
+        void convertsSupportedElementTypesInOrder() {
+            JulcList<Object> list = JulcList.of(
+                    BigInteger.valueOf(42),
+                    7L,
+                    8,
+                    new byte[]{1, 2},
+                    false,
+                    true,
+                    "hello",
+                    PlutusData.integer(9));
+
+            var result = list.toPlutusData();
+
+            assertEquals(List.of(
+                    PlutusData.integer(42),
+                    PlutusData.integer(7),
+                    PlutusData.integer(8),
+                    PlutusData.bytes(new byte[]{1, 2}),
+                    PlutusData.constr(0),
+                    PlutusData.constr(1),
+                    PlutusData.bytes("hello".getBytes(StandardCharsets.UTF_8)),
+                    PlutusData.integer(9)), result.items());
+        }
+
+        @Test
+        void recursivelyConvertsNestedLists() {
+            JulcList<Object> list = JulcList.of(
+                    (Object) JulcList.of(BigInteger.ONE, BigInteger.TWO));
+
+            assertEquals(
+                    PlutusData.list(PlutusData.list(
+                            PlutusData.integer(1),
+                            PlutusData.integer(2))),
+                    list.toPlutusData());
+        }
+
+        @Test
+        void rejectsUnsupportedElements() {
+            JulcList<Object> list = JulcList.of(new Object());
+
+            assertThrows(IllegalArgumentException.class, list::toPlutusData);
+        }
     }
 
     // --- Element access ---

--- a/julc-core/src/test/java/com/bloxbean/cardano/julc/core/types/JulcAssocMapTest.java
+++ b/julc-core/src/test/java/com/bloxbean/cardano/julc/core/types/JulcAssocMapTest.java
@@ -1,7 +1,12 @@
 package com.bloxbean.cardano.julc.core.types;
 
+import com.bloxbean.cardano.julc.core.PlutusData;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,6 +26,49 @@ class JulcAssocMapTest {
         JulcMap<String, Integer> map = JulcAssocMap.of("a", 1);
         assertEquals(1, map.size());
         assertEquals(1, map.get("a"));
+    }
+
+    // --- Plutus Data conversion ---
+
+    @Nested
+    class PlutusDataConversion {
+        @Test
+        void preservesEntryOrderAndDuplicateKeys() {
+            JulcMap<String, BigInteger> map =
+                    JulcAssocMap.of("same", BigInteger.ONE)
+                            .insert("same", BigInteger.TWO);
+
+            assertEquals(new PlutusData.MapData(List.of(
+                    new PlutusData.Pair(
+                            PlutusData.bytes("same".getBytes(StandardCharsets.UTF_8)),
+                            PlutusData.integer(2)),
+                    new PlutusData.Pair(
+                            PlutusData.bytes("same".getBytes(StandardCharsets.UTF_8)),
+                            PlutusData.integer(1)))),
+                    map.toPlutusData());
+        }
+
+        @Test
+        void recursivelyConvertsNestedMapAndListValues() {
+            JulcMap<String, Object> nested = JulcAssocMap.of(
+                    "items", JulcList.of(BigInteger.ONE, BigInteger.TWO));
+
+            assertEquals(new PlutusData.MapData(List.of(
+                    new PlutusData.Pair(
+                            PlutusData.bytes("items".getBytes(StandardCharsets.UTF_8)),
+                            PlutusData.list(
+                                    PlutusData.integer(1),
+                                    PlutusData.integer(2))))),
+                    nested.toPlutusData());
+        }
+
+        @Test
+        void rejectsUnsupportedKeysOrValues() {
+            JulcMap<Object, BigInteger> map =
+                    JulcAssocMap.of(new Object(), BigInteger.ONE);
+
+            assertThrows(IllegalArgumentException.class, map::toPlutusData);
+        }
     }
 
     // --- Lookup ---

--- a/julc-e2e-tests/src/test/java/com/bloxbean/cardano/julc/e2e/E2ETestBase.java
+++ b/julc-e2e-tests/src/test/java/com/bloxbean/cardano/julc/e2e/E2ETestBase.java
@@ -64,7 +64,7 @@ abstract class E2ETestBase {
      * Compile Java source to a UPLC Program with stdlib support.
      */
     protected Program compile(String javaSource) {
-        var compiler = new JulcCompiler(stdlib::lookup);
+        var compiler = new JulcCompiler(stdlib);
         var result = compiler.compile(javaSource);
         if (result.hasErrors()) {
             throw new AssertionError("Compilation errors: " + result.diagnostics());

--- a/julc-examples/README.md
+++ b/julc-examples/README.md
@@ -32,7 +32,7 @@ Example validators demonstrating JuLC features. Each example is a JUnit test tha
 Each example follows the same pattern:
 
 1. Define the validator source as a Java string with `@SpendingValidator`/`@MintingValidator`/etc.
-2. Compile with `ValidatorTest.compile(source)` or `ValidatorTest.compile(source, stdlib::lookup)`
+2. Compile with `ValidatorTest.compile(source)` or `ValidatorTest.compile(source, stdlib)`
 3. Build a mock `ScriptContext` as `PlutusData`
 4. Evaluate with `ValidatorTest.evaluate(program, ctx)`
 5. Assert results with `BudgetAssertions.assertSuccess(result)`

--- a/julc-examples/src/test/java/com/bloxbean/cardano/julc/examples/OutputValueCheckTest.java
+++ b/julc-examples/src/test/java/com/bloxbean/cardano/julc/examples/OutputValueCheckTest.java
@@ -92,7 +92,7 @@ class OutputValueCheckTest {
     }
 
     private Program compileWithStdlib(String source) {
-        return ValidatorTest.compile(source, stdlib::lookup);
+        return ValidatorTest.compile(source, stdlib);
     }
 
     // ---- Test data builders ----

--- a/julc-examples/src/test/java/com/bloxbean/cardano/julc/examples/RealisticMintingTest.java
+++ b/julc-examples/src/test/java/com/bloxbean/cardano/julc/examples/RealisticMintingTest.java
@@ -63,7 +63,7 @@ class RealisticMintingTest {
     }
 
     private Program compileWithStdlib(String source) {
-        return ValidatorTest.compile(source, stdlib::lookup);
+        return ValidatorTest.compile(source, stdlib);
     }
 
     /**

--- a/julc-examples/src/test/java/com/bloxbean/cardano/julc/examples/RealisticVestingTest.java
+++ b/julc-examples/src/test/java/com/bloxbean/cardano/julc/examples/RealisticVestingTest.java
@@ -74,7 +74,7 @@ class RealisticVestingTest {
     }
 
     private Program compileWithStdlib(String source) {
-        return ValidatorTest.compile(source, stdlib::lookup);
+        return ValidatorTest.compile(source, stdlib);
     }
 
     /**

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/CompileJulcTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/CompileJulcTask.java
@@ -57,7 +57,7 @@ public abstract class CompileJulcTask extends DefaultTask {
         if (Boolean.TRUE.equals(getSourceMap().getOrElse(false))) {
             options.setSourceMapEnabled(true);
         }
-        var compiler = new JulcCompiler(stdlib::lookup, options);
+        var compiler = new JulcCompiler(stdlib, options);
 
         List<File> javaFiles = findJavaFiles(srcDir);
 

--- a/julc-ledger-api/src/main/java/com/bloxbean/cardano/julc/ledger/PlutusDataConvertible.java
+++ b/julc-ledger-api/src/main/java/com/bloxbean/cardano/julc/ledger/PlutusDataConvertible.java
@@ -1,12 +1,14 @@
 package com.bloxbean.cardano.julc.ledger;
 
 import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.ToPlutusData;
 
 /**
  * Interface for ledger types that can be converted to PlutusData.
  * Each implementing type provides its own encoding convention
  * matching the Haskell/Scalus reference implementation.
  */
-public interface PlutusDataConvertible {
+public interface PlutusDataConvertible extends ToPlutusData {
+    @Override
     PlutusData toPlutusData();
 }

--- a/julc-playground/src/main/java/com/bloxbean/julc/playground/JulcPlaygroundServer.java
+++ b/julc-playground/src/main/java/com/bloxbean/julc/playground/JulcPlaygroundServer.java
@@ -40,7 +40,7 @@ public class JulcPlaygroundServer {
 
     public static Javalin createApp(int port, int maxThreads, long timeoutSeconds) {
         var stdlib = com.bloxbean.cardano.julc.stdlib.StdlibRegistry.defaultRegistry();
-        var julcCompiler = new JulcCompiler(stdlib::lookup);
+        var julcCompiler = new JulcCompiler(stdlib);
         var sandbox = new CompilationSandbox(maxThreads, timeoutSeconds);
 
         // Cache stdlib source scan once at startup (classpath doesn't change at runtime)

--- a/julc-plugin-test/src/test/java/com/bloxbean/cardano/julc/plugintest/PluginTestBase.java
+++ b/julc-plugin-test/src/test/java/com/bloxbean/cardano/julc/plugintest/PluginTestBase.java
@@ -66,7 +66,7 @@ abstract class PluginTestBase {
      * This is equivalent to what the Gradle plugin does at build time.
      */
     protected PlutusV3Script compileScript(String javaSource) {
-        var compiler = new JulcCompiler(stdlib::lookup);
+        var compiler = new JulcCompiler(stdlib);
         var result = compiler.compile(javaSource);
         if (result.hasErrors()) {
             throw new AssertionError("Compilation errors: " + result.diagnostics());

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
@@ -1,11 +1,12 @@
 package com.bloxbean.cardano.julc.stdlib;
 
 import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.PlutusDataConversions;
+import com.bloxbean.cardano.julc.core.ToPlutusData;
 import com.bloxbean.cardano.julc.core.types.JulcArrayList;
 import com.bloxbean.cardano.julc.core.types.JulcAssocMap;
 import com.bloxbean.cardano.julc.core.types.JulcList;
 import com.bloxbean.cardano.julc.core.types.JulcMap;
-import com.bloxbean.cardano.julc.ledger.PlutusDataConvertible;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -149,6 +150,19 @@ public final class Builtins {
     /** Wrap a list as ListData. */
     public static PlutusData.ListData listData(PlutusData list) {
         return (PlutusData.ListData) list; // already a ListData
+    }
+
+    /**
+     * Wrap a JulcList as ListData. Elements are auto-wrapped to Data using the same
+     * rules as the on-chain compiler: BigInteger/Long/Integer → IntData,
+     * byte[] → BytesData, boolean → ConstrData(0/1), String → BytesData(utf8),
+     * PlutusData → as-is, nested JulcList → ListData.
+     * <p>
+     * Pairs with {@code JulcList.of(...)}: {@code Builtins.listData(JulcList.of(a, b, c))}
+     * replaces manual {@code mkCons} chains.
+     */
+    public static PlutusData.ListData listData(JulcList<?> list) {
+        return PlutusDataConversions.listToPlutusData(list);
     }
 
     /** Wrap a map as MapData. */
@@ -300,11 +314,17 @@ public final class Builtins {
 
     /** Convert integer to bytestring with given endianness and width. Accepts arbitrary-precision BigInteger. */
     public static byte[] integerToByteString(boolean bigEndian, long width, BigInteger i) {
+        if (width < 0) {
+            throw new IllegalArgumentException("integerToByteString: negative width");
+        }
+        if (width > 8192) {
+            throw new IllegalArgumentException("integerToByteString: width exceeds 8192 bytes");
+        }
         if (i.signum() < 0) {
             throw new IllegalArgumentException("integerToByteString: negative integer");
         }
+        int w = (int) width; // Safe after the bounded validation above.
         if (i.signum() == 0) {
-            int w = (int) width;
             if (w > 0) {
                 return new byte[w]; // zero-padded
             }
@@ -315,7 +335,12 @@ public final class Builtins {
         if (raw.length > 1 && raw[0] == 0) {
             raw = Arrays.copyOfRange(raw, 1, raw.length);
         }
-        int w = (int) width;
+        int maximumLength = w == 0 ? 8192 : w;
+        if (raw.length > maximumLength) {
+            throw new IllegalArgumentException(w == 0
+                    ? "integerToByteString: result exceeds 8192 bytes"
+                    : "integerToByteString: integer does not fit in " + w + " bytes");
+        }
         if (w > 0 && raw.length < w) {
             byte[] padded = new byte[w];
             System.arraycopy(raw, 0, padded, w - raw.length, raw.length);
@@ -410,6 +435,28 @@ public final class Builtins {
     /** @see #appendByteString(PlutusData.BytesData, PlutusData.BytesData) */
     public static byte[] appendByteString(byte[] a, byte[] b) {
         return appendByteString(new PlutusData.BytesData(a), new PlutusData.BytesData(b)).value();
+    }
+
+    /**
+     * Concatenate two or more bytestrings. On-chain this compiles to a right-fold
+     * of {@code appendByteString}, replacing nested
+     * {@code appendByteString(appendByteString(a, b), c)} chains.
+     */
+    public static byte[] concat(byte[] first, byte[] second, byte[]... rest) {
+        int total = Math.addExact(first.length, second.length);
+        for (byte[] part : rest) {
+            total = Math.addExact(total, part.length);
+        }
+        byte[] result = new byte[total];
+        System.arraycopy(first, 0, result, 0, first.length);
+        int pos = first.length;
+        System.arraycopy(second, 0, result, pos, second.length);
+        pos += second.length;
+        for (byte[] part : rest) {
+            System.arraycopy(part, 0, result, pos, part.length);
+            pos += part.length;
+        }
+        return result;
     }
 
     /** @see #equalsByteString(PlutusData.BytesData, PlutusData.BytesData) */
@@ -925,11 +972,19 @@ public final class Builtins {
     // On-chain types (ScriptInfo, TxInfo, etc.) don't extend PlutusData in
     // IDE stubs. The compiler matches by method name via StdlibRegistry and
     // ignores parameter types, so these overloads simply satisfy the IDE.
-    // Off-chain, ledger records implement PlutusDataConvertible for conversion.
+    // Off-chain, core collections and ledger records implement ToPlutusData.
 
     private static PlutusData asPlutusData(Object obj) {
         if (obj instanceof PlutusData pd) return pd;
-        if (obj instanceof PlutusDataConvertible pdc) return pdc.toPlutusData();
+        if (obj instanceof ToPlutusData convertible) {
+            var converted = convertible.toPlutusData();
+            if (converted == null) {
+                throw new ClassCastException(
+                        "toPlutusData() returned null for " + obj.getClass().getName());
+            }
+            return converted;
+        }
+        if (obj == null) throw new ClassCastException("Cannot convert null to PlutusData");
         throw new ClassCastException("Cannot convert " + obj.getClass().getName() + " to PlutusData");
     }
 
@@ -1004,10 +1059,15 @@ public final class Builtins {
     public static byte[] toByteString(Object data) {
         if (data instanceof byte[] b) return b;
         if (data instanceof PlutusData.BytesData bd) return bd.value();
-        if (data instanceof PlutusDataConvertible pdc) {
-            var pd = pdc.toPlutusData();
+        if (data instanceof ToPlutusData convertible) {
+            var pd = convertible.toPlutusData();
             if (pd instanceof PlutusData.BytesData bd) return bd.value();
+            if (pd == null) {
+                throw new ClassCastException(
+                        "toPlutusData() returned null for " + data.getClass().getName());
+            }
         }
+        if (data == null) throw new ClassCastException("Cannot extract byte[] from null");
         throw new ClassCastException("Cannot extract byte[] from " + data.getClass().getName());
     }
 

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
@@ -94,16 +94,27 @@ public final class StdlibRegistry implements StdlibLookup {
                     List.of(new PirType.Field("value", elemType)));
             return Optional.of(new PirTerm.DataConstr(0, recordType, List.of(args.get(0))));
         }
+        // JulcList.of(a, b, ...) — wrap each element to Data before MkCons
+        if (isJulcListClass(className) && methodName.equals("of")) {
+            PirTerm result = builtinApp1(DefaultFun.MkNilData, new PirTerm.Const(Constant.unit()));
+            for (int i = args.size() - 1; i >= 0; i--) {
+                var wrapped = PirHelpers.wrapEncode(args.get(i), safeArgType(argTypes, i));
+                result = builtinApp2(DefaultFun.MkCons, wrapped, result);
+            }
+            return Optional.of(result);
+        }
+
         // ListsLib.prepend(list, elem) — wrap elem to Data before MkCons
         if (isListsLibClass(className) && methodName.equals("prepend") && args.size() == 2) {
             var wrappedElem = PirHelpers.wrapEncode(args.get(1), safeArgType(argTypes, 1));
-            return Optional.of(builtinApp2(DefaultFun.MkCons, wrappedElem, args.get(0)));
+            var list = asUplcList(args.get(0), safeArgType(argTypes, 0));
+            return Optional.of(builtinApp2(DefaultFun.MkCons, wrappedElem, list));
         }
 
         // ListsLib.contains(list, target) — wrap target, search with EqualsData
         if (isListsLibClass(className) && methodName.equals("contains") && args.size() == 2) {
             var wrappedTarget = PirHelpers.wrapEncode(args.get(1), safeArgType(argTypes, 1));
-            return Optional.of(PirHelpers.listSearch("con", args.get(0), wrappedTarget,
+            return Optional.of(PirHelpers.listSearch("con", asUplcList(args.get(0), safeArgType(argTypes, 0)), wrappedTarget,
                     new PirTerm.Const(Constant.bool(false)),
                     (elem, t, recurse) -> {
                         var eq = builtinApp2(DefaultFun.EqualsData, elem, t);
@@ -117,13 +128,14 @@ public final class StdlibRegistry implements StdlibLookup {
             var key = PirHelpers.wrapEncode(args.get(1), safeArgType(argTypes, 1));
             var value = PirHelpers.wrapEncode(args.get(2), safeArgType(argTypes, 2));
             var pair = builtinApp2(DefaultFun.MkPairData, key, value);
-            return Optional.of(builtinApp2(DefaultFun.MkCons, pair, args.get(0)));
+            return Optional.of(builtinApp2(DefaultFun.MkCons, pair,
+                    asPairList(args.get(0), safeArgType(argTypes, 0))));
         }
 
         // MapLib.member(map, key) — wrap key, pairListSearch returning bool
         if (isMapLibClass(className) && methodName.equals("member") && args.size() == 2) {
             var key = PirHelpers.wrapEncode(args.get(1), safeArgType(argTypes, 1));
-            return Optional.of(PirHelpers.pairListSearch("mb", args.get(0), key,
+            return Optional.of(PirHelpers.pairListSearch("mb", asPairList(args.get(0), safeArgType(argTypes, 0)), key,
                     new PirTerm.Const(Constant.bool(false)),
                     (h, k, goTail) -> {
                         var fstH = builtinApp1(DefaultFun.FstPair, h);
@@ -136,7 +148,7 @@ public final class StdlibRegistry implements StdlibLookup {
         // MapLib.lookup(map, key) — wrap key, pairListSearch returning Optional
         if (isMapLibClass(className) && methodName.equals("lookup") && args.size() == 2) {
             var key = PirHelpers.wrapEncode(args.get(1), safeArgType(argTypes, 1));
-            return Optional.of(PirHelpers.pairListSearch("lk", args.get(0), key,
+            return Optional.of(PirHelpers.pairListSearch("lk", asPairList(args.get(0), safeArgType(argTypes, 0)), key,
                     PirHelpers.mkNone(),
                     (h, k, goTail) -> {
                         var fstH = builtinApp1(DefaultFun.FstPair, h);
@@ -150,7 +162,7 @@ public final class StdlibRegistry implements StdlibLookup {
         // MapLib.delete(map, key) — wrap key, pairListSearch filtering out matching pair
         if (isMapLibClass(className) && methodName.equals("delete") && args.size() == 2) {
             var key = PirHelpers.wrapEncode(args.get(1), safeArgType(argTypes, 1));
-            return Optional.of(PirHelpers.pairListSearch("del", args.get(0), key,
+            return Optional.of(PirHelpers.pairListSearch("del", asPairList(args.get(0), safeArgType(argTypes, 0)), key,
                     PirHelpers.mkNilPairData(),
                     (h, k, goTail) -> {
                         var fstH = builtinApp1(DefaultFun.FstPair, h);
@@ -175,8 +187,35 @@ public final class StdlibRegistry implements StdlibLookup {
         return className.equals("MapLib") || className.equals(LIB + "MapLib");
     }
 
+    private static boolean isJulcListClass(String className) {
+        return className.equals("JulcList")
+                || className.equals("com.bloxbean.cardano.julc.core.types.JulcList");
+    }
+
     private static PirType safeArgType(List<PirType> argTypes, int index) {
         return (argTypes != null && argTypes.size() > index) ? argTypes.get(index) : new PirType.DataType();
+    }
+
+    /**
+     * Coerce a list argument to a UPLC list. ListType variables already hold UPLC lists;
+     * a DataType argument (e.g. raw redeemer Data) is ListData and needs UnListData first.
+     */
+    private static PirTerm asUplcList(PirTerm list, PirType type) {
+        if (type instanceof PirType.DataType) {
+            return builtinApp1(DefaultFun.UnListData, list);
+        }
+        return list;
+    }
+
+    /**
+     * Coerce a map argument to a UPLC pair list. MapType variables already hold pair lists;
+     * a DataType argument (e.g. raw redeemer Data) is MapData and needs UnMapData first.
+     */
+    private static PirTerm asPairList(PirTerm map, PirType type) {
+        if (type instanceof PirType.DataType) {
+            return builtinApp1(DefaultFun.UnMapData, map);
+        }
+        return map;
     }
 
     /**
@@ -488,6 +527,16 @@ public final class StdlibRegistry implements StdlibLookup {
             return new PirTerm.Const(Constant.byteString(new byte[0]));
         });
 
+        // concat: variadic — right-fold of AppendByteString over at least two args
+        reg.register(B, "concat", args -> {
+            requireMinArgs("Builtins.concat", args, 2);
+            PirTerm result = args.get(args.size() - 1);
+            for (int i = args.size() - 2; i >= 0; i--) {
+                result = builtinApp2(DefaultFun.AppendByteString, args.get(i), result);
+            }
+            return result;
+        });
+
         // toByteString: identity on-chain (value is already a ByteString)
         reg.register(B, "toByteString", args -> {
             requireArgs("Builtins.toByteString", args, 1);
@@ -690,6 +739,13 @@ public final class StdlibRegistry implements StdlibLookup {
         if (args.size() != expected) {
             throw new IllegalArgumentException(
                     method + " expects " + expected + " arguments, got " + args.size());
+        }
+    }
+
+    private static void requireMinArgs(String method, List<PirTerm> args, int minimum) {
+        if (args.size() < minimum) {
+            throw new IllegalArgumentException(
+                    method + " expects at least " + minimum + " arguments, got " + args.size());
         }
     }
 

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ByteStringLib.java
@@ -43,7 +43,7 @@ public class ByteStringLib {
         return Builtins.sliceByteString(0, n, bs);
     }
 
-    /** Concatenate two bytestrings. */
+    /** Concatenate two bytestrings. For 3+ parts use {@code Builtins.concat(a, b, c, ...)}. */
     public static byte[] append(byte[] a, byte[] b) {
         return Builtins.appendByteString(a, b);
     }

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLib.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.julc.core.types.AssetEntry;
 import com.bloxbean.cardano.julc.core.types.JulcList;
 import com.bloxbean.cardano.julc.core.types.JulcMap;
 import com.bloxbean.cardano.julc.stdlib.annotation.OnchainLibrary;
+import com.bloxbean.cardano.julc.ledger.TxOutRef;
 import com.bloxbean.cardano.julc.ledger.Value;
 import com.bloxbean.cardano.julc.stdlib.Builtins;
 
@@ -484,5 +485,32 @@ public class ValuesLib {
             current = Builtins.tailList(current);
         }
         return result;
+    }
+
+    /**
+     * Seed bytes uniquely identifying a TxOutRef: {@code txId ++ integerToByteString(true, 2, index)}.
+     * <p>
+     * The index is encoded as fixed 2-byte big-endian, so the result is deterministic and
+     * identical on-chain and off-chain (a width of 0 would encode index 0 as empty bytes on-chain).
+     * Fails for index &gt; 65535, which cannot occur for real transaction outputs.
+     * <p>
+     * Use this as input to a hash of your choice, e.g.
+     * {@code CryptoLib.sha2_256(ValuesLib.refBytes(ref))}, or use
+     * {@link #uniqueTokenName(TxOutRef)} for the canonical blake2b_256 derivation.
+     */
+    public static byte[] refBytes(TxOutRef ref) {
+        byte[] idxBytes = Builtins.integerToByteString(true, 2, ref.index());
+        return Builtins.appendByteString(ref.txId().hash(), idxBytes);
+    }
+
+    /**
+     * Canonical token name for a spent TxOutRef: {@code blake2b_256(refBytes(ref))}.
+     * <p>
+     * The 32-byte output (the maximum Cardano asset-name length) is
+     * collision-resistant and deterministically tied to the reference. A one-shot
+     * minting policy must also enforce that the referenced output is consumed.
+     */
+    public static byte[] uniqueTokenName(TxOutRef ref) {
+        return Builtins.blake2b_256(refBytes(ref));
     }
 }

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/BuiltinsTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/BuiltinsTest.java
@@ -1,0 +1,95 @@
+package com.bloxbean.cardano.julc.stdlib;
+
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.types.JulcList;
+import com.bloxbean.cardano.julc.core.types.JulcMap;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuiltinsTest {
+
+    @Nested
+    class PlutusDataConversion {
+
+        @Test
+        void objectOverloadsAcceptCoreConversionTypes() {
+            var list = JulcList.of(BigInteger.ONE, BigInteger.TWO);
+            var map = JulcMap.of("key", BigInteger.TEN);
+
+            assertTrue(Builtins.equalsData(
+                    list, PlutusData.list(
+                            PlutusData.integer(1),
+                            PlutusData.integer(2))));
+            assertTrue(Builtins.equalsData(
+                    map, map.toPlutusData()));
+        }
+    }
+
+    @Nested
+    class IntegerToByteString {
+
+        @Test
+        void rejectsNegativeWidthBeforeCasting() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> Builtins.integerToByteString(true, -1, BigInteger.ZERO));
+        }
+
+        @Test
+        void acceptsMaximumWidth() {
+            byte[] result = Builtins.integerToByteString(true, 8192, BigInteger.ZERO);
+
+            assertEquals(8192, result.length);
+        }
+
+        @Test
+        void rejectsWidthAboveMaximum() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> Builtins.integerToByteString(true, 8193, BigInteger.ZERO));
+        }
+
+        @Test
+        void rejectsWidthThatWouldOverflowAnIntCast() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> Builtins.integerToByteString(true, Long.MAX_VALUE, BigInteger.ZERO));
+        }
+
+        @Test
+        void rejectsValueThatDoesNotFitRequestedWidth() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> Builtins.integerToByteString(
+                            true, 2, BigInteger.valueOf(65_536)));
+        }
+
+        @Test
+        void rejectsUnboundedResultAboveMaximum() {
+            BigInteger tooLarge = BigInteger.ONE.shiftLeft(8192 * 8);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> Builtins.integerToByteString(true, 0, tooLarge));
+        }
+
+        @Test
+        void acceptsLargestUnboundedResult() {
+            BigInteger maximum = BigInteger.ONE.shiftLeft(8192 * 8).subtract(BigInteger.ONE);
+
+            assertEquals(8192, Builtins.integerToByteString(true, 0, maximum).length);
+        }
+
+        @Test
+        void preservesExactWidthEndianness() {
+            assertArrayEquals(
+                    new byte[]{0, 1, 2},
+                    Builtins.integerToByteString(true, 3, BigInteger.valueOf(0x0102)));
+            assertArrayEquals(
+                    new byte[]{2, 1, 0},
+                    Builtins.integerToByteString(false, 3, BigInteger.valueOf(0x0102)));
+        }
+    }
+}

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLibTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/ValuesLibTest.java
@@ -3,8 +3,12 @@ package com.bloxbean.cardano.julc.stdlib.lib;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.ledger.PolicyId;
 import com.bloxbean.cardano.julc.ledger.TokenName;
+import com.bloxbean.cardano.julc.ledger.TxId;
+import com.bloxbean.cardano.julc.ledger.TxOutRef;
 import com.bloxbean.cardano.julc.ledger.Value;
+import com.bloxbean.cardano.julc.stdlib.Builtins;
 import com.bloxbean.cardano.julc.testkit.JulcEval;
+import com.bloxbean.cardano.julc.testkit.JvmCryptoProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,6 +31,7 @@ class ValuesLibTest {
     @BeforeAll
     static void setUp() {
         eval = JulcEval.forClass(ValuesLib.class);
+        Builtins.setCryptoProvider(new JvmCryptoProvider());
     }
 
     /** Lovelace-only value. */
@@ -345,6 +350,106 @@ class ValuesLibTest {
             var mint = Value.singleton(PolicyId.of(POLICY_A), TokenName.of(TOKEN_X), BigInteger.valueOf(5));
             byte[] found = eval.call("findTokenName", mint, POLICY_A, BigInteger.ONE).asByteString();
             assertEquals(0, found.length);
+        }
+    }
+
+    // =========================================================================
+    // refBytes / uniqueTokenName
+    // =========================================================================
+
+    @Nested
+    class UniqueTokenNameTests {
+
+        final byte[] txHash = makeBytes(32, 0xCD);
+
+        TxOutRef ref(long index) {
+            return new TxOutRef(new TxId(txHash), BigInteger.valueOf(index));
+        }
+
+        byte[] expectedRefBytes(int hi, int lo) {
+            byte[] expected = new byte[34];
+            System.arraycopy(txHash, 0, expected, 0, 32);
+            expected[32] = (byte) hi;
+            expected[33] = (byte) lo;
+            return expected;
+        }
+
+        @Test
+        void refBytesIndexZero() {
+            // Index 0 must still contribute 2 bytes — the width-0 minimal encoding
+            // would drop it entirely, which is why refBytes uses fixed width 2
+            byte[] result = eval.call("refBytes", ref(0)).asByteString();
+            assertArrayEquals(expectedRefBytes(0, 0), result);
+        }
+
+        @Test
+        void refBytesSmallIndex() {
+            byte[] result = eval.call("refBytes", ref(1)).asByteString();
+            assertArrayEquals(expectedRefBytes(0, 1), result);
+        }
+
+        @Test
+        void refBytesTwoByteIndex() {
+            byte[] result = eval.call("refBytes", ref(256)).asByteString();
+            assertArrayEquals(expectedRefBytes(1, 0), result);
+        }
+
+        @Test
+        void refBytesMaxIndex() {
+            byte[] result = eval.call("refBytes", ref(65535)).asByteString();
+            assertArrayEquals(expectedRefBytes(0xFF, 0xFF), result);
+        }
+
+        @Test
+        void refBytesIndexTooLargeFails() {
+            assertThrows(Exception.class, () -> eval.call("refBytes", ref(65536)));
+        }
+
+        @Test
+        void refBytesJvmMatchesUplcAtWidthBoundaries() {
+            for (long index : new long[]{0, 1, 256, 65535}) {
+                assertArrayEquals(
+                        eval.call("refBytes", ref(index)).asByteString(),
+                        ValuesLib.refBytes(ref(index)),
+                        "JVM/UPLC mismatch at output index " + index);
+            }
+        }
+
+        @Test
+        void uniqueTokenNameIsBlake2bOfRefBytes() {
+            var cryptoEval = JulcEval.forClass(CryptoLib.class);
+            byte[] expected = cryptoEval.call("blake2b_256", expectedRefBytes(0, 7)).asByteString();
+            byte[] actual = eval.call("uniqueTokenName", ref(7)).asByteString();
+            assertArrayEquals(expected, actual);
+        }
+
+        @Test
+        void uniqueTokenNameIs32Bytes() {
+            byte[] name = eval.call("uniqueTokenName", ref(0)).asByteString();
+            assertEquals(32, name.length);
+        }
+
+        @Test
+        void uniqueTokenNameJvmMatchesUplc() {
+            assertArrayEquals(
+                    eval.call("uniqueTokenName", ref(7)).asByteString(),
+                    ValuesLib.uniqueTokenName(ref(7)));
+        }
+
+        @Test
+        void uniqueTokenNameDiffersByIndex() {
+            byte[] name0 = eval.call("uniqueTokenName", ref(0)).asByteString();
+            byte[] name1 = eval.call("uniqueTokenName", ref(1)).asByteString();
+            assertFalse(java.util.Arrays.equals(name0, name1));
+        }
+
+        @Test
+        void uniqueTokenNameDiffersByTxId() {
+            byte[] otherHash = makeBytes(32, 0xEE);
+            var otherRef = new TxOutRef(new TxId(otherHash), BigInteger.ZERO);
+            byte[] name0 = eval.call("uniqueTokenName", ref(0)).asByteString();
+            byte[] nameOther = eval.call("uniqueTokenName", otherRef).asByteString();
+            assertFalse(java.util.Arrays.equals(name0, nameOther));
         }
     }
 }

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/VariadicIntrinsicsTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/VariadicIntrinsicsTest.java
@@ -1,0 +1,284 @@
+package com.bloxbean.cardano.julc.stdlib.lib;
+
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.stdlib.Builtins;
+import com.bloxbean.cardano.julc.testkit.JulcEval;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for variadic compiler intrinsics: {@code Builtins.concat(...)} and
+ * {@code Builtins.listData(JulcList.of(...))}.
+ * <p>
+ * These are PIR-registered (StdlibRegistry), so on-chain behavior is tested through
+ * compiled source via {@link JulcEval#forSource}, and JVM parity through direct calls.
+ */
+class VariadicIntrinsicsTest {
+
+    private static final String IMPORTS = """
+            import com.bloxbean.cardano.julc.stdlib.Builtins;
+            import com.bloxbean.cardano.julc.core.PlutusData;
+            import com.bloxbean.cardano.julc.core.types.JulcList;
+            import java.math.BigInteger;
+            """;
+
+    @Nested
+    class ConcatOnChain {
+
+        @Test
+        void concatTwoParts() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test(byte[] a, byte[] b) {
+                            return Builtins.concat(a, b);
+                        }
+                    }
+                    """);
+            byte[] result = eval.call("test", new byte[]{1, 2}, new byte[]{3, 4}).asByteString();
+            assertArrayEquals(new byte[]{1, 2, 3, 4}, result);
+        }
+
+        @Test
+        void concatThreeParts() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test(byte[] a, byte[] b, byte[] c) {
+                            return Builtins.concat(a, b, c);
+                        }
+                    }
+                    """);
+            byte[] result = eval.call("test",
+                    new byte[]{1, 2}, new byte[]{3, 4}, new byte[]{5, 6}).asByteString();
+            assertArrayEquals(new byte[]{1, 2, 3, 4, 5, 6}, result);
+        }
+
+        @Test
+        void concatFiveParts() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test(byte[] a, byte[] b, byte[] c, byte[] d, byte[] e) {
+                            return Builtins.concat(a, b, c, d, e);
+                        }
+                    }
+                    """);
+            byte[] result = eval.call("test",
+                    new byte[]{1}, new byte[]{2}, new byte[]{3}, new byte[]{4}, new byte[]{5}).asByteString();
+            assertArrayEquals(new byte[]{1, 2, 3, 4, 5}, result);
+        }
+
+        @Test
+        void concatWithEmptyParts() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test(byte[] a, byte[] b, byte[] c) {
+                            return Builtins.concat(a, b, c);
+                        }
+                    }
+                    """);
+            byte[] result = eval.call("test",
+                    new byte[]{}, new byte[]{7}, new byte[]{}).asByteString();
+            assertArrayEquals(new byte[]{7}, result);
+        }
+
+        @Test
+        void concatMatchesNestedAppendByteString() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(byte[] a, byte[] b, byte[] c) {
+                            byte[] viaConcat = Builtins.concat(a, b, c);
+                            byte[] viaAppend = Builtins.appendByteString(Builtins.appendByteString(a, b), c);
+                            return Builtins.equalsByteString(viaConcat, viaAppend);
+                        }
+                    }
+                    """);
+            assertTrue(eval.call("test",
+                    new byte[]{1, 2}, new byte[]{3}, new byte[]{4, 5}).asBoolean());
+        }
+
+        @Test
+        void concatRejectsZeroPartsInSourceCompilation() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test() {
+                            return Builtins.concat();
+                        }
+                    }
+                    """);
+
+            assertThrows(IllegalArgumentException.class, () -> eval.call("test"));
+        }
+
+        @Test
+        void concatRejectsOnePartInSourceCompilation() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static byte[] test(byte[] only) {
+                            return Builtins.concat(only);
+                        }
+                    }
+                    """);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> eval.call("test", new byte[]{1}));
+        }
+    }
+
+    @Nested
+    class ConcatJvm {
+
+        @Test
+        void jvmConcatMatchesOnChain() {
+            byte[] a = {1, 2}, b = {3}, c = {4, 5};
+            byte[] jvm = Builtins.concat(a, b, c);
+            assertArrayEquals(new byte[]{1, 2, 3, 4, 5}, jvm);
+        }
+
+        @Test
+        void jvmConcatTwoArgs() {
+            assertArrayEquals(new byte[]{1, 2, 3, 4},
+                    Builtins.concat(new byte[]{1, 2}, new byte[]{3, 4}));
+        }
+
+        @Test
+        void jvmConcatAllEmpty() {
+            assertArrayEquals(new byte[]{},
+                    Builtins.concat(new byte[]{}, new byte[]{}, new byte[]{}));
+        }
+    }
+
+    @Nested
+    class ListDataOfJulcList {
+
+        @Test
+        void listDataOfPlutusDataElements() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(PlutusData expected) {
+                            PlutusData built = Builtins.listData(JulcList.of(
+                                    Builtins.iData(BigInteger.valueOf(1)),
+                                    Builtins.iData(BigInteger.valueOf(2))));
+                            return Builtins.equalsData(built, expected);
+                        }
+                    }
+                    """);
+            var expected = new PlutusData.ListData(List.of(
+                    new PlutusData.IntData(BigInteger.ONE),
+                    new PlutusData.IntData(BigInteger.TWO)));
+            assertTrue(eval.call("test", expected).asBoolean());
+        }
+
+        @Test
+        void listDataOfAutoWrappedIntegers() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(PlutusData expected) {
+                            BigInteger pkh = BigInteger.valueOf(11);
+                            BigInteger recipient = BigInteger.valueOf(22);
+                            PlutusData built = Builtins.listData(JulcList.of(pkh, recipient));
+                            return Builtins.equalsData(built, expected);
+                        }
+                    }
+                    """);
+            var expected = new PlutusData.ListData(List.of(
+                    new PlutusData.IntData(BigInteger.valueOf(11)),
+                    new PlutusData.IntData(BigInteger.valueOf(22))));
+            assertTrue(eval.call("test", expected).asBoolean());
+        }
+
+        @Test
+        void jvmListDataMatchesOnChainWrapping() {
+            var list = com.bloxbean.cardano.julc.core.types.JulcList.of(
+                    BigInteger.valueOf(11), BigInteger.valueOf(22));
+            var jvm = Builtins.listData(list);
+            var expected = new PlutusData.ListData(List.of(
+                    new PlutusData.IntData(BigInteger.valueOf(11)),
+                    new PlutusData.IntData(BigInteger.valueOf(22))));
+            assertEquals(expected, jvm);
+        }
+
+        @Test
+        void jvmListDataMixedElements() {
+            var list = com.bloxbean.cardano.julc.core.types.JulcList.of(
+                    (Object) BigInteger.ONE, new byte[]{1, 2}, true);
+            var jvm = Builtins.listData(list);
+            assertEquals(3, jvm.items().size());
+            assertEquals(new PlutusData.IntData(BigInteger.ONE), jvm.items().get(0));
+            assertEquals(new PlutusData.BytesData(new byte[]{1, 2}), jvm.items().get(1));
+            assertEquals(new PlutusData.ConstrData(1, List.of()), jvm.items().get(2));
+        }
+
+        @Test
+        void jvmListDataUnsupportedElementThrows() {
+            var list = com.bloxbean.cardano.julc.core.types.JulcList.of(new Object());
+            assertThrows(IllegalArgumentException.class, () -> Builtins.listData(list));
+        }
+
+        @Test
+        void chainedJulcListToPlutusDataCompilesAndEvaluates() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(PlutusData expected) {
+                            PlutusData actual = JulcList.of(
+                                    BigInteger.valueOf(11),
+                                    BigInteger.valueOf(22)).toPlutusData();
+                            return Builtins.equalsData(actual, expected);
+                        }
+                    }
+                    """);
+            var expected = PlutusData.list(
+                    PlutusData.integer(11),
+                    PlutusData.integer(22));
+
+            assertTrue(eval.call("test", expected).asBoolean());
+        }
+
+        @Test
+        void variableJulcListToPlutusDataCompilesAndEvaluates() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    class T {
+                        static boolean test(PlutusData expected) {
+                            JulcList<BigInteger> values =
+                                    JulcList.of(BigInteger.ONE, BigInteger.TWO);
+                            PlutusData actual = values.toPlutusData();
+                            return Builtins.equalsData(actual, expected);
+                        }
+                    }
+                    """);
+            var expected = PlutusData.list(
+                    PlutusData.integer(1),
+                    PlutusData.integer(2));
+
+            assertTrue(eval.call("test", expected).asBoolean());
+        }
+    }
+
+    @Nested
+    class MapToPlutusData {
+
+        @Test
+        void variableJulcMapToPlutusDataCompilesAndEvaluates() {
+            var eval = JulcEval.forSource(IMPORTS + """
+                    import com.bloxbean.cardano.julc.core.types.JulcMap;
+                    class T {
+                        static boolean test(PlutusData expected) {
+                            JulcMap<BigInteger, byte[]> empty = JulcMap.empty();
+                            JulcMap<BigInteger, byte[]> values =
+                                    empty.insert(BigInteger.valueOf(7), new byte[]{1, 2});
+                            PlutusData actual = values.toPlutusData();
+                            return Builtins.equalsData(actual, expected);
+                        }
+                    }
+                    """);
+            var expected = PlutusData.map(new PlutusData.Pair(
+                    PlutusData.integer(7),
+                    PlutusData.bytes(new byte[]{1, 2})));
+
+            assertTrue(eval.call("test", expected).asBoolean());
+        }
+    }
+}

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ArgConverter.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ArgConverter.java
@@ -1,10 +1,7 @@
 package com.bloxbean.cardano.julc.testkit;
 
 import com.bloxbean.cardano.julc.core.PlutusData;
-import com.bloxbean.cardano.julc.ledger.PlutusDataConvertible;
-
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
+import com.bloxbean.cardano.julc.core.PlutusDataConversions;
 
 /**
  * Converts Java method arguments to {@link PlutusData} for UPLC evaluation.
@@ -41,18 +38,6 @@ public final class ArgConverter {
         if (arg == null) {
             throw new IllegalArgumentException("Null arguments are not supported");
         }
-        return switch (arg) {
-            case PlutusData pd -> pd;
-            case PlutusDataConvertible pdc -> pdc.toPlutusData();
-            case BigInteger bi -> PlutusData.integer(bi);
-            case Long l -> PlutusData.integer(l);
-            case Integer i -> PlutusData.integer(i);
-            case byte[] bs -> PlutusData.bytes(bs);
-            case Boolean b -> PlutusData.constr(b ? 1 : 0);
-            case String s -> PlutusData.bytes(s.getBytes(StandardCharsets.UTF_8));
-            default -> throw new IllegalArgumentException(
-                    "Unsupported argument type: " + arg.getClass().getName()
-                    + ". Supported: BigInteger, long, int, byte[], boolean, String, PlutusData, PlutusDataConvertible");
-        };
+        return PlutusDataConversions.toPlutusData(arg);
     }
 }

--- a/julc-testkit/src/test/java/com/bloxbean/cardano/julc/testkit/JulcEvalTest.java
+++ b/julc-testkit/src/test/java/com/bloxbean/cardano/julc/testkit/JulcEvalTest.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.julc.testkit;
 
 import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.types.JulcList;
+import com.bloxbean.cardano.julc.core.types.JulcMap;
 import com.bloxbean.cardano.julc.ledger.PubKeyHash;
 import com.bloxbean.cardano.julc.testkit.fixtures.ParameterizedSample;
 import com.bloxbean.cardano.julc.testkit.fixtures.SampleValidator;
@@ -465,6 +467,23 @@ class JulcEvalTest {
             var result = ArgConverter.convert(new Object[]{pkh});
             assertEquals(1, result.length);
             assertInstanceOf(PlutusData.BytesData.class, result[0]);
+        }
+
+        @Test
+        void convertCoreCollectionsThroughSharedConversionContract() {
+            JulcList<BigInteger> list = JulcList.of(BigInteger.ONE);
+            JulcMap<String, BigInteger> map = JulcMap.of("key", BigInteger.TWO);
+
+            var result = ArgConverter.convert(new Object[]{list, map});
+
+            assertEquals(
+                    PlutusData.list(PlutusData.integer(1)),
+                    result[0]);
+            assertEquals(
+                    PlutusData.map(new PlutusData.Pair(
+                            PlutusData.bytes("key".getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+                            PlutusData.integer(2))),
+                    result[1]);
         }
     }
 

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/BitwiseBuiltins.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/BitwiseBuiltins.java
@@ -30,14 +30,14 @@ public final class BitwiseBuiltins {
             throw new BuiltinException("IntegerToByteString: negative integer");
         }
 
-        int requestedLen = len.intValue();
-        if (requestedLen < 0) {
+        if (len.signum() < 0) {
             throw new BuiltinException("IntegerToByteString: negative length");
         }
         // Limit to 8192 bytes
-        if (requestedLen > 8192) {
+        if (len.compareTo(BigInteger.valueOf(8192)) > 0) {
             throw new BuiltinException("IntegerToByteString: length exceeds 8192 bytes");
         }
+        int requestedLen = len.intValueExact();
 
         byte[] bytes;
         if (value.signum() == 0) {

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/builtins/BitwiseBuiltinsTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/builtins/BitwiseBuiltinsTest.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.julc.vm.java.builtins;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.vm.java.CekValue;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BitwiseBuiltinsTest {
+
+    @Test
+    void integerToByteStringRejectsWidthThatWouldOverflowInt() {
+        var args = List.<CekValue>of(
+                new CekValue.VCon(Constant.bool(true)),
+                new CekValue.VCon(Constant.integer(BigInteger.ONE.shiftLeft(32))),
+                new CekValue.VCon(Constant.integer(BigInteger.ZERO)));
+
+        assertThrows(BuiltinException.class,
+                () -> BitwiseBuiltins.integerToByteString(args));
+    }
+
+    @Test
+    void integerToByteStringRejectsHugeNegativeWidth() {
+        var args = List.<CekValue>of(
+                new CekValue.VCon(Constant.bool(true)),
+                new CekValue.VCon(Constant.integer(
+                        BigInteger.ONE.shiftLeft(64).negate())),
+                new CekValue.VCon(Constant.integer(BigInteger.ZERO)));
+
+        assertThrows(BuiltinException.class,
+                () -> BitwiseBuiltins.integerToByteString(args));
+    }
+}


### PR DESCRIPTION
## Summary

Implements ADR-027 end to end: concise list/Data construction, variadic byte-string concatenation, deterministic token-name helpers, and the production typed-lookup bypass fix discovered while implementing them.

## What changed

- `JulcList.of(...)` now auto-wraps typed elements to Data on-chain.
- `JulcList` and `JulcMap` expose JVM/on-chain-consistent `toPlutusData()` conversion through a new core `ToPlutusData` contract and shared conversion table.
- `JulcAssocMap.toPlutusData()` preserves native entry order and duplicate keys.
- `Builtins.concat(byte[], byte[], byte[]...)` is implemented as an overflow-checked JVM concatenation and a PIR `AppendByteString` right fold, with a minimum arity of two enforced in source-compilation paths.
- `ValuesLib.refBytes(TxOutRef)` and `uniqueTokenName(TxOutRef)` provide the documented fixed-width, big-endian seed derivation and Blake2b-256 token name.
- `StdlibLookup` now requires both untyped and typed lookup forms, so lambdas/method references cannot silently discard typed coercions.
- All production, test, example, and documentation call sites now pass the registry object.
- The `@NewType` lookup adapter propagates the typed lookup path.
- Typed `MapLib`/`ListsLib` operations accept both typed containers and raw Plutus Data through explicit list/map coercions.
- `ArgConverter` delegates to the same core conversion table.

`JulcPair`, map `entries()`, and native-pair list semantics remain deferred to ADR-028 and are not implemented here.

## Security and correctness

- Enforces the complete `integerToByteString` contract: non-negative width, maximum width/output of 8192 bytes, and positive-width fit checks before allocation or narrowing.
- Fixes a latent Java VM bypass where an arbitrary-precision width was narrowed with `BigInteger.intValue()` before validation.
- Uses `Math.addExact` when sizing JVM `concat` output.
- Documents token names as collision-resistant and deterministic; the minting policy must enforce consumption of the seed `TxOutRef`.

## Compatibility

- Correct typed coercions can change generated UPLC and therefore script hashes for affected validators; downstream projects should recompile and re-derive addresses.
- External `StdlibLookup` lambdas, method references, and partial implementations intentionally stop compiling and must implement both lookup forms.
- External `JulcMap` implementations must add `toPlutusData()`.

## Verification

- `./gradlew test --rerun-tasks` — **PASS**; all 111 enabled tasks executed.
- Official bundled Plutus conformance runner — **999/999 PASS**, including all 32 `integerToByteString` vectors.
- Focused compiler, stdlib, core, testkit, examples, and Java VM regressions — **PASS**.
- Production Gradle plugin tests, including fresh test-project compilation paths — **PASS**.
- `git diff --check` — **PASS**.
- Repository audit finds no remaining Stdlib-related `::lookup` bypass and no ADR-028 `JulcPair` implementation in this change.

Network-dependent E2E and plugin-test suites retain their normal opt-in configuration and are skipped by the default root test task.
