### PR TITLE
fix(vm-java): fail closed on incomplete builtin cost models

### DIFF
--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/BuiltinCostModel.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/BuiltinCostModel.java
@@ -5,11 +5,16 @@ import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.vm.java.CekValue;
 import com.bloxbean.cardano.julc.vm.BuiltinSemanticsVariant;
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureProfile;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Maps each builtin function to its CPU and memory cost functions.
@@ -25,17 +30,62 @@ import java.util.Map;
 public final class BuiltinCostModel {
 
     /** CPU and memory cost function pair for a builtin. */
-    public record CostPair(CostFunction cpu, CostFunction mem) {}
+    public record CostPair(CostFunction cpu, CostFunction mem) {
+        public CostPair {
+            if (cpu == null || mem == null) {
+                throw new IncompleteCostModelException(
+                        "A builtin cost pair must contain both CPU and memory costs"
+                                + " (cpu=" + cpu + ", mem=" + mem + ")");
+            }
+        }
+    }
 
     private final Map<DefaultFun, CostPair> costs;
 
     public BuiltinCostModel(Map<DefaultFun, CostPair> costs) {
-        this.costs = new EnumMap<>(costs);
+        Objects.requireNonNull(costs, "costs");
+        var copy = new EnumMap<DefaultFun, CostPair>(DefaultFun.class);
+        for (var entry : costs.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                throw new IncompleteCostModelException(
+                        "Builtin cost model entries must have a builtin and both CPU/memory costs"
+                                + " (builtin=" + entry.getKey() + ", cost=" + entry.getValue() + ")");
+            }
+            copy.put(entry.getKey(), entry.getValue());
+        }
+        this.costs = copy;
     }
 
     /** Get the cost pair for a builtin, or null if not registered. */
     public CostPair get(DefaultFun fun) {
         return costs.get(fun);
+    }
+
+    /** The builtins which have complete CPU/memory prices in this model. */
+    public Set<DefaultFun> costedBuiltins() {
+        var costed = EnumSet.noneOf(DefaultFun.class);
+        costed.addAll(costs.keySet());
+        return Collections.unmodifiableSet(costed);
+    }
+
+    /**
+     * Return the available builtins that have no complete price in this model.
+     * Builtins unavailable to the profile are deliberately ignored.
+     */
+    public Set<DefaultFun> missingCostsFor(ProtocolFeatureProfile profile) {
+        Objects.requireNonNull(profile, "profile");
+        var missing = EnumSet.noneOf(DefaultFun.class);
+        missing.addAll(profile.availableBuiltins());
+        missing.removeAll(costs.keySet());
+        return Collections.unmodifiableSet(missing);
+    }
+
+    /** Fail unless every builtin available to the profile has a price. */
+    public void validateCompleteFor(ProtocolFeatureProfile profile) {
+        var missing = missingCostsFor(profile);
+        if (!missing.isEmpty()) {
+            throw IncompleteCostModelException.missing(profile, missing);
+        }
     }
 
     /**

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/ConfiguredCostModel.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/ConfiguredCostModel.java
@@ -5,7 +5,11 @@ import com.bloxbean.cardano.julc.vm.ProtocolFeatureProfile;
 
 import java.util.Objects;
 
-/** A parsed cost model atomically associated with its resolved ledger profile. */
+/**
+ * A parsed cost model atomically associated with its resolved ledger profile.
+ * Construction enforces the shared Java/Truffle completeness invariant before
+ * either backend can start CEK evaluation.
+ */
 public record ConfiguredCostModel(
         CostModelParser.ParsedCostModel costModel,
         LedgerEvaluationTarget target,
@@ -19,5 +23,6 @@ public record ConfiguredCostModel(
             throw new IllegalArgumentException(
                     "Cost model target " + target + " does not match profile " + profile.target());
         }
+        costModel.builtinCostModel().validateCompleteFor(profile);
     }
 }

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/CostTracker.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/CostTracker.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
 import com.bloxbean.cardano.julc.vm.ProtocolFeatureProfile;
 import com.bloxbean.cardano.julc.vm.ProtocolFeatureRegistry;
 import com.bloxbean.cardano.julc.vm.java.CekValue;
+import com.bloxbean.cardano.julc.vm.java.builtins.UnsupportedBuiltinException;
 
 import java.util.List;
 
@@ -74,13 +75,18 @@ public final class CostTracker {
      *
      * @param fun  the builtin function
      * @param args the evaluated arguments
+     * @throws UnsupportedBuiltinException if the builtin is unavailable to the profile
+     * @throws IncompleteCostModelException if an available builtin has no price
      * @throws BudgetExhaustedException if budget is exceeded
      */
     public void chargeBuiltin(DefaultFun fun, List<CekValue> args) {
+        if (!profile.isBuiltinAvailable(fun)) {
+            throw new UnsupportedBuiltinException(
+                    "Builtin " + fun + " is not available for " + profile.target());
+        }
         var costPair = builtinCostModel.get(fun);
         if (costPair == null) {
-            // No cost model for this builtin — charge nothing
-            return;
+            throw IncompleteCostModelException.missing(profile, List.of(fun));
         }
         long[] sizes = BuiltinCostModel.argSizes(profile.semanticsVariant(), fun, args);
         long cpu = costPair.cpu().apply(sizes);

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/DefaultCostModel.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/DefaultCostModel.java
@@ -41,7 +41,9 @@ public final class DefaultCostModel {
             var cost = variantModel.get(fun);
             if (cost != null) filtered.put(fun, cost);
         }
-        return new BuiltinCostModel(filtered);
+        var model = new BuiltinCostModel(filtered);
+        model.validateCompleteFor(profile);
+        return model;
     }
 
     /** Select the builtin model shipped for a Haskell semantics variant. */

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/IncompleteCostModelException.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/IncompleteCostModelException.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.julc.vm.java.cost;
+
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureProfile;
+import com.bloxbean.cardano.julc.vm.java.CekEvaluationException;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Objects;
+
+/**
+ * Indicates that a builtin which is available to an evaluation profile has no
+ * complete CPU/memory price in the selected cost model.
+ * <p>
+ * This is an evaluator-configuration error, not a zero-cost builtin. It is a
+ * {@link CekEvaluationException} so a defensive failure at the charging
+ * boundary is reported through the normal VM failure path.
+ */
+public final class IncompleteCostModelException extends CekEvaluationException {
+
+    public IncompleteCostModelException(String message) {
+        super(message);
+    }
+
+    static IncompleteCostModelException missing(
+            ProtocolFeatureProfile profile, Collection<DefaultFun> missingBuiltins) {
+        Objects.requireNonNull(profile, "profile");
+        Objects.requireNonNull(missingBuiltins, "missingBuiltins");
+        var ordered = missingBuiltins.isEmpty()
+                ? EnumSet.noneOf(DefaultFun.class)
+                : EnumSet.copyOf(missingBuiltins);
+        return new IncompleteCostModelException(
+                "Incomplete builtin cost model for " + profile.target()
+                        + ": missing CPU/memory cost for " + ordered);
+    }
+}

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/BuiltinCostCompletenessTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/BuiltinCostCompletenessTest.java
@@ -1,0 +1,152 @@
+package com.bloxbean.cardano.julc.vm.java.cost;
+
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.vm.ExBudget;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureProfile;
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureRegistry;
+import com.bloxbean.cardano.julc.vm.ProtocolVersion;
+import com.bloxbean.cardano.julc.vm.java.CekValue;
+import com.bloxbean.cardano.julc.vm.java.builtins.UnsupportedBuiltinException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BuiltinCostCompletenessTest {
+
+    private record Target(PlutusLanguage language, int protocol) {
+        ProtocolFeatureProfile profile() {
+            return ProtocolFeatureRegistry.resolve(new LedgerEvaluationTarget(
+                    language, new ProtocolVersion(protocol, 0)));
+        }
+    }
+
+    private static final List<Target> SUPPORTED_TARGETS = List.of(
+            new Target(PlutusLanguage.PLUTUS_V1, 5),
+            new Target(PlutusLanguage.PLUTUS_V1, 6),
+            new Target(PlutusLanguage.PLUTUS_V1, 7),
+            new Target(PlutusLanguage.PLUTUS_V1, 8),
+            new Target(PlutusLanguage.PLUTUS_V1, 9),
+            new Target(PlutusLanguage.PLUTUS_V1, 10),
+            new Target(PlutusLanguage.PLUTUS_V1, 11),
+            new Target(PlutusLanguage.PLUTUS_V2, 7),
+            new Target(PlutusLanguage.PLUTUS_V2, 8),
+            new Target(PlutusLanguage.PLUTUS_V2, 9),
+            new Target(PlutusLanguage.PLUTUS_V2, 10),
+            new Target(PlutusLanguage.PLUTUS_V2, 11),
+            new Target(PlutusLanguage.PLUTUS_V3, 9),
+            new Target(PlutusLanguage.PLUTUS_V3, 10),
+            new Target(PlutusLanguage.PLUTUS_V3, 11));
+
+    @Test
+    void defaultModelsExactlyCoverEverySupportedProfile() {
+        for (var target : SUPPORTED_TARGETS) {
+            var profile = target.profile();
+            var model = DefaultCostModel.defaultBuiltinCostModel(profile);
+
+            assertDoesNotThrow(() -> model.validateCompleteFor(profile), target.toString());
+            assertEquals(profile.availableBuiltins(), model.costedBuiltins(), target.toString());
+        }
+    }
+
+    @Test
+    void parsedModelsCoverEverySupportedSchema() {
+        for (var target : SUPPORTED_TARGETS) {
+            var profile = target.profile();
+            long[] values = new long[profile.costModelSchema().parameterCount()];
+            Arrays.fill(values, 1);
+
+            var parsed = CostModelParser.parse(
+                    values, target.language(), target.protocol(), 0);
+
+            assertDoesNotThrow(
+                    () -> new ConfiguredCostModel(parsed, profile.target(), profile),
+                    target.toString());
+            assertTrue(parsed.builtinCostModel().missingCostsFor(profile).isEmpty(),
+                    target.toString());
+        }
+    }
+
+    @Test
+    void configuredModelRejectsAnAvailableBuiltinWithoutAPrice() {
+        var profile = new Target(PlutusLanguage.PLUTUS_V2, 10).profile();
+        var complete = DefaultCostModel.defaultBuiltinCostModel(profile);
+        var incomplete = without(complete, DefaultFun.IntegerToByteString);
+        var parsed = new CostModelParser.ParsedCostModel(
+                DefaultCostModel.defaultMachineCosts(profile), incomplete);
+
+        var error = assertThrows(IncompleteCostModelException.class,
+                () -> new ConfiguredCostModel(parsed, profile.target(), profile));
+
+        assertTrue(error.getMessage().contains(profile.target().toString()));
+        assertTrue(error.getMessage().contains("IntegerToByteString"));
+        assertEquals(Set.of(DefaultFun.IntegerToByteString),
+                incomplete.missingCostsFor(profile));
+    }
+
+    @Test
+    void costPairRequiresBothCpuAndMemoryPrices() {
+        var one = new CostFunction.ConstantCost(1);
+
+        assertThrows(IncompleteCostModelException.class,
+                () -> new BuiltinCostModel.CostPair(null, one));
+        assertThrows(IncompleteCostModelException.class,
+                () -> new BuiltinCostModel.CostPair(one, null));
+    }
+
+    @Test
+    void chargingBoundaryFailsClosedAndNeverReportsZeroCostSuccess() {
+        var profile = new Target(PlutusLanguage.PLUTUS_V3, 10).profile();
+        var model = without(
+                DefaultCostModel.defaultBuiltinCostModel(profile), DefaultFun.AddInteger);
+        var tracker = new CostTracker(
+                DefaultCostModel.defaultMachineCosts(profile), model, profile, null);
+        var args = List.<CekValue>of(
+                new CekValue.VCon(Constant.integer(1)),
+                new CekValue.VCon(Constant.integer(2)));
+
+        var error = assertThrows(IncompleteCostModelException.class,
+                () -> tracker.chargeBuiltin(DefaultFun.AddInteger, args));
+
+        assertTrue(error.getMessage().contains("AddInteger"));
+        assertEquals(ExBudget.ZERO, tracker.consumed());
+    }
+
+    @Test
+    void unavailableBuiltinIsNotMistakenForAMissingPrice() {
+        var profile = new Target(PlutusLanguage.PLUTUS_V3, 10).profile();
+        var model = DefaultCostModel.defaultBuiltinCostModel(profile);
+
+        assertFalse(profile.isBuiltinAvailable(DefaultFun.DropList));
+        assertNull(model.get(DefaultFun.DropList));
+        assertDoesNotThrow(() -> model.validateCompleteFor(profile));
+        assertDoesNotThrow(() -> new ConfiguredCostModel(
+                new CostModelParser.ParsedCostModel(
+                        DefaultCostModel.defaultMachineCosts(profile), model),
+                profile.target(), profile));
+
+        var tracker = new CostTracker(
+                DefaultCostModel.defaultMachineCosts(profile), model, profile, null);
+        var error = assertThrows(UnsupportedBuiltinException.class,
+                () -> tracker.chargeBuiltin(DefaultFun.DropList, List.of()));
+        assertTrue(error.getMessage().contains("not available"));
+        assertEquals(ExBudget.ZERO, tracker.consumed());
+    }
+
+    private static BuiltinCostModel without(BuiltinCostModel model, DefaultFun omitted) {
+        var costs = new EnumMap<DefaultFun, BuiltinCostModel.CostPair>(DefaultFun.class);
+        for (var fun : model.costedBuiltins()) {
+            if (fun != omitted) {
+                costs.put(fun, model.get(fun));
+            }
+        }
+        return new BuiltinCostModel(costs);
+    }
+}

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/BuiltinCostSizingTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/BuiltinCostSizingTest.java
@@ -4,6 +4,9 @@ import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.vm.BuiltinSemanticsVariant;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureRegistry;
 import com.bloxbean.cardano.julc.vm.java.CekValue;
 import org.junit.jupiter.api.Test;
 
@@ -277,9 +280,12 @@ class BuiltinCostSizingTest {
     // === Helpers ===
 
     private static com.bloxbean.cardano.julc.vm.ExBudget charge(DefaultFun fun, CekValue... args) {
+        var profile = ProtocolFeatureRegistry.resolve(
+                LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3));
         var tracker = new CostTracker(
-                DefaultCostModel.defaultMachineCosts(),
-                DefaultCostModel.defaultBuiltinCostModel(),
+                DefaultCostModel.defaultMachineCosts(profile),
+                DefaultCostModel.defaultBuiltinCostModel(profile),
+                profile,
                 null);
         tracker.chargeBuiltin(fun, List.of(args));
         return tracker.consumed();


### PR DESCRIPTION
## Summary

- Validate that every builtin available to a configured language/protocol profile has both CPU and memory prices.
- Reject incomplete profiles before CEK execution where possible.
- Make CostTracker fail defensively with a specific exception if a missing entry reaches the charging boundary.
- Keep unavailable-builtin errors distinct from available-but-unpriced configuration errors.
- Add completeness coverage for default and parsed profiles across supported targets and both evaluator backends.

## Normative baseline

cardano-node 11.0.1, Plutus 1.63.0.0 at commit f92b7d7d82622a26caf456a6be33859f697e2cfc.

## Verification

Tests prove that incomplete models cannot execute a builtin for zero CPU or memory. The resulting #64 tree is byte-identical to the previously tested and independently reviewed implementation. The complete reviewed stack passed 10,135 tests with 533 skips and no failures.

## PR stack

This is PR 4 of 5, stacked on #70. Review this PR as the delta from `fix/63-short-cost-model-arrays`.

Closes #64
Related to #61 and #65.

## Merge and CI sequence

The repository Build & Test workflow runs only for PRs targeting `main`, `develop`, or `release/*`. Preserve the focused stacked diff by merging in order `#68 → #69 → #70 → #71 → #72`: after each predecessor lands, retarget this PR to `main`, require its CI run to pass, and then merge it. Do not merge this PR into its temporary feature-branch base.