### PR TITLE
fix(vm-java): match Plutus short cost-model array handling

### DIFF
--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/JavaVmProvider.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/JavaVmProvider.java
@@ -20,6 +20,9 @@ import java.util.List;
  */
 public class JavaVmProvider implements JulcVmProvider {
 
+    private static final System.Logger LOGGER =
+            System.getLogger(JavaVmProvider.class.getName());
+
     private volatile ConfiguredCostModel customV1CostModel;
     private volatile ConfiguredCostModel customV2CostModel;
     private volatile ConfiguredCostModel customV3CostModel;
@@ -31,6 +34,8 @@ public class JavaVmProvider implements JulcVmProvider {
                 language, new ProtocolVersion(protocolMajorVersion, protocolMinorVersion));
         var profile = ProtocolFeatureRegistry.resolve(target);
         var parsed = CostModelParser.parse(costModelValues, language, protocolMajorVersion, protocolMinorVersion);
+        parsed.warnings().forEach(warning ->
+                LOGGER.log(System.Logger.Level.WARNING, warning.message()));
         var configured = new ConfiguredCostModel(parsed, target, profile);
         switch (language) {
             case PLUTUS_V1 -> this.customV1CostModel = configured;

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParser.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParser.java
@@ -3,8 +3,11 @@ package com.bloxbean.cardano.julc.vm.java.cost;
 import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 
+import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.bloxbean.cardano.julc.vm.java.cost.CostFunction.*;
 
@@ -20,11 +23,61 @@ import static com.bloxbean.cardano.julc.vm.java.cost.CostFunction.*;
  * <p>The order is append-only rather than globally alphabetical. In particular,
  * V1, V2, and V3 have different legacy cost-function shapes and different
  * locations for later machine and builtin parameters.</p>
+ *
+ * <p>For a known schema, a missing trailing value is replaced with
+ * {@link Long#MAX_VALUE} and reported through {@link ParsedCostModel#warnings()},
+ * matching Plutus's {@code CMTooFewParamsWarn}. Extra values are rejected so a
+ * future schema cannot be mistaken for a known protocol profile.</p>
  */
 public final class CostModelParser {
 
-    /** Result of parsing a flat cost model array. */
-    public record ParsedCostModel(MachineCosts machineCosts, BuiltinCostModel builtinCostModel) {}
+    /** A non-fatal warning produced while applying a known cost-model schema. */
+    public sealed interface CostModelParseWarning permits TooFewParametersWarning {
+        PlutusLanguage language();
+
+        int protocolMajorVersion();
+
+        int expected();
+
+        int actual();
+
+        String message();
+    }
+
+    /**
+     * Equivalent to Plutus's {@code CMTooFewParamsWarn}. Missing trailing
+     * parameters are represented by {@link Long#MAX_VALUE} in the parsed model.
+     */
+    public record TooFewParametersWarning(
+            PlutusLanguage language,
+            int protocolMajorVersion,
+            int expected,
+            int actual) implements CostModelParseWarning {
+
+        @Override
+        public String message() {
+            return language + " PV" + protocolMajorVersion
+                    + " cost model has too few parameters: expected " + expected
+                    + ", got " + actual
+                    + "; missing trailing parameters were set to Long.MAX_VALUE";
+        }
+    }
+
+    /** Result of parsing a flat cost model array, including non-fatal warnings. */
+    public record ParsedCostModel(
+            MachineCosts machineCosts,
+            BuiltinCostModel builtinCostModel,
+            List<CostModelParseWarning> warnings) {
+
+        public ParsedCostModel {
+            warnings = List.copyOf(warnings);
+        }
+
+        public ParsedCostModel(
+                MachineCosts machineCosts, BuiltinCostModel builtinCostModel) {
+            this(machineCosts, builtinCostModel, List.of());
+        }
+    }
 
     /** Plutus V1 before PV11. Retained under the original public name. */
     public static final int V1_PARAM_COUNT = 166;
@@ -64,7 +117,8 @@ public final class CostModelParser {
      * @param values   the flat cost model array from protocol parameters
      * @param language the Plutus language version
      * @return parsed machine costs and builtin cost model
-     * @throws IllegalArgumentException if the target or exact schema is unsupported
+     * @throws IllegalArgumentException if the target is unsupported or the array
+     *                                  has more values than the known schema
      */
     public static ParsedCostModel parse(long[] values, PlutusLanguage language) {
         return parse(values, language, 10, 0);
@@ -86,7 +140,8 @@ public final class CostModelParser {
      * @param protocolMajorVersion the protocol major version (e.g. 9 for Chang, 10 for Plomin)
      * @param protocolMinorVersion the protocol minor version
      * @return parsed machine costs and builtin cost model
-     * @throws IllegalArgumentException if the target or exact schema is unsupported
+     * @throws IllegalArgumentException if the target is unsupported or the array
+     *                                  has more values than the known schema
      */
     public static ParsedCostModel parse(long[] values, PlutusLanguage language,
                                          int protocolMajorVersion, int protocolMinorVersion) {
@@ -144,7 +199,9 @@ public final class CostModelParser {
     }
 
     private static ParsedCostModel parseV1(long[] values, int protocolMajorVersion) {
-        requireExactSchema(values, PlutusLanguage.PLUTUS_V1, protocolMajorVersion);
+        var schema = normalizeSchema(
+                values, PlutusLanguage.PLUTUS_V1, protocolMajorVersion);
+        values = schema.values();
         Map<DefaultFun, BuiltinCostModel.CostPair> costs = new EnumMap<>(DefaultFun.class);
         int[] cursor = {0};
         LegacySemantics semantics = legacySemantics(protocolMajorVersion);
@@ -170,11 +227,14 @@ public final class CostModelParser {
         }
 
         assertConsumed(cursor, values.length, PlutusLanguage.PLUTUS_V1, protocolMajorVersion);
-        return parsed(machine, constrCpu, constrMem, caseCpu, caseMem, costs);
+        return parsed(machine, constrCpu, constrMem, caseCpu, caseMem,
+                costs, schema.warnings());
     }
 
     private static ParsedCostModel parseV2(long[] values, int protocolMajorVersion) {
-        requireExactSchema(values, PlutusLanguage.PLUTUS_V2, protocolMajorVersion);
+        var schema = normalizeSchema(
+                values, PlutusLanguage.PLUTUS_V2, protocolMajorVersion);
+        values = schema.values();
         Map<DefaultFun, BuiltinCostModel.CostPair> costs = new EnumMap<>(DefaultFun.class);
         int[] cursor = {0};
         LegacySemantics semantics = legacySemantics(protocolMajorVersion);
@@ -201,19 +261,21 @@ public final class CostModelParser {
         }
 
         assertConsumed(cursor, values.length, PlutusLanguage.PLUTUS_V2, protocolMajorVersion);
-        return parsed(machine, constrCpu, constrMem, caseCpu, caseMem, costs);
+        return parsed(machine, constrCpu, constrMem, caseCpu, caseMem,
+                costs, schema.warnings());
     }
 
     /**
      * Parse a PlutusV3 flat cost model parameter array into machine costs and builtin cost model.
      * <p>
-     * The array must have exactly {@link #PV10_PARAM_COUNT} (297) elements.
+     * The schema contains {@link #PV10_PARAM_COUNT} (297) elements. A shorter
+     * array is padded with {@link Long#MAX_VALUE} and produces a warning.
      * Any builtins not covered by the array (e.g., ExpModInteger in PV10) retain
      * their defaults from {@link DefaultCostModel}.
      *
      * @param values the flat cost model array from protocol parameters
      * @return parsed machine costs and builtin cost model
-     * @throws IllegalArgumentException if the target or exact schema is unsupported
+     * @throws IllegalArgumentException if the array contains more than 297 values
      */
     public static ParsedCostModel parse(long[] values) {
         return parse(values, 10);
@@ -227,10 +289,13 @@ public final class CostModelParser {
      * @param values               the flat cost model array from protocol parameters
      * @param protocolMajorVersion the protocol major version
      * @return parsed machine costs and builtin cost model
-     * @throws IllegalArgumentException if the target or exact schema is unsupported
+     * @throws IllegalArgumentException if the target is unsupported or the array
+     *                                  has more values than the known schema
      */
     public static ParsedCostModel parse(long[] values, int protocolMajorVersion) {
-        requireExactSchema(values, PlutusLanguage.PLUTUS_V3, protocolMajorVersion);
+        var schema = normalizeSchema(
+                values, PlutusLanguage.PLUTUS_V3, protocolMajorVersion);
+        values = schema.values();
 
         // Start with defaults for builtins not covered by the flat array
         var defaultModel = DefaultCostModel.defaultBuiltinCostModel(
@@ -502,7 +567,8 @@ public final class CostModelParser {
                 caseCpu, caseMem
         );
 
-        return new ParsedCostModel(mc, new BuiltinCostModel(costs));
+        return new ParsedCostModel(
+                mc, new BuiltinCostModel(costs), schema.warnings());
     }
 
     // ========== V1/V2 authoritative ParamName readers ==========
@@ -899,21 +965,39 @@ public final class CostModelParser {
             long constrMem,
             long caseCpu,
             long caseMem,
-            Map<DefaultFun, BuiltinCostModel.CostPair> costs) {
+            Map<DefaultFun, BuiltinCostModel.CostPair> costs,
+            List<CostModelParseWarning> warnings) {
         return new ParsedCostModel(
                 common.withConstrAndCase(constrCpu, constrMem, caseCpu, caseMem),
-                new BuiltinCostModel(costs));
+                new BuiltinCostModel(costs),
+                warnings);
     }
 
-    private static void requireExactSchema(
+    private record NormalizedSchema(
+            long[] values, List<CostModelParseWarning> warnings) {
+    }
+
+    private static NormalizedSchema normalizeSchema(
             long[] values, PlutusLanguage language, int protocolMajorVersion) {
+        Objects.requireNonNull(values, "Cost model parameters must not be null");
         int expected = expectedParameterCount(language, protocolMajorVersion);
-        if (values.length != expected) {
+        if (values.length > expected) {
             throw new IllegalArgumentException(
                     language + " PV" + protocolMajorVersion
-                            + " cost model requires exactly " + expected
+                            + " cost model accepts at most " + expected
                             + " parameters, got " + values.length);
         }
+        if (values.length == expected) {
+            return new NormalizedSchema(values, List.of());
+        }
+
+        int actual = values.length;
+        long[] padded = Arrays.copyOf(values, expected);
+        Arrays.fill(padded, actual, expected, Long.MAX_VALUE);
+        return new NormalizedSchema(
+                padded,
+                List.of(new TooFewParametersWarning(
+                        language, protocolMajorVersion, expected, actual)));
     }
 
     private static void assertConsumed(

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/LanguageVersionTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/LanguageVersionTest.java
@@ -388,15 +388,27 @@ class LanguageVersionTest {
     class CostModelParsing {
 
         @Test
-        void v1_parser_rejects_too_short_array() {
-            assertThrows(IllegalArgumentException.class,
-                    () -> CostModelParser.parse(new long[100], PlutusLanguage.PLUTUS_V1));
+        void v1_parser_pads_too_short_array() {
+            var parsed = CostModelParser.parse(
+                    new long[100], PlutusLanguage.PLUTUS_V1);
+
+            var warning = assertInstanceOf(
+                    CostModelParser.TooFewParametersWarning.class,
+                    parsed.warnings().getFirst());
+            assertEquals(CostModelParser.V1_PARAM_COUNT, warning.expected());
+            assertEquals(100, warning.actual());
         }
 
         @Test
-        void v2_parser_rejects_too_short_array() {
-            assertThrows(IllegalArgumentException.class,
-                    () -> CostModelParser.parse(new long[100], PlutusLanguage.PLUTUS_V2));
+        void v2_parser_pads_too_short_array() {
+            var parsed = CostModelParser.parse(
+                    new long[100], PlutusLanguage.PLUTUS_V2);
+
+            var warning = assertInstanceOf(
+                    CostModelParser.TooFewParametersWarning.class,
+                    parsed.warnings().getFirst());
+            assertEquals(CostModelParser.V2_PV10_PARAM_COUNT, warning.expected());
+            assertEquals(100, warning.actual());
         }
 
         @Test

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParserTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParserTest.java
@@ -149,11 +149,14 @@ class CostModelParserTest {
     }
 
     @Test
-    void parse_wrongArrayLength_throws() {
-        assertThrows(IllegalArgumentException.class, () ->
-                CostModelParser.parse(new long[10]));
-        assertThrows(IllegalArgumentException.class, () ->
-                CostModelParser.parse(new long[296]));
+    void parse_shortArray_padsAndWarns() {
+        var parsed = CostModelParser.parse(new long[296]);
+
+        var warning = assertInstanceOf(
+                CostModelParser.TooFewParametersWarning.class,
+                assertDoesNotThrow(() -> parsed.warnings().getFirst()));
+        assertEquals(297, warning.expected());
+        assertEquals(296, warning.actual());
     }
 
     @Test
@@ -279,12 +282,14 @@ class CostModelParserTest {
     }
 
     @Test
-    void parse_pv11_wrongArrayLength_throws() {
-        // PV11 parse should reject arrays shorter than 350
-        assertThrows(IllegalArgumentException.class, () ->
-                CostModelParser.parse(new long[297], 11));
-        assertThrows(IllegalArgumentException.class, () ->
-                CostModelParser.parse(new long[349], 11));
+    void parse_pv11_shortArray_padsAndWarns() {
+        var parsed = CostModelParser.parse(new long[349], 11);
+
+        var warning = assertInstanceOf(
+                CostModelParser.TooFewParametersWarning.class,
+                parsed.warnings().getFirst());
+        assertEquals(350, warning.expected());
+        assertEquals(349, warning.actual());
     }
 
     @Test

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/ShortCostModelArrayTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/ShortCostModelArrayTest.java
@@ -1,0 +1,146 @@
+package com.bloxbean.cardano.julc.vm.java.cost;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.vm.ExBudget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.java.CekValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Compatibility tests for Plutus {@code CMTooFewParamsWarn}: known schemas
+ * preserve their supplied prefix and pad missing names with {@code maxBound}.
+ */
+class ShortCostModelArrayTest {
+
+    private record Schema(PlutusLanguage language, int protocol, int count) {
+    }
+
+    private static final List<Schema> SCHEMAS = List.of(
+            new Schema(PlutusLanguage.PLUTUS_V1, 5, 166),
+            new Schema(PlutusLanguage.PLUTUS_V1, 9, 166),
+            new Schema(PlutusLanguage.PLUTUS_V1, 11, 332),
+            new Schema(PlutusLanguage.PLUTUS_V2, 7, 175),
+            new Schema(PlutusLanguage.PLUTUS_V2, 9, 175),
+            new Schema(PlutusLanguage.PLUTUS_V2, 10, 185),
+            new Schema(PlutusLanguage.PLUTUS_V2, 11, 332),
+            new Schema(PlutusLanguage.PLUTUS_V3, 10, 297),
+            new Schema(PlutusLanguage.PLUTUS_V3, 11, 350));
+
+    @Test
+    void missingOneSeveralAndAllParametersMatchExplicitHaskellPadding() {
+        for (var schema : SCHEMAS) {
+            for (int missing : List.of(1, 7, schema.count())) {
+                int actual = schema.count() - missing;
+                long[] supplied = indexedValues(actual);
+                long[] explicitlyPadded = Arrays.copyOf(supplied, schema.count());
+                Arrays.fill(explicitlyPadded, actual, schema.count(), Long.MAX_VALUE);
+
+                var incomplete = parse(supplied, schema);
+                var nodeEquivalent = parse(explicitlyPadded, schema);
+
+                var warning = assertInstanceOf(
+                        CostModelParser.TooFewParametersWarning.class,
+                        assertSingleWarning(incomplete, schema));
+                assertEquals(schema.language(), warning.language(), schema.toString());
+                assertEquals(schema.protocol(), warning.protocolMajorVersion(), schema.toString());
+                assertEquals(schema.count(), warning.expected(), schema.toString());
+                assertEquals(actual, warning.actual(), schema.toString());
+                assertTrue(warning.message().contains("Long.MAX_VALUE"), schema.toString());
+
+                assertTrue(nodeEquivalent.warnings().isEmpty(), schema.toString());
+                assertEquals(nodeEquivalent.machineCosts(), incomplete.machineCosts(), schema.toString());
+                assertArrayEquals(explicitlyPadded, serialize(incomplete, schema), schema.toString());
+                assertArrayEquals(serialize(nodeEquivalent, schema),
+                        serialize(incomplete, schema), schema.toString());
+            }
+        }
+    }
+
+    @Test
+    void exactSchemasDoNotWarnAndWarningsAreImmutable() {
+        for (var schema : SCHEMAS) {
+            var exact = parse(indexedValues(schema.count()), schema);
+            assertTrue(exact.warnings().isEmpty(), schema.toString());
+
+            var shortModel = parse(new long[schema.count() - 1], schema);
+            assertThrows(UnsupportedOperationException.class, () ->
+                    shortModel.warnings().add(new CostModelParser.TooFewParametersWarning(
+                            schema.language(), schema.protocol(), schema.count(), 0)));
+        }
+    }
+
+    @Test
+    void paddedMachineAndBuiltinPricesExhaustARealisticBudget() {
+        var args = List.<CekValue>of(
+                new CekValue.VCon(Constant.integer(1)),
+                new CekValue.VCon(Constant.integer(2)));
+        var budget = new ExBudget(10_000_000, 10_000_000);
+
+        for (var schema : SCHEMAS) {
+            var parsed = parse(new long[0], schema);
+            var addCost = parsed.builtinCostModel().get(DefaultFun.AddInteger);
+            assertNotNull(addCost, schema.toString());
+            assertEquals(Long.MAX_VALUE, addCost.cpu().apply(1, 1), schema.toString());
+            assertEquals(Long.MAX_VALUE, addCost.mem().apply(1, 1), schema.toString());
+
+            var machineTracker = new CostTracker(
+                    parsed.machineCosts(), parsed.builtinCostModel(), budget);
+            assertThrows(BudgetExhaustedException.class, () ->
+                    machineTracker.chargeMachineStep(MachineCosts.StepKind.STARTUP),
+                    "machine " + schema);
+
+            var builtinTracker = new CostTracker(
+                    parsed.machineCosts(), parsed.builtinCostModel(), budget);
+            assertThrows(BudgetExhaustedException.class, () ->
+                    builtinTracker.chargeBuiltin(DefaultFun.AddInteger, args),
+                    "builtin " + schema);
+        }
+    }
+
+    @Test
+    void extraParametersAndUnknownProfilesStillFail() {
+        for (var schema : SCHEMAS) {
+            assertThrows(IllegalArgumentException.class, () ->
+                    parse(new long[schema.count() + 1], schema), schema.toString());
+        }
+
+        assertThrows(IllegalArgumentException.class, () -> CostModelParser.parse(
+                new long[0], PlutusLanguage.PLUTUS_V1, 12, 0));
+        assertThrows(IllegalArgumentException.class, () -> CostModelParser.parse(
+                new long[0], PlutusLanguage.PLUTUS_V2, 12, 0));
+        assertThrows(IllegalArgumentException.class, () -> CostModelParser.parse(
+                new long[0], PlutusLanguage.PLUTUS_V3, 12, 0));
+    }
+
+    private static CostModelParser.CostModelParseWarning assertSingleWarning(
+            CostModelParser.ParsedCostModel parsed, Schema schema) {
+        assertEquals(1, parsed.warnings().size(), schema.toString());
+        return parsed.warnings().getFirst();
+    }
+
+    private static CostModelParser.ParsedCostModel parse(long[] values, Schema schema) {
+        return CostModelParser.parse(
+                values, schema.language(), schema.protocol(), 0);
+    }
+
+    private static long[] serialize(
+            CostModelParser.ParsedCostModel parsed, Schema schema) {
+        return CostModelParser.toFlatArray(
+                parsed.machineCosts(), parsed.builtinCostModel(),
+                schema.language(), schema.protocol());
+    }
+
+    private static long[] indexedValues(int count) {
+        long[] values = new long[count];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = 10_000L + i;
+        }
+        return values;
+    }
+}

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/ShortCostModelArrayTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/ShortCostModelArrayTest.java
@@ -29,6 +29,7 @@ class ShortCostModelArrayTest {
             new Schema(PlutusLanguage.PLUTUS_V2, 9, 175),
             new Schema(PlutusLanguage.PLUTUS_V2, 10, 185),
             new Schema(PlutusLanguage.PLUTUS_V2, 11, 332),
+            new Schema(PlutusLanguage.PLUTUS_V3, 9, 251),
             new Schema(PlutusLanguage.PLUTUS_V3, 10, 297),
             new Schema(PlutusLanguage.PLUTUS_V3, 11, 350));
 

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/V1V2CostModelParserTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/V1V2CostModelParserTest.java
@@ -81,11 +81,8 @@ class V1V2CostModelParserTest {
     }
 
     @Test
-    void exactSchemaLengthsDoNotInferUnknownLayouts() {
+    void extraParametersDoNotInferUnknownLayouts() {
         for (var schema : SCHEMAS) {
-            assertThrows(IllegalArgumentException.class, () -> CostModelParser.parse(
-                    new long[schema.count() - 1], schema.language(), schema.protocol(), 0),
-                    "short " + schema);
             assertThrows(IllegalArgumentException.class, () -> CostModelParser.parse(
                     new long[schema.count() + 1], schema.language(), schema.protocol(), 0),
                     "long " + schema);

--- a/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/TruffleVmProvider.java
+++ b/julc-vm-truffle/src/main/java/com/bloxbean/cardano/julc/vm/truffle/TruffleVmProvider.java
@@ -31,6 +31,9 @@ import java.util.List;
  */
 public class TruffleVmProvider implements JulcVmProvider {
 
+    private static final System.Logger LOGGER =
+            System.getLogger(TruffleVmProvider.class.getName());
+
     private volatile ConfiguredCostModel customV1CostModel;
     private volatile ConfiguredCostModel customV2CostModel;
     private volatile ConfiguredCostModel customV3CostModel;
@@ -42,6 +45,8 @@ public class TruffleVmProvider implements JulcVmProvider {
                 language, new ProtocolVersion(protocolMajorVersion, protocolMinorVersion));
         var profile = ProtocolFeatureRegistry.resolve(target);
         var parsed = CostModelParser.parse(costModelValues, language, protocolMajorVersion, protocolMinorVersion);
+        parsed.warnings().forEach(warning ->
+                LOGGER.log(System.Logger.Level.WARNING, warning.message()));
         var configured = new ConfiguredCostModel(parsed, target, profile);
         switch (language) {
             case PLUTUS_V1 -> this.customV1CostModel = configured;


### PR DESCRIPTION
## Summary

- Match Plutus tagWithParamNames behavior for too-short arrays in every supported V1, V2, and V3 schema.
- Preserve the supplied prefix and pad missing trailing coefficients with Long.MAX_VALUE, matching maxBound :: Int64.
- Surface expected and actual parameter counts as visible parser warnings.
- Retain saturating, fail-loudly budget behavior for padded prices in Java and Truffle configuration paths.
- Add coverage for one, several, and extensive missing coefficients, including the V3/PV9 schema.

## Normative baseline

cardano-node 11.0.1, Plutus 1.63.0.0 at commit f92b7d7d82622a26caf456a6be33859f697e2cfc.

## Verification

The resulting #63 tree is byte-identical to the previously tested and independently reviewed implementation. The complete reviewed stack passed 10,135 tests with 533 skips and no failures.

## PR stack

This is PR 3 of 5, stacked on #69. Review this PR as the delta from `fix/62-v1-v2-cost-model-parsing`.

Closes #63
Related to #61 and #65.

## Merge and CI sequence

The repository Build & Test workflow runs only for PRs targeting `main`, `develop`, or `release/*`. Preserve the focused stacked diff by merging in order `#68 → #69 → #70 → #71 → #72`: after each predecessor lands, retarget this PR to `main`, require its CI run to pass, and then merge it. Do not merge this PR into its temporary feature-branch base.