### PR TITLE
Match node 11.0.1 SerialisedScript CBOR decoding

### DIFF
--- a/adr/030-protocol-version-propagation-and-pv11-builtin-semantics.md
+++ b/adr/030-protocol-version-propagation-and-pv11-builtin-semantics.md
@@ -593,13 +593,20 @@ the same node/Plutus pin:
 - V3 rejects bytes remaining after the inner serialized-script CBOR item;
   V1/V2 retain the pinned historical tolerance. Restricting-budget subtraction
   uses `SatInt`-equivalent saturation.
+- The inner ledger `SerialisedScript` accepts exactly cborg `decodeBytes`'
+  untagged, definite-length header range (`0x40..0x5b`). Tagged, indefinite,
+  and reserved forms are rejected before cbor-java can normalize them, while
+  non-canonical definite lengths remain accepted. This shape check deliberately
+  also applies to the no-target tooling path: its trailing-remainder tolerance
+  is historical behavior, whereas accepting alternate wrapper shapes was not.
 - Historical variant A defaults and CEK costs, variant D's canonical
   `linear_in_y2` representation, minor-version compatibility, and explicit
   PV11 debugger profile selection are covered by pinned regression tests.
 
-The Java/Truffle evaluator is exact against node 11.0.1 within this scope; the
-sole known decode-boundary exclusion is the adversarial-input phase-1 CBOR
-wrapper divergence tracked in [#67](https://github.com/bloxbean/julc/issues/67).
+The Java/Truffle evaluator and client-library ledger decode path are exact
+against node 11.0.1 within this scope, including adversarial inner-wrapper
+inputs. Permissive format-inspection tools outside ledger evaluation remain
+outside this claim.
 
 Later Plutus `master` behavior remains intentionally excluded.
 
@@ -653,6 +660,9 @@ Later Plutus `master` behavior remains intentionally excluded.
       values that the pinned Haskell evaluator rejects without narrowing.
 - [x] V3 serialized-script remainders fail while V1/V2 historical remainders
       remain accepted.
+- [x] Inner serialized-script CBOR accepts raw headers `0x40..0x5b`, including
+      non-canonical definite lengths, while tagged, indefinite, and reserved
+      wrappers fail for V1, V2, V3, and the no-target tooling path.
 
 ### Conformance provenance
 

--- a/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/JulcScriptAdapter.java
+++ b/julc-cardano-client-lib/src/main/java/com/bloxbean/cardano/julc/clientlib/JulcScriptAdapter.java
@@ -83,13 +83,16 @@ public final class JulcScriptAdapter {
         byte[] outerBytes = HexFormat.of().parseHex(doubleCborHex);
         // The outer item is cardano-client-lib's transport wrapper and must be
         // a single CBOR bytestring. The inner item is the ledger
-        // SerialisedScript: the no-target tooling path and Plutus V1/V2 preserve
-        // their historical tolerance for trailing bytes, while V3 rejects any
-        // remainder at phase 1.
+        // SerialisedScript. Its wrapper shape is checked for every path because
+        // cborg's decodeBytes accepts only an untagged, definite-length byte
+        // string. Independently, the no-target tooling path and Plutus V1/V2
+        // preserve their historical tolerance for trailing bytes, while V3
+        // rejects any remainder at phase 1.
         byte[] innerBytes = cborUnwrapBytes(outerBytes, false);
         boolean allowScriptRemainder = target == null
                 || target.ledgerLanguage() != PlutusLanguage.PLUTUS_V3;
-        byte[] flatBytes = cborUnwrapBytes(innerBytes, allowScriptRemainder);
+        byte[] flatBytes = cborUnwrapSerialisedScript(
+                innerBytes, allowScriptRemainder);
         if (target == null) {
             // Compatibility/tooling path: callers without ledger context keep
             // the historical unrestricted decoder.
@@ -128,6 +131,35 @@ public final class JulcScriptAdapter {
         } catch (Exception e) {
             throw new RuntimeException("CBOR unwrapping failed", e);
         }
+    }
+
+    /**
+     * Decode the ledger's inner {@code SerialisedScript} exactly like cborg's
+     * {@code decodeBytes}: only raw headers {@code 0x40..0x5b} are accepted.
+     * This deliberately accepts non-canonical definite-length encodings while
+     * rejecting tags, indefinite-length byte strings, and reserved headers
+     * before cbor-java can normalize them.
+     */
+    private static byte[] cborUnwrapSerialisedScript(
+            byte[] cborData, boolean allowRemainder) {
+        if (cborData.length == 0) {
+            throw invalidSerialisedScriptWrapper();
+        }
+
+        int initialByte = Byte.toUnsignedInt(cborData[0]);
+        if (initialByte < 0x40 || initialByte > 0x5b) {
+            throw invalidSerialisedScriptWrapper();
+        }
+
+        // cbor-java still validates the declared length and payload. The raw
+        // header check above only preserves information it would otherwise
+        // discard while decoding tags or joining indefinite chunks.
+        return cborUnwrapBytes(cborData, allowRemainder);
+    }
+
+    private static RuntimeException invalidSerialisedScriptWrapper() {
+        return new RuntimeException(
+                "CBOR SerialisedScript must be an untagged definite-length bytestring");
     }
 
     private static byte[] cborWrapBytes(byte[] data) {

--- a/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/JulcScriptAdapterTest.java
+++ b/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/JulcScriptAdapterTest.java
@@ -16,10 +16,12 @@ import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.model.ByteString;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HexFormat;
@@ -162,6 +164,40 @@ class JulcScriptAdapterTest {
     }
 
     @Test
+    void rejectsTaggedInnerSerialisedScriptForEveryDecodeTarget() {
+        String tagged = tagInnerSerialisedScript(validV1ScriptCbor());
+
+        assertRejectedForEveryDecodeTarget(tagged);
+    }
+
+    @Test
+    void rejectsIndefiniteLengthInnerSerialisedScriptForEveryDecodeTarget() {
+        String indefinite = makeInnerSerialisedScriptIndefinite(validV1ScriptCbor());
+
+        assertRejectedForEveryDecodeTarget(indefinite);
+    }
+
+    @Test
+    void acceptsNonCanonicalEightByteDefiniteLengthHeader() {
+        var original = new Program(1, 0, 0, Term.const_(Constant.unit()));
+        String nonCanonical = useEightByteLengthForInnerSerialisedScript(
+                JulcScriptAdapter.fromProgram(original).getCborHex());
+
+        assertEquals(original, JulcScriptAdapter.toProgram(nonCanonical));
+        for (var language : PlutusLanguage.values()) {
+            assertEquals(original, JulcScriptAdapter.toProgram(
+                    nonCanonical, LedgerEvaluationTarget.pv11(language)));
+        }
+    }
+
+    @Test
+    void rejectsHeaderImmediatelyAboveDefiniteByteStringRange() {
+        String reservedHeader = replaceInnerInitialByte(validV1ScriptCbor(), (byte) 0x5c);
+
+        assertRejectedForEveryDecodeTarget(reservedHeader);
+    }
+
+    @Test
     void toProgramParameterized() {
         // Compile a parameterized validator, decode it, apply CCL params, re-encode
         var source = """
@@ -202,16 +238,86 @@ class JulcScriptAdapterTest {
     }
 
     private static String appendToInnerSerialisedScript(String outerCborHex, byte remainder) {
+        byte[] inner = unwrapOuterCbor(outerCborHex);
+        byte[] withRemainder = Arrays.copyOf(inner, inner.length + 1);
+        withRemainder[withRemainder.length - 1] = remainder;
+        return wrapOuterCbor(withRemainder);
+    }
+
+    private static String validV1ScriptCbor() {
+        var program = new Program(1, 0, 0, Term.const_(Constant.unit()));
+        return JulcScriptAdapter.fromProgram(program).getCborHex();
+    }
+
+    private static void assertRejectedForEveryDecodeTarget(String cborHex) {
+        assertInvalidInnerWrapper(() -> JulcScriptAdapter.toProgram(cborHex));
+        for (var language : PlutusLanguage.values()) {
+            assertInvalidInnerWrapper(() -> JulcScriptAdapter.toProgram(
+                    cborHex, LedgerEvaluationTarget.pv11(language)));
+        }
+    }
+
+    private static void assertInvalidInnerWrapper(Executable decode) {
+        var error = assertThrows(RuntimeException.class, decode);
+        assertTrue(error.getMessage().contains("untagged definite-length bytestring"),
+                "Unexpected error: " + error.getMessage());
+    }
+
+    private static String tagInnerSerialisedScript(String outerCborHex) {
+        byte[] inner = unwrapOuterCbor(outerCborHex);
+        byte[] tagged = new byte[inner.length + 2];
+        tagged[0] = (byte) 0xd8;
+        tagged[1] = 0x18;
+        System.arraycopy(inner, 0, tagged, 2, inner.length);
+        return wrapOuterCbor(tagged);
+    }
+
+    private static String makeInnerSerialisedScriptIndefinite(String outerCborHex) {
+        byte[] inner = unwrapOuterCbor(outerCborHex);
+        byte[] indefinite = new byte[inner.length + 2];
+        indefinite[0] = 0x5f;
+        System.arraycopy(inner, 0, indefinite, 1, inner.length);
+        indefinite[indefinite.length - 1] = (byte) 0xff;
+        return wrapOuterCbor(indefinite);
+    }
+
+    private static String useEightByteLengthForInnerSerialisedScript(String outerCborHex) {
+        byte[] inner = unwrapOuterCbor(outerCborHex);
+        try {
+            var innerItem = new CborDecoder(new ByteArrayInputStream(inner)).decodeNext();
+            byte[] flat = assertInstanceOf(ByteString.class, innerItem).getBytes();
+            byte[] nonCanonical = ByteBuffer.allocate(9 + flat.length)
+                    .put((byte) 0x5b)
+                    .putLong(flat.length)
+                    .put(flat)
+                    .array();
+            return wrapOuterCbor(nonCanonical);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String replaceInnerInitialByte(String outerCborHex, byte replacement) {
+        byte[] inner = unwrapOuterCbor(outerCborHex);
+        inner[0] = replacement;
+        return wrapOuterCbor(inner);
+    }
+
+    private static byte[] unwrapOuterCbor(String outerCborHex) {
         try {
             byte[] outer = HexFormat.of().parseHex(outerCborHex);
             var outerItem = new CborDecoder(new ByteArrayInputStream(outer)).decodeNext();
-            var outerBytes = assertInstanceOf(ByteString.class, outerItem).getBytes();
-            byte[] malformedInner = Arrays.copyOf(outerBytes, outerBytes.length + 1);
-            malformedInner[malformedInner.length - 1] = remainder;
+            return assertInstanceOf(ByteString.class, outerItem).getBytes();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
+    private static String wrapOuterCbor(byte[] inner) {
+        try {
             var encoded = new ByteArrayOutputStream();
             new CborEncoder(encoded).encode(new CborBuilder()
-                    .add(malformedInner)
+                    .add(inner)
                     .build());
             return HexFormat.of().formatHex(encoded.toByteArray());
         } catch (Exception e) {

--- a/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluatorTest.java
+++ b/julc-cardano-client-lib/src/test/java/com/bloxbean/cardano/julc/clientlib/eval/JulcTransactionEvaluatorTest.java
@@ -17,9 +17,15 @@ import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.JulcVm;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 import com.bloxbean.cardano.julc.vm.java.cost.CostModelParser;
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.CborDecoder;
+import co.nstant.in.cbor.CborEncoder;
+import co.nstant.in.cbor.model.ByteString;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.util.*;
 
@@ -433,6 +439,53 @@ class JulcTransactionEvaluatorTest {
 
         assertTrue(result.isSuccessful(), "Expected success but got: " + result.getResponse());
         assertEquals(1, result.getValue().size());
+    }
+
+    @Test
+    void evaluateTx_rejectsTaggedInnerSerialisedScriptFromSupplier() throws Exception {
+        String scriptAddr = buildScriptAddress(alwaysTrueHash);
+        String txHash = "ac".repeat(32);
+
+        Utxo inputUtxo = Utxo.builder()
+                .txHash(txHash)
+                .outputIndex(0)
+                .address(scriptAddr)
+                .amount(List.of(Amount.lovelace(BigInteger.valueOf(5_000_000))))
+                .build();
+
+        var redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.ZERO)
+                .data(new BigIntPlutusData(BigInteger.ZERO))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.ZERO)
+                        .steps(BigInteger.ZERO)
+                        .build())
+                .build();
+
+        var tx = Transaction.builder()
+                .body(TransactionBody.builder()
+                        .inputs(List.of(new TransactionInput(txHash, 0)))
+                        .outputs(List.of())
+                        .fee(BigInteger.valueOf(200_000))
+                        .build())
+                .witnessSet(TransactionWitnessSet.builder()
+                        .redeemers(List.of(redeemer))
+                        .build())
+                .build();
+
+        var taggedScript = PlutusV3Script.builder()
+                .cborHex(tagInnerSerialisedScript(alwaysTrueScript.getCborHex()))
+                .build();
+        ScriptSupplier scriptSupplier = hash -> alwaysTrueHash.equals(hash)
+                ? Optional.of(taggedScript)
+                : Optional.empty();
+
+        var result = createEvaluator(scriptSupplier).evaluateTx(tx.serialize(), Set.of(inputUtxo));
+
+        assertFalse(result.isSuccessful());
+        assertTrue(result.getResponse().contains("untagged definite-length bytestring"),
+                "Unexpected evaluator response: " + result.getResponse());
     }
 
     @Test
@@ -1059,6 +1112,27 @@ class JulcTransactionEvaluatorTest {
 
         return new JulcTransactionEvaluator(
                 utxoSupplier, protocolParamsSupplier, scriptSupplier);
+    }
+
+    private static String tagInnerSerialisedScript(String outerCborHex) {
+        try {
+            byte[] outer = HexFormat.of().parseHex(outerCborHex);
+            var outerItem = new CborDecoder(new ByteArrayInputStream(outer)).decodeNext();
+            byte[] inner = assertInstanceOf(ByteString.class, outerItem).getBytes();
+
+            byte[] tagged = new byte[inner.length + 2];
+            tagged[0] = (byte) 0xd8;
+            tagged[1] = 0x18;
+            System.arraycopy(inner, 0, tagged, 2, inner.length);
+
+            var encoded = new ByteArrayOutputStream();
+            new CborEncoder(encoded).encode(new CborBuilder()
+                    .add(tagged)
+                    .build());
+            return HexFormat.of().formatHex(encoded.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- validate the raw inner SerialisedScript CBOR header before cbor-java can normalize it
- accept exactly the cborg decodeBytes range 0x40 through 0x5b, including non-canonical definite lengths
- reject tagged, indefinite-length, reserved, and non-bytestring inner wrappers across no-target, V1, V2, and V3 paths
- keep wrapper-shape validation independent from the existing V1/V2/no-target versus V3 trailing-remainder rule
- cover the real JulcTransactionEvaluator ScriptSupplier path
- update ADR-030 and remove the issue 67 decode-boundary exclusion

The outer cardano-client-lib transport wrapper remains unchanged. Permissive format-inspection tools outside ledger evaluation remain outside this parity claim.

## Normative target

- cardano-node 11.0.1
- Plutus 1.63.0.0 at f92b7d7d82622a26caf456a6be33859f697e2cfc
- cborg 0.2.10.0

## Verification

- regression tests failed against the pre-fix implementation for tagged, indefinite, reserved, and transaction-evaluator cases
- focused adapter/evaluator tests passed after the fix
- full julc-cardano-client-lib test suite passed
- full repository test rerun: 10,028 test cases reported, 533 skipped, 0 failures, 0 errors
- git diff --check passed

Fixes #67