### PR TITLE
fix(compiler): enforce released PV11 builtin contract

### DIFF
--- a/adr/architecture-reference.md
+++ b/adr/architecture-reference.md
@@ -104,7 +104,10 @@ julc-compiler ── julc-annotation-processor
 
 ### DefaultFun (Built-in Functions)
 
-102 enum values (codes 0-101) covering Plutus V1 through V4. JuLC targets V3 (codes 0-87). V4 builtins (88-101) are defined in the enum but not used by the compiler.
+102 enum values (codes 0-101). Under the PV11 contract, codes 0-100 are released
+and Batch 6 is exactly 87-100.
+Code 101 (`MultiIndexArray`, CIP-156) is retained for FLAT and experimental VM
+development, but is future/unreleased and the current V3/PV11 compiler rejects it.
 
 ### FLAT Serialization
 
@@ -406,9 +409,13 @@ List methods `map`, `filter`, `any`, `all`, `find` are available as both static 
 
 ## 8. Ledger API
 
-### V3-Only Decision
+### Current V3/PV11 Compiler Target
 
-JuLC targets Plutus V3 exclusively. V3 scripts receive a single `ScriptContext` argument as `Data` (rather than V1/V2's three separate arguments). This simplifies the wrapper and aligns with the Conway era.
+JuLC currently targets the Plutus V3/PV11 feature set. V3
+scripts receive a single `ScriptContext` argument as `Data` (rather than
+V1/V2's three separate arguments). Configurable compiler targets are separate
+roadmap work; until then, the compiler must not emit features outside this
+profile.
 
 ### Registered Ledger Types
 

--- a/adr/architecture-reference.md
+++ b/adr/architecture-reference.md
@@ -108,6 +108,8 @@ julc-compiler ── julc-annotation-processor
 and Batch 6 is exactly 87-100.
 Code 101 (`MultiIndexArray`, CIP-156) is retained for FLAT and experimental VM
 development, but is future/unreleased and the current V3/PV11 compiler rejects it.
+The placeholder retains JuLC's legacy `(array, indices)` order, not CIP-156's
+proposed indices-first signature, and is not a conformant preview.
 
 ### FLAT Serialization
 

--- a/adr/issues/julc-dce-soundness-fix-plan.md
+++ b/adr/issues/julc-dce-soundness-fix-plan.md
@@ -187,7 +187,8 @@ shape-level soundness argument in the code):
 
 1. **`BuiltinSemantics` (julc-core)** carries type arity, value arity, totality, declared
    argument types, and a **result type** per builtin. The vm-java cross-check test
-   verifies arities against `BuiltinTable` for all 102 builtins and **executes every
+   verifies arities against `BuiltinTable` for all 102 enum entries (101 released
+   builtins plus the retained future tag 101) and **executes every
    claimed-total builtin** on typical + edge samples of its declared arg types. That
    execution check immediately caught a misclassification: `constrData` errors on tags
    outside int range, so it is total only at `CONSTR_TAG` (constant in [0, MAX_INT]).

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -51,6 +51,7 @@ export default defineConfig({
           label: 'Reference',
           items: [
             { label: 'API Reference', slug: 'reference/api-reference' },
+            { label: 'Release Notes', slug: 'reference/release-notes' },
             { label: 'Library Developer Guide', slug: 'reference/library-developer-guide' },
             { label: 'Examples', slug: 'reference/examples' },
             { label: 'Troubleshooting', slug: 'reference/troubleshooting' },

--- a/docs/scripts/generate-llms-txt.mjs
+++ b/docs/scripts/generate-llms-txt.mjs
@@ -55,6 +55,7 @@ const SECTIONS = [
     title: 'Reference',
     files: [
       'reference/api-reference.md',
+      'reference/release-notes.md',
       'reference/library-developer-guide.md',
       'reference/examples.mdx',
       'reference/troubleshooting.md',

--- a/docs/src/content/docs/ai/starter-pack.md
+++ b/docs/src/content/docs/ai/starter-pack.md
@@ -313,7 +313,7 @@ All imports are from `com.bloxbean.cardano.julc.stdlib.lib.*`.
 `txOutAddress(out)`, `txOutValue(out)`, `txOutDatum(out)`, `outputsAt(outputs, addr)`, `countOutputsAt(outputs, addr)`, `uniqueOutputAt(outputs, addr)`, `outputsWithToken(outputs, policy, token)`, `valueHasToken(value, policy, token)`, `lovelacePaidTo(outputs, addr)`, `paidAtLeast(outputs, addr, amount)`, `getInlineDatum(out)`, `resolveDatum(txInfo, out)`. **Prefer field access**: `out.address()`, `out.value()`, `out.datum()`.
 
 ### MathLib
-`abs(n)`, `max(a, b)`, `min(a, b)`, `floorDiv(a, b)`, `floorMod(a, b)`, `divMod(a, b)` → `Tuple2`, `quotRem(a, b)` → `Tuple2`, `pow(b, e)`, `sign(n)`, `expMod(b, e, m)`.
+`abs(n)`, `max(a, b)`, `min(a, b)`, `floorDiv(a, b)`, `floorMod(a, b)`, `divMod(a, b)` → `Tuple2`, `quotRem(a, b)` → `Tuple2`, `pow(b, e)`, `sign(n)`, `expMod(b, e, m)` (PV11 only).
 
 ### IntervalLib
 `between(lo, hi)`, `never()`, `isEmpty(interval)`, `finiteUpperBound(interval)`, `finiteLowerBound(interval)`, `contains(interval, point)`.
@@ -331,7 +331,8 @@ All imports are from `com.bloxbean.cardano.julc.stdlib.lib.*`.
 `credentialHash(addr)` → `byte[]`, `isScriptAddress(addr)`, `isPubKeyAddress(addr)`, `paymentCredential(addr)` → `Credential`.
 
 ### BlsLib (Plutus V3)
-G1/G2 add/scale/neg, pairing, MSM, and `bls12_381_finalVerify`.
+G1/G2 add/scale/neg, pairing, and `bls12_381_finalVerify` are available on
+PV10+; multi-scalar multiplication (MSM) requires PV11.
 
 ### NativeValueLib (PV11)
 Native Mary-era `Value` operations.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -1479,7 +1479,7 @@ following limitations apply:
   `PlutusData`, records, sealed interfaces, `List<T>`, `Map<K,V>`, `Optional<T>`,
   `Tuple2<A,B>`, `Tuple3<A,B,C>`, `JulcArray<T>` *(PV11+)*.
 - **No float/double**: Floating-point types do not exist on-chain.
-- **No Java arrays** (except `byte[]`): Use `JulcList<T>` for collections (or `List<T>`), or `JulcArray<T>` for O(1) random access on PV11+ networks (CIP-156). `byte[]` literal arrays (`new byte[]{0x48, 0x45}`) and `"TOKEN".getBytes()` are supported as compile-time constants. `JulcList<T>` is preferred over `List<T>` because it provides IDE autocomplete for on-chain methods (`.contains()`, `.size()`, `.get()`, `.filter()`, etc.).
+- **No Java arrays** (except `byte[]`): Use `JulcList<T>` for collections (or `List<T>`), or `JulcArray<T>` for O(1) random access on PV11+ networks (CIP-138). `byte[]` literal arrays (`new byte[]{0x48, 0x45}`) and `"TOKEN".getBytes()` are supported as compile-time constants. `JulcList<T>` is preferred over `List<T>` because it provides IDE autocomplete for on-chain methods (`.contains()`, `.size()`, `.get()`, `.filter()`, etc.).
 - **No class inheritance**: Only records and sealed interfaces are supported for
   data types.
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -889,7 +889,7 @@ when your validator references them.
 | `ValuesLib` | `lovelaceOf`, `assetOf`, `containsPolicy`, `geq`, `geqMultiAsset`, `leq`, `eq`, `isZero`, `singleton`, `negate`, `flatten`, `flattenTyped`, `add`, `subtract`, `countTokensWithQty`, `findTokenName` |
 | `MapLib` | `lookup`, `member`, `insert`, `delete`, `keys`, `values`, `toList`, `fromList`, `size` |
 | `OutputLib` | `txOutAddress`, `txOutValue`, `txOutDatum`, `outputsAt`, `countOutputsAt`, `uniqueOutputAt`, `outputsWithToken`, `valueHasToken`, `lovelacePaidTo`, `paidAtLeast`, `getInlineDatum`, `resolveDatum`, `findOutputWithToken`, `findInputWithToken` |
-| `MathLib` | `abs`, `max`, `min`, `floorDiv`, `floorMod`, `divMod`, `quotRem`, `pow`, `sign`, `expMod` |
+| `MathLib` | `abs`, `max`, `min`, `floorDiv`, `floorMod`, `divMod`, `quotRem`, `pow`, `sign`, `expMod` (PV11) |
 | `IntervalLib` | `contains`, `always`, `after`, `before`, `between`, `never`, `isEmpty`, `finiteUpperBound`, `finiteLowerBound` |
 | `CryptoLib` | `sha2_256`, `blake2b_256`, `sha3_256`, `blake2b_224`, `keccak_256`, `verifyEd25519Signature`, `verifyEcdsaSecp256k1`, `verifySchnorrSecp256k1`, `ripemd_160` (all hash functions also available via `Builtins.*`) |
 | `ByteStringLib` | `at`, `cons`, `slice`, `length`, `drop`, `take`, `append`, `empty`, `zeros`, `equals`, `lessThan`, `lessThanEquals`, `integerToByteString`, `byteStringToInteger`, `encodeUtf8`, `decodeUtf8`, `serialiseData`, `hexNibble`, `toHex`, `intToDecimalString`, `utf8ToInteger` |

--- a/docs/src/content/docs/internals/compiler-design.md
+++ b/docs/src/content/docs/internals/compiler-design.md
@@ -967,13 +967,13 @@ These are `@OnchainLibrary`-annotated Java classes compiled from source:
 | `ValuesLib` | 9 | Multi-asset Value operations (add, subtract, compare) |
 | `ContextsLib` | 13 | ScriptContext/TxInfo field extraction helpers |
 | `OutputLib` | 8 | TxOut querying (outputsAt, lovelacePaidTo, etc.) |
-| `MathLib` | 10 | Math utilities (abs, pow, floorDiv, floorMod, divMod, quotRem, expMod) |
+| `MathLib` | 10 | Math utilities (abs, pow, floorDiv, floorMod, divMod, quotRem, expMod [PV11]) |
 | `IntervalLib` | 5 | Time interval operations |
 | `CryptoLib` | 3 | ECDSA, Schnorr, RIPEMD-160 |
 | `ByteStringLib` | 8 | ByteString manipulation |
 | `BitwiseLib` | 10 | Bitwise operations |
 | `AddressLib` | 3 | Address/credential utilities |
-| `BlsLib` | — | BLS12-381 operations (PV11) |
+| `BlsLib` | — | BLS12-381 operations (base PV10+, MSM PV11) |
 | `NativeValueLib` | — | Native Value operations (PV11) |
 
 ### StdlibLookup Chain

--- a/docs/src/content/docs/internals/compiler-design.md
+++ b/docs/src/content/docs/internals/compiler-design.md
@@ -130,7 +130,7 @@ JuLC is organized into focused modules. Here are the key ones grouped by role:
 
 | Module | Role | Key Types |
 |--------|------|-----------|
-| `julc-core` | UPLC AST, constants, serialization | `Term` (10 variants), `DefaultFun` (102 builtins), `PlutusData`, `Program` |
+| `julc-core` | UPLC AST, constants, serialization | `Term` (10 variants), `DefaultFun` (101 released builtins plus one future tag), `PlutusData`, `Program` |
 | `julc-ledger-api` | Java records for all Cardano V3 ledger types | `ScriptContext`, `TxInfo`, `TxOut`, `Value`, `Address`, `Credential` + 35 more |
 
 ### Compiler (the main event)
@@ -247,7 +247,7 @@ sealed interface Term {
     record Force(Term term)                           // Force polymorphic term
     record Delay(Term term)                           // Delay evaluation (thunk)
     record Const(Constant value)                      // Constant value
-    record Builtin(DefaultFun fun)                    // Built-in function (102 total)
+    record Builtin(DefaultFun fun)                    // Builtin enum entry (101 released + 1 future)
     record Error()                                    // Halt execution
     record Constr(long tag, List<Term> fields)        // Constructor (Plutus V3)
     record Case(Term scrutinee, List<Term> branches)  // Case match (Plutus V3)
@@ -292,7 +292,7 @@ sealed interface PirType {
     record PairType(PirType first, PirType second)
     record MapType(PirType keyType, PirType valueType)
     record OptionalType(PirType elemType)
-    record ArrayType(PirType elemType)    // PV11, CIP-156
+    record ArrayType(PirType elemType)    // PV11, CIP-138
 
     // Functions
     record FunType(PirType paramType, PirType returnType)
@@ -1260,7 +1260,7 @@ After optimization, the validator becomes equivalent to `\ctx -> Unit` (always s
 | File | Role |
 |------|------|
 | `julc-core/.../Term.java` | UPLC term AST (10 variants) |
-| `julc-core/.../DefaultFun.java` | 102 Plutus builtin functions |
+| `julc-core/.../DefaultFun.java` | 101 released Plutus builtins (tags 0-100) plus future `MultiIndexArray` (tag 101) |
 | `julc-core/.../PlutusData.java` | Universal on-chain data encoding |
 | `julc-stdlib/.../StdlibRegistry.java` | PIR term builders for ~65 stdlib methods |
 | `julc-vm/.../JulcVmProvider.java` | VM SPI interface |

--- a/docs/src/content/docs/internals/compiler-developer-guide.md
+++ b/docs/src/content/docs/internals/compiler-developer-guide.md
@@ -1254,7 +1254,7 @@ public interface StdlibLookup {
 - Crypto: `sha2_256`, `blake2b_256`, `verifyEd25519Signature`, `sha3_256`, `blake2b_224`, `keccak_256`, `verifyEcdsaSecp256k1Signature`, `verifySchnorrSecp256k1Signature`, `ripemd_160`
 - Bitwise: `andByteString`, `orByteString`, `xorByteString`, `complementByteString`, `readBit`, `writeBits`, `shiftByteString`, `rotateByteString`, `countSetBits`, `findFirstSetBit`
 - Data decomposition: `constrTag`, `constrFields`
-- Math: `expModInteger`
+- Math: `expModInteger` (PV11)
 
 **ListsLib HOF methods (require lambda/LetRec — cannot be compiled from Java source):**
 

--- a/docs/src/content/docs/internals/compiler-developer-guide.md
+++ b/docs/src/content/docs/internals/compiler-developer-guide.md
@@ -48,7 +48,7 @@ Untyped Plutus Lambda Calculus (UPLC) is the on-chain language that Cardano node
 | 4 | `Force(Term term)` | Force evaluation of a delayed (polymorphic) term |
 | 5 | `Delay(Term term)` | Delay evaluation (create a thunk) |
 | 6 | `Const(Constant value)` | Constant value (integer, bytestring, string, bool, unit, data) |
-| 7 | `Builtin(DefaultFun fun)` | Reference to one of 102 built-in functions |
+| 7 | `Builtin(DefaultFun fun)` | Reference to one of 101 released builtins or the retained future tag 101 |
 | 8 | `Error()` | Halt evaluation (transaction fails) |
 | 9 | `Constr(long tag, List<Term> fields)` | Constructor application (Plutus V3, SOPs) |
 | 10 | `Case(Term scrutinee, List<Term> branches)` | Case/pattern matching (Plutus V3, SOPs) |
@@ -207,7 +207,7 @@ sealed interface Shape {
 
 | Module | Role |
 |--------|------|
-| `julc-core` | UPLC AST (`Term.java`), constants, `DefaultFun` enum (102 builtins), FLAT/CBOR serialization, `Program` wrapper |
+| `julc-core` | UPLC AST (`Term.java`), constants, `DefaultFun` enum (101 released builtins plus one future tag), FLAT/CBOR serialization, `Program` wrapper |
 | `julc-compiler` | The compiler itself — parsing, validation, type resolution, PIR generation, loop desugaring, pattern matching, UPLC lowering, optimization |
 | `julc-stdlib` | `StdlibRegistry` — PIR term builders for ~65 stdlib methods (builtins, HOFs, math) |
 | `julc-vm` | VM SPI interface — pluggable execution backend |
@@ -315,7 +315,7 @@ Defined in `TypeResolver.resolve(Type)`:
 | `List<T>` | `ListType(resolve(T))` | Generic |
 | `Map<K,V>` | `MapType(resolve(K), resolve(V))` | Generic |
 | `Optional<T>` | `OptionalType(resolve(T))` | Generic |
-| `JulcArray<T>` | `ArrayType(resolve(T))` | PV11 only; O(1) random access (CIP-156) |
+| `JulcArray<T>` | `ArrayType(resolve(T))` | PV11 only; O(1) random access (CIP-138) |
 | `PubKeyHash`, `ScriptHash`, `ValidatorHash`, `PolicyId`, `TokenName`, `DatumHash`, `TxId` | `ByteStringType` | Ledger hash types |
 | `StakingCredential`, `ScriptPurpose`, `Vote`, `Voter`, `DRep`, `Delegatee`, `GovernanceActionId`, `GovernanceAction`, `ProposalProcedure`, `TxCert`, `Rational`, `ProtocolVersion`, `Committee` | `DataType` | Opaque ledger types |
 | Registered records | `RecordType(...)` | User-defined or ledger records |
@@ -2003,6 +2003,6 @@ ADR files are in the `adr/` directory at the project root.
 | `julc-compiler/.../validate/SubsetValidator.java` | — | Java subset enforcement |
 | `julc-compiler/.../util/MethodDependencyResolver.java` | — | Method dependency graph construction |
 | `julc-compiler/.../util/StringUtils.java` | — | String utilities (Levenshtein distance, etc.) |
-| `julc-core/.../DefaultFun.java` | — | 102 Plutus builtin functions with FLAT codes |
+| `julc-core/.../DefaultFun.java` | — | 101 released Plutus builtins (tags 0-100) plus future `MultiIndexArray` (tag 101) |
 | `julc-core/.../Term.java` | — | UPLC term AST (10 variants) |
 | `julc-stdlib/.../StdlibRegistry.java` | — | PIR term builders for ~65 stdlib methods |

--- a/docs/src/content/docs/internals/java-to-uplc-end-to-end.md
+++ b/docs/src/content/docs/internals/java-to-uplc-end-to-end.md
@@ -581,7 +581,8 @@ When source maps are enabled, optimization is skipped to preserve term identity 
 
 ### Phase 11: Create `Program`
 
-JuLC currently emits Plutus V3:
+JuLC currently emits Plutus V3 under its PV11 compiler
+contract:
 
 ```java
 var program = Program.plutusV3(uplcTerm);
@@ -592,6 +593,10 @@ That means the version is:
 ```text
 1.1.0
 ```
+
+The `Program` stores the UPLC version, not the ledger protocol version. JuLC's
+compiler policy therefore enforces the PV11 builtin boundary while lowering;
+future tag 101 (`MultiIndexArray`) is rejected before a script is produced.
 
 ### Phase 12: Encode
 

--- a/docs/src/content/docs/reference/api-reference.md
+++ b/docs/src/content/docs/reference/api-reference.md
@@ -25,7 +25,7 @@ This document covers all supported Java operations in the JuLC compiler, the sta
 | `@NewType` records | Underlying type | Zero-cost alias (identity on-chain) |
 | `PubKeyHash`, `PolicyId`, `TokenName`, `TxId`, `ScriptHash`, `ValidatorHash`, `DatumHash` | ByteString | Ledger hash types |
 | `Value` | Map(Pair) | Named RecordType with instance methods |
-| `JulcArray<T>` *(PV11)* | BuiltinArray | O(1) random access array (CIP-156). PV11+ only |
+| `JulcArray<T>` *(PV11)* | BuiltinArray | O(1) random access array (CIP-138). PV11+ only |
 
 ### JulcList and JulcMap
 
@@ -38,7 +38,7 @@ JulcMap<Credential, BigInteger> withdrawals = txInfo.withdrawals();
 
 ### JulcArray (PV11)
 
-> **Protocol Version 11+ only.** Arrays use CIP-156 builtins and are not available on PV10 networks.
+> **Protocol Version 11+ only.** Base Array operations use CIP-138 builtins and are not available on PV10 networks.
 
 `JulcArray<T>` is an immutable array interface providing O(1) random access on-chain. Create from a list via `list.toArray()` or `JulcArray.fromList(list)`.
 
@@ -50,6 +50,10 @@ long len = arr.length();                         // LengthOfArray builtin
 ```
 
 Off-chain: backed by `JulcArrayImpl`, wrapping `java.util.List` with O(1) index access.
+
+`Builtins.multiIndexArray` (tag 101, CIP-156) is a separate future/unreleased
+operation. It is not valid under Plutus V3/PV11, and the current compiler
+rejects it. See the [release notes](/reference/release-notes/) for migration guidance.
 
 ### Tuple2 and Tuple3
 

--- a/docs/src/content/docs/reference/api-reference.md
+++ b/docs/src/content/docs/reference/api-reference.md
@@ -53,7 +53,10 @@ Off-chain: backed by `JulcArrayImpl`, wrapping `java.util.List` with O(1) index 
 
 `Builtins.multiIndexArray` (tag 101, CIP-156) is a separate future/unreleased
 operation. It is not valid under Plutus V3/PV11, and the current compiler
-rejects it. See the [release notes](/reference/release-notes/) for migration guidance.
+rejects it. Its retained experimental placeholder uses the legacy
+`(array, indices)` order rather than CIP-156's proposed indices-first signature
+and is not a conformant preview. See the
+[release notes](/reference/release-notes/) for migration guidance.
 
 ### Tuple2 and Tuple3
 
@@ -582,7 +585,7 @@ Import from `com.bloxbean.cardano.julc.stdlib.lib.*` in validators. See [Standar
 | `floorMod(a, b)` | Integer, Integer | Floor modulo |
 | `divMod(a, b)` | Integer, Integer | Returns Tuple2(floor division, floor modulo) |
 | `quotRem(a, b)` | Integer, Integer | Returns Tuple2(quotient, remainder) |
-| `expMod(base, exp, mod)` | Integer, Integer, Integer | Modular exponentiation |
+| `expMod(base, exp, mod)` | Integer, Integer, Integer | Modular exponentiation (PV11 only) |
 
 Use `MathLib.floorDiv` and `MathLib.floorMod` for `BigInteger` floor division. `java.lang.Math.floorDiv` and `Math.floorMod` are valid for normal Java `int`/`long` calls, but the JDK does not provide `BigInteger` overloads for those methods.
 
@@ -658,7 +661,10 @@ Note: `sha2_256`, `sha3_256`, `blake2b_256`, `blake2b_224`, `keccak_256`, and `v
 
 ### BlsLib
 
-BLS12-381 elliptic curve operations. Available on PV10+. See [Standard Library Guide](/stdlib/stdlib-guide/#blslib----bls12-381-curve-operations) for full documentation.
+BLS12-381 elliptic curve operations. Base curve and pairing methods are available
+on PV10+; multi-scalar multiplication requires PV11. See
+[Standard Library Guide](/stdlib/stdlib-guide/#blslib----bls12-381-curve-operations)
+for full documentation.
 
 | Method | Args | Description |
 |--------|------|-------------|
@@ -672,8 +678,8 @@ BLS12-381 elliptic curve operations. Available on PV10+. See [Standard Library G
 | `millerLoop(g1, g2)` | G1, G2 | Compute Miller loop pairing |
 | `mulMlResult(a, b)` | ML, ML | Multiply two Miller loop results |
 | `finalVerify(a, b)` | ML, ML | Final pairing verification |
-| `g1MultiScalarMul(scalars, points)` | List, List | Multi-scalar multiplication on G1 |
-| `g2MultiScalarMul(scalars, points)` | List, List | Multi-scalar multiplication on G2 |
+| `g1MultiScalarMul(scalars, points)` | List, List | Multi-scalar multiplication on G1 (PV11 only) |
+| `g2MultiScalarMul(scalars, points)` | List, List | Multi-scalar multiplication on G2 (PV11 only) |
 
 ### NativeValueLib (PV11)
 

--- a/docs/src/content/docs/reference/library-developer-guide.md
+++ b/docs/src/content/docs/reference/library-developer-guide.md
@@ -951,7 +951,7 @@ Complete listing of all `Builtins` methods, grouped by category. Each method map
 
 | Method | Signature | UPLC Builtin |
 |--------|-----------|-------------|
-| `expModInteger` | `(long base, long exp, long mod) -> long` | `ExpModInteger` |
+| `expModInteger` (PV11) | `(long base, long exp, long mod) -> long` | `ExpModInteger` |
 
 ### Error and Trace
 

--- a/docs/src/content/docs/reference/release-notes.md
+++ b/docs/src/content/docs/reference/release-notes.md
@@ -32,4 +32,6 @@ automatic bytecode migration for an already-generated tag-101 script.
 
 The tag remains in JuLC's AST/FLAT support and Java VM for forward-development
 experiments only. That experimental implementation does not make it ledger-valid
-for PV11.
+for PV11. It also retains JuLC's legacy `(array, indices)` argument order rather
+than CIP-156's proposed indices-first signature, so it is not a conformant preview
+of the future builtin.

--- a/docs/src/content/docs/reference/release-notes.md
+++ b/docs/src/content/docs/reference/release-notes.md
@@ -1,0 +1,35 @@
+---
+title: "Release Notes"
+description: "JuLC release notes and migration guidance"
+---
+
+## Upcoming release: PV11 builtin contract correction
+
+JuLC's current compiler targets the Plutus V3/PV11 feature set. This contract
+was verified against Plutus 1.63.0.0
+(`f92b7d7d82622a26caf456a6be33859f697e2cfc`), as shipped by cardano-node 11.0.1.
+
+The released PV11 Batch 6 is exactly:
+
+| Tags | Builtins | Specification |
+|---|---|---|
+| 87 | `ExpModInteger` | CIP-109 |
+| 88 | `DropList` | CIP-132 |
+| 89-91 | `LengthOfArray`, `ListToArray`, `IndexArray` | CIP-138 |
+| 92-93 | BLS12-381 G1/G2 multi-scalar multiplication | CIP-133 |
+| 94-100 | Native MaryEraValue operations | CIP-153 |
+
+### `multiIndexArray` migration warning
+
+Earlier JuLC previews exposed `Builtins.multiIndexArray` as if it were a PV11
+builtin and could generate FLAT tag 101. Tag 101 is the future CIP-156 operation;
+it is not part of PV11, and scripts containing it are not valid for that target.
+
+The current compiler now rejects `multiIndexArray` with a compile-time diagnostic.
+Recompile affected scripts and replace the call with repeated `IndexArray`
+operations (for typed arrays, repeated `array.get(index)` calls). There is no
+automatic bytecode migration for an already-generated tag-101 script.
+
+The tag remains in JuLC's AST/FLAT support and Java VM for forward-development
+experiments only. That experimental implementation does not make it ledger-valid
+for PV11.

--- a/docs/src/content/docs/reference/troubleshooting.md
+++ b/docs/src/content/docs/reference/troubleshooting.md
@@ -750,7 +750,7 @@ var data = new byte[32];
 // Use ByteString for byte arrays, or List<T> for element lists
 ```
 
-> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-156 builtins. Use `list.toArray()` to convert a list.
+> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-138 builtins. Use `list.toArray()` to convert a list.
 
 ---
 
@@ -772,7 +772,7 @@ var first = Builtins.headList(items);
 var nth = ListsLib.nth(items, 2);
 ```
 
-> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-156 builtins. Use `list.toArray()` to convert a list, then `arr.get(index)` for O(1) access.
+> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-138 builtins. Use `list.toArray()` to convert a list, then `arr.get(index)` for O(1) access.
 
 ---
 
@@ -1007,7 +1007,7 @@ public record MyData(BigInteger amount, byte[] hash) {}
 
 **Fix:** Use `List<T>` instead of arrays.
 
-> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-156 builtins. Use `list.toArray()` to convert a list.
+> **PV11 Note:** From protocol version 11, `JulcArray<T>` provides O(1) random-access arrays via CIP-138 builtins. Use `list.toArray()` to convert a list.
 
 ---
 

--- a/docs/src/content/docs/stdlib/stdlib-guide.md
+++ b/docs/src/content/docs/stdlib/stdlib-guide.md
@@ -1448,8 +1448,14 @@ JulcList<PlutusData> mapped = outputs.map(out -> transform(out));
 
 The following features require protocol version 11 or later and will not work on PV10 networks:
 
+- **Builtins.expModInteger()** — Modular exponentiation (tag 87, CIP-109)
+- **Builtins.dropList()** — Drop the first n elements from a list (tag 88, CIP-132)
+- **JulcArray\<T\>** — Immutable arrays with O(1) random access (tags 89-91, CIP-138)
+- **BLS multi-scalar multiplication** — G1/G2 MSM operations (tags 92-93, CIP-133)
 - **NativeValueLib** — Native MaryEra Value operations (CIP-153)
-- **JulcArray\<T\>** — Immutable arrays with O(1) random access (CIP-156)
-- **Builtins.dropList()** — Drop first n elements from a list (CIP-158)
 
-These are experimental APIs that may evolve as PV11 stabilizes. BlsLib and all other existing stdlib libraries work on PV10+.
+Together these are the exact released PV11 Batch 6 set, tags 87-100.
+`Builtins.multiIndexArray` (tag 101, CIP-156) is a
+future/unreleased operation: the API remains visible for forward development,
+but the current compiler rejects it and its VM implementation is not
+ledger-valid at PV11.

--- a/docs/src/content/docs/stdlib/stdlib-guide.md
+++ b/docs/src/content/docs/stdlib/stdlib-guide.md
@@ -15,13 +15,13 @@ The JuLC standard library provides 13 on-chain libraries in the `com.bloxbean.ca
 | **ValuesLib** | `com.bloxbean.cardano.julc.stdlib.lib.ValuesLib` | Multi-asset Value comparison, arithmetic, and extraction |
 | **MapLib** | `com.bloxbean.cardano.julc.stdlib.lib.MapLib` | Association list (map) lookup, insert, delete, keys/values |
 | **OutputLib** | `com.bloxbean.cardano.julc.stdlib.lib.OutputLib` | Output filtering by address/token, lovelace summation, datum extraction |
-| **MathLib** | `com.bloxbean.cardano.julc.stdlib.lib.MathLib` | abs, max, min, pow, floorDiv, floorMod, divMod, quotRem, expMod, sign |
+| **MathLib** | `com.bloxbean.cardano.julc.stdlib.lib.MathLib` | abs, max, min, pow, floorDiv, floorMod, divMod, quotRem, expMod (PV11), sign |
 | **IntervalLib** | `com.bloxbean.cardano.julc.stdlib.lib.IntervalLib` | Time interval construction, containment, bound extraction |
 | **CryptoLib** | `com.bloxbean.cardano.julc.stdlib.lib.CryptoLib` | Hash functions and signature verification |
 | **ByteStringLib** | `com.bloxbean.cardano.julc.stdlib.lib.ByteStringLib` | ByteString slicing, comparison, encoding, serialization |
 | **BitwiseLib** | `com.bloxbean.cardano.julc.stdlib.lib.BitwiseLib` | Bitwise AND/OR/XOR, shift, rotate, bit read/write |
 | **AddressLib** | `com.bloxbean.cardano.julc.stdlib.lib.AddressLib` | Credential extraction, address type checks |
-| **BlsLib** | `com.bloxbean.cardano.julc.stdlib.lib.BlsLib` | BLS12-381 G1/G2/pairing/MSM operations |
+| **BlsLib** | `com.bloxbean.cardano.julc.stdlib.lib.BlsLib` | BLS12-381 G1/G2/pairing operations; MSM requires PV11 |
 | **NativeValueLib** *(PV11)* | `com.bloxbean.cardano.julc.stdlib.lib.NativeValueLib` | Native MaryEra Value insert, lookup, union, contains, scale |
 
 ---
@@ -154,7 +154,7 @@ The JuLC standard library provides 13 on-chain libraries in the `com.bloxbean.ca
 | `floorMod(a, b)` | Floor modulo |
 | `divMod(a, b)` | Floor division and modulo as Tuple2 |
 | `quotRem(a, b)` | Quotient and remainder as Tuple2 |
-| `expMod(base, exp, mod)` | Modular exponentiation |
+| `expMod(base, exp, mod)` | Modular exponentiation (PV11 only) |
 
 Use `MathLib.floorDiv` and `MathLib.floorMod` for `BigInteger` floor division. `java.lang.Math.floorDiv` and `Math.floorMod` are valid for normal Java `int`/`long` calls, but the JDK does not provide `BigInteger` overloads for those methods.
 
@@ -867,6 +867,9 @@ class MathExample {
 
 Compatibility note: `MathLib.divMod` is floor-based. Code that needs Java-style truncating division should use `MathLib.quotRem`.
 
+> **PV11 only:** `MathLib.expMod` lowers to the Batch 6 `ExpModInteger`
+> builtin. The other division and modulo helpers in this section do not require PV11.
+
 ```java
 import com.bloxbean.cardano.julc.core.types.Tuple2;
 
@@ -1240,7 +1243,9 @@ class DestinationCheckExample {
 
 ## BlsLib -- BLS12-381 Curve Operations
 
-`BlsLib` wraps the Plutus V3 BLS12-381 builtins for elliptic curve cryptography. All methods are `static` and available on PV10+.
+`BlsLib` wraps the Plutus V3 BLS12-381 builtins for elliptic curve cryptography.
+All methods are `static`. Base curve and pairing methods are available on PV10+;
+`g1MultiScalarMul` and `g2MultiScalarMul` require PV11.
 
 ### Quick Reference
 
@@ -1263,8 +1268,8 @@ class DestinationCheckExample {
 | `millerLoop(g1, g2)` | Compute Miller loop pairing |
 | `mulMlResult(a, b)` | Multiply two Miller loop results |
 | `finalVerify(a, b)` | Final pairing verification |
-| `g1MultiScalarMul(scalars, points)` | Multi-scalar multiplication on G1 |
-| `g2MultiScalarMul(scalars, points)` | Multi-scalar multiplication on G2 |
+| `g1MultiScalarMul(scalars, points)` | Multi-scalar multiplication on G1 (PV11 only) |
+| `g2MultiScalarMul(scalars, points)` | Multi-scalar multiplication on G2 (PV11 only) |
 
 ### Usage
 
@@ -1458,4 +1463,6 @@ Together these are the exact released PV11 Batch 6 set, tags 87-100.
 `Builtins.multiIndexArray` (tag 101, CIP-156) is a
 future/unreleased operation: the API remains visible for forward development,
 but the current compiler rejects it and its VM implementation is not
-ledger-valid at PV11.
+ledger-valid at PV11. The retained experimental placeholder uses the legacy
+`(array, indices)` order rather than CIP-156's proposed indices-first signature,
+so it must not be treated as a conformant preview.

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
@@ -509,14 +509,26 @@ public class UplcGenerator {
      */
     private static Term generateBuiltin(DefaultFun fun) {
         if (fun.flatCode() > LAST_RELEASED_PV11_BUILTIN_TAG) {
-            throw new CompilerException(
+            throw unsupportedTargetBuiltin(fun);
+        }
+        return wrapForces(Term.builtin(fun), forceCount(fun));
+    }
+
+    private static CompilerException unsupportedTargetBuiltin(DefaultFun fun) {
+        if (fun == DefaultFun.MultiIndexArray) {
+            return new CompilerException(
                     "Cannot compile " + fun + " (FLAT tag " + fun.flatCode()
                             + "): it is a future/unreleased "
                             + "CIP-156 builtin and is not available in Plutus V3 at protocol "
                             + "version 11. Use IndexArray repeatedly "
                             + "for PV11, or wait for a compiler target that explicitly enables CIP-156.");
         }
-        return wrapForces(Term.builtin(fun), forceCount(fun));
+        return new CompilerException(
+                "Cannot compile " + fun + " (FLAT tag " + fun.flatCode()
+                        + "): it is not available in the current Plutus V3/PV11 target. "
+                        + "This compiler supports released builtins through "
+                        + DefaultFun.ScaleValue + " (FLAT tag "
+                        + LAST_RELEASED_PV11_BUILTIN_TAG + ").");
     }
 
     private static Term wrapForces(Term term, int count) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
@@ -22,6 +22,8 @@ import java.util.*;
  */
 public class UplcGenerator {
 
+    private static final int LAST_RELEASED_PV11_BUILTIN_TAG = DefaultFun.ScaleValue.flatCode();
+
     private final Deque<String> scope = new ArrayDeque<>();
 
     /** PIR term → source location (provided by PirGenerator when source maps are enabled). */
@@ -99,7 +101,7 @@ public class UplcGenerator {
 
             case PirTerm.Const(var value) -> Term.const_(value);
 
-            case PirTerm.Builtin(var fun) -> wrapForces(Term.builtin(fun), forceCount(fun));
+            case PirTerm.Builtin(var fun) -> generateBuiltin(fun);
 
             case PirTerm.Lam(var param, _, var body) -> {
                 scope.push(param);
@@ -498,6 +500,23 @@ public class UplcGenerator {
             // 0 Forces (monomorphic)
             default -> 0;
         };
+    }
+
+    /**
+     * Enforce the current compiler's Plutus V3/PV11 target at the final
+     * common lowering boundary. This catches direct PIR, public Builtins calls,
+     * library wrappers, and every JulcCompiler entry point.
+     */
+    private static Term generateBuiltin(DefaultFun fun) {
+        if (fun.flatCode() > LAST_RELEASED_PV11_BUILTIN_TAG) {
+            throw new CompilerException(
+                    "Cannot compile " + fun + " (FLAT tag " + fun.flatCode()
+                            + "): it is a future/unreleased "
+                            + "CIP-156 builtin and is not available in Plutus V3 at protocol "
+                            + "version 11. Use IndexArray repeatedly "
+                            + "for PV11, or wait for a compiler target that explicitly enables CIP-156.");
+        }
+        return wrapForces(Term.builtin(fun), forceCount(fun));
     }
 
     private static Term wrapForces(Term term, int count) {

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/Pv11CompilerContractTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/Pv11CompilerContractTest.java
@@ -1,0 +1,85 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
+import com.bloxbean.cardano.julc.compiler.uplc.UplcGenerator;
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the current compiler contract to the Plutus V3/PV11 feature set.
+ * The expected builtin boundary was verified against Plutus 1.63.0.0 at
+ * f92b7d7d8, as shipped by cardano-node 11.0.1.
+ */
+class Pv11CompilerContractTest {
+
+    @Test
+    void allReleasedBatch6BuiltinsCanBeLowered() {
+        var generator = new UplcGenerator();
+        for (int tag = 87; tag <= 100; tag++) {
+            var builtin = DefaultFun.fromFlatCode(tag);
+            assertDoesNotThrow(
+                    () -> generator.generate(new PirTerm.Builtin(builtin)),
+                    () -> "Released PV11 builtin must compile: " + builtin);
+        }
+    }
+
+    @Test
+    void directPirCannotEmitFutureMultiIndexArray() {
+        var error = assertThrows(CompilerException.class,
+                () -> new UplcGenerator().generate(
+                        new PirTerm.Builtin(DefaultFun.MultiIndexArray)));
+
+        assertFutureBuiltinDiagnostic(error);
+    }
+
+    @Test
+    void stdlibRegistryPathCannotEmitFutureMultiIndexArray() {
+        var dummy = new PirTerm.Const(Constant.unit());
+        var pir = StdlibRegistry.defaultRegistry()
+                .lookup("com.bloxbean.cardano.julc.stdlib.Builtins", "multiIndexArray",
+                        List.of(dummy, dummy))
+                .orElseThrow();
+
+        var error = assertThrows(CompilerException.class,
+                () -> new UplcGenerator().generate(pir));
+
+        assertFutureBuiltinDiagnostic(error);
+    }
+
+    @Test
+    void publicBuiltinsCallFailsDuringCompilation() {
+        var source = """
+                import com.bloxbean.cardano.julc.core.PlutusData;
+                import com.bloxbean.cardano.julc.stdlib.Builtins;
+
+                class FutureArrayCall {
+                    static PlutusData select(PlutusData array, PlutusData indices) {
+                        return Builtins.multiIndexArray(array, indices);
+                    }
+                }
+                """;
+
+        var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
+        var error = assertThrows(CompilerException.class,
+                () -> compiler.compileMethod(source, "select"));
+
+        assertFutureBuiltinDiagnostic(error);
+    }
+
+    private static void assertFutureBuiltinDiagnostic(CompilerException error) {
+        assertAll(
+                () -> assertTrue(error.getMessage().contains("MultiIndexArray (FLAT tag 101)")),
+                () -> assertTrue(error.getMessage().contains("future/unreleased")),
+                () -> assertTrue(error.getMessage().contains("protocol version 11")),
+                () -> assertTrue(error.getMessage().contains("Use IndexArray repeatedly")));
+    }
+}

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/BuiltinSemantics.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/BuiltinSemantics.java
@@ -217,15 +217,14 @@ public final class BuiltinSemantics {
         total(DefaultFun.CountSetBits, 0, I, B);
         total(DefaultFun.FindFirstSetBit, 0, I, B);
 
-        // === V3 Modular exponentiation (CIP-109) ===
+        // === PV11 Batch 6: modular exponentiation (CIP-109) ===
         partial(DefaultFun.ExpModInteger, 0, 3);        // non-invertible cases
 
-        // === PV11 Batch 6 (conservative until semantics are locked in) ===
+        // === PV11 Batch 6: tags 88-100 ===
         partial(DefaultFun.DropList, 1, 2);
         partial(DefaultFun.LengthOfArray, 1, 1);
         partial(DefaultFun.ListToArray, 1, 1);
         partial(DefaultFun.IndexArray, 1, 2);
-        partial(DefaultFun.MultiIndexArray, 1, 2);
         partial(DefaultFun.Bls12_381_G1_multiScalarMul, 0, 2);
         partial(DefaultFun.Bls12_381_G2_multiScalarMul, 0, 2);
         partial(DefaultFun.InsertCoin, 0, 4);
@@ -235,6 +234,9 @@ public final class BuiltinSemantics {
         partial(DefaultFun.ValueData, 0, 1);
         partial(DefaultFun.UnValueData, 0, 1);
         partial(DefaultFun.ScaleValue, 0, 2);
+
+        // === Future/unreleased (CIP-156), retained for experimental VM use ===
+        partial(DefaultFun.MultiIndexArray, 1, 2);
     }
 
     /**

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/DefaultFun.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/DefaultFun.java
@@ -1,7 +1,8 @@
 package com.bloxbean.cardano.julc.core;
 
 /**
- * All 102 Plutus Core built-in functions (V1 through V3).
+ * The 101 builtins released through PV11, plus the
+ * future/experimental {@link #MultiIndexArray} builtin.
  * <p>
  * Each entry has a 7-bit FLAT encoding code that must match the Plutus specification exactly.
  * The codes are contiguous from 0 to 101.
@@ -10,9 +11,14 @@ package com.bloxbean.cardano.julc.core;
  * <ul>
  *   <li>V1 (0-50): Integer, ByteString, String, Crypto, Control, Pair, List, Data ops</li>
  *   <li>V2 (51-53): SerialiseData, SECP256k1 signature verification</li>
- *   <li>V3 (54-87): BLS12-381, bitwise ops, hash functions, integer/bytestring conversion (CIP-381/121/122/123/127/109)</li>
- *   <li>V3 PV11 Batch 6 (88-101): Array ops, DropList, BLS MSM, MaryEraValue ops (CIP-156/158/153/133)</li>
+ *   <li>Pre-PV11 V3 additions (54-86): BLS12-381, bitwise ops, hash functions,
+ *       and integer/bytestring conversion (CIP-381/121/122/123/127)</li>
+ *   <li>PV11 Batch 6 (87-100): modular exponentiation, list drop, base Array,
+ *       BLS MSM, and MaryEraValue operations (CIP-109/132/138/133/153)</li>
+ *   <li>Future/unreleased (101): MultiIndexArray (CIP-156)</li>
  * </ul>
+ * Ledger availability depends on both language and protocol version; the enum
+ * itself deliberately retains future tags for FLAT and VM experimentation.
  */
 public enum DefaultFun {
 
@@ -139,13 +145,13 @@ public enum DefaultFun {
     // RIPEMD-160 hash (V3, CIP-127)
     Ripemd_160(86),
 
-    // Modular exponentiation (V3, CIP-109)
+    // Modular exponentiation (PV11 Batch 6, CIP-109)
     ExpModInteger(87),
 
-    // List extensions (PV11 Batch 6, CIP-158)
+    // List extensions (PV11 Batch 6, CIP-132)
     DropList(88),
 
-    // Array operations (PV11 Batch 6, CIP-156)
+    // Base Array operations (PV11 Batch 6, CIP-138)
     LengthOfArray(89),
     ListToArray(90),
     IndexArray(91),
@@ -163,7 +169,7 @@ public enum DefaultFun {
     UnValueData(99),
     ScaleValue(100),
 
-    // Array multi-index (PV11 Batch 6, CIP-156)
+    // Future/unreleased Array multi-index operation (CIP-156); not valid at PV11
     MultiIndexArray(101);
 
     private final int flatCode;
@@ -178,19 +184,24 @@ public enum DefaultFun {
     }
 
     /**
-     * The minimum Plutus language version that includes this builtin.
+     * A legacy, language-only grouping for this builtin.
      * <p>
      * Returns 1 for V1 builtins (codes 0-50), 2 for V2 (51-53),
-     * 3 for V3 (54-101, includes PV11 Batch 6).
+     * and 3 for later tags (54-101). This is not a ledger-availability check:
+     * protocol versions can enable later batches for V1/V2, and tag 101 is not
+     * released at PV11 even though it belongs to the V3-era AST.
      */
     public int minLanguageVersion() {
         if (flatCode <= 50) return 1;
         if (flatCode <= 53) return 2;
-        return 3;  // codes 54-101 all available in V3 (PV11 Batch 6)
+        return 3;
     }
 
     /**
-     * Check if this builtin is available in the given Plutus language version.
+     * Check the legacy language-only grouping for this builtin.
+     * <p>
+     * This method does not account for protocol-version activation. Ledger and
+     * evaluator code must use the protocol feature profile instead.
      *
      * @param languageVersion 1 for PlutusV1, 2 for PlutusV2, 3 for PlutusV3
      * @return true if the builtin is available in that version

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/PlutusTarget.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/PlutusTarget.java
@@ -3,9 +3,10 @@ package com.bloxbean.cardano.julc.core;
 /**
  * JuLC's compile target for generated scripts.
  * <p>
- * JuLC currently emits Plutus V3 scripts. The VM/evaluator can execute other
- * Plutus language versions when given external scripts, but compiler output is
- * intentionally pinned to this target.
+ * JuLC currently emits Plutus V3 scripts under the PV11 feature contract. The
+ * VM/evaluator can execute other language/protocol profiles when given external
+ * scripts, but the compiler target is intentionally fixed until configurable
+ * compiler targeting is implemented.
  */
 public enum PlutusTarget {
     V3("v3", "PlutusScriptV3", 1, 1, 0);

--- a/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcArray.java
+++ b/julc-core/src/main/java/com/bloxbean/cardano/julc/core/types/JulcArray.java
@@ -3,7 +3,7 @@ package com.bloxbean.cardano.julc.core.types;
 /**
  * Immutable array interface for O(1) random access on-chain.
  * <p>
- * <b>PV11 only</b> — Arrays use PV11 Batch 6 builtins (CIP-156) and are available
+ * <b>PV11 only</b> — Arrays use PV11 Batch 6 builtins (CIP-138) and are available
  * from protocol version 11 onwards. They will not work on PV10 networks.
  * <p>
  * On-chain: the JuLC compiler resolves {@code JulcArray<T>} to {@code ArrayType(resolve(T))}.

--- a/julc-core/src/test/java/com/bloxbean/cardano/julc/core/DefaultFunTest.java
+++ b/julc-core/src/test/java/com/bloxbean/cardano/julc/core/DefaultFunTest.java
@@ -139,7 +139,7 @@ class DefaultFunTest {
         assertEquals(expectedCode, DefaultFun.valueOf(name).flatCode());
     }
 
-    // --- V3 bitwise and hash ---
+    // --- Pre-PV11 V3 bitwise and hash additions ---
 
     @ParameterizedTest
     @CsvSource({
@@ -158,17 +158,17 @@ class DefaultFunTest {
             "RotateByteString, 83",
             "CountSetBits, 84",
             "FindFirstSetBit, 85",
-            "Ripemd_160, 86",
-            "ExpModInteger, 87"
+            "Ripemd_160, 86"
     })
     void v3BitwiseAndHash(String name, int expectedCode) {
         assertEquals(expectedCode, DefaultFun.valueOf(name).flatCode());
     }
 
-    // --- V4 additions ---
+    // --- Released PV11 Batch 6 ---
 
     @ParameterizedTest
     @CsvSource({
+            "ExpModInteger, 87",
             "DropList, 88",
             "LengthOfArray, 89",
             "ListToArray, 90",
@@ -181,11 +181,15 @@ class DefaultFunTest {
             "ValueContains, 97",
             "ValueData, 98",
             "UnValueData, 99",
-            "ScaleValue, 100",
-            "MultiIndexArray, 101"
+            "ScaleValue, 100"
     })
-    void v4Additions(String name, int expectedCode) {
+    void pv11Batch6(String name, int expectedCode) {
         assertEquals(expectedCode, DefaultFun.valueOf(name).flatCode());
+    }
+
+    @Test
+    void futureMultiIndexArrayKeepsItsExperimentalFlatTag() {
+        assertEquals(101, DefaultFun.MultiIndexArray.flatCode());
     }
 
     // --- fromFlatCode ---

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
@@ -771,15 +771,15 @@ public final class Builtins {
     }
 
     // =========================================================================
-    // Math operations
+    // PV11 Batch 6 math operation (CIP-109)
     // =========================================================================
 
-    /** Modular exponentiation: (base^exp) mod modulus. */
+    /** Modular exponentiation: (base^exp) mod modulus. PV11 only (CIP-109). */
     public static long expModInteger(long base, long exp, long mod) {
         return BigInteger.valueOf(base).modPow(BigInteger.valueOf(exp), BigInteger.valueOf(mod)).longValue();
     }
 
-    /** Modular exponentiation with BigInteger: (base^exp) mod modulus. */
+    /** Modular exponentiation with BigInteger: (base^exp) mod modulus. PV11 only (CIP-109). */
     public static BigInteger expModInteger(BigInteger base, BigInteger exp, BigInteger mod) {
         return base.modPow(exp, mod);
     }
@@ -895,7 +895,7 @@ public final class Builtins {
     }
 
     // =========================================================================
-    // PV11 List Extensions (CIP-158)
+    // PV11 List Extensions (CIP-132)
     // =========================================================================
 
     /** Drop the first n elements from a list. PV11 only. */
@@ -904,7 +904,7 @@ public final class Builtins {
     }
 
     // =========================================================================
-    // PV11 Array Operations (CIP-156)
+    // PV11 Base Array Operations (CIP-138)
     // =========================================================================
 
     /** Convert a list to an immutable array for O(1) random access. PV11 only. */
@@ -922,9 +922,19 @@ public final class Builtins {
         throw new UnsupportedOperationException("Builtins.indexArray: on-chain only — use Julc VM for off-chain evaluation");
     }
 
-    /** Get multiple elements at the given indices. PV11 only. */
+    /**
+     * Future CIP-156 operation for selecting multiple array indices.
+     * <p>
+     * This is not released in Plutus V3/PV11. The API is retained for forward
+     * development, but the current compiler always rejects calls to it. Use
+     * repeated {@link #indexArray(PlutusData, long)} calls for PV11.
+     *
+     * @deprecated future/unreleased; not ledger-valid at PV11
+     */
+    @Deprecated(forRemoval = false)
     public static PlutusData multiIndexArray(PlutusData array, PlutusData indices) {
-        throw new UnsupportedOperationException("Builtins.multiIndexArray: on-chain only — use Julc VM for off-chain evaluation");
+        throw new UnsupportedOperationException(
+                "Builtins.multiIndexArray: future/unreleased CIP-156 builtin; not ledger-valid at PV11");
     }
 
     // =========================================================================

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/Builtins.java
@@ -884,12 +884,18 @@ public final class Builtins {
 
     // ---- Multi-Scalar Multiplication ----
 
-    /** Multi-scalar multiplication on BLS12-381 G1. Takes a list of scalars and a list of G1 elements. */
+    /**
+     * Multi-scalar multiplication on BLS12-381 G1. Takes a list of scalars and
+     * a list of G1 elements. PV11 only (CIP-133).
+     */
     public static byte[] bls12_381_G1_multiScalarMul(PlutusData scalars, PlutusData points) {
         throw new UnsupportedOperationException("BLS12-381 G1 multiScalarMul: on-chain only — use Julc VM for off-chain evaluation");
     }
 
-    /** Multi-scalar multiplication on BLS12-381 G2. Takes a list of scalars and a list of G2 elements. */
+    /**
+     * Multi-scalar multiplication on BLS12-381 G2. Takes a list of scalars and
+     * a list of G2 elements. PV11 only (CIP-133).
+     */
     public static byte[] bls12_381_G2_multiScalarMul(PlutusData scalars, PlutusData points) {
         throw new UnsupportedOperationException("BLS12-381 G2 multiScalarMul: on-chain only — use Julc VM for off-chain evaluation");
     }
@@ -928,6 +934,9 @@ public final class Builtins {
      * This is not released in Plutus V3/PV11. The API is retained for forward
      * development, but the current compiler always rejects calls to it. Use
      * repeated {@link #indexArray(PlutusData, long)} calls for PV11.
+     * The retained placeholder predates the proposed CIP-156 signature and uses
+     * the legacy {@code (array, indices)} order instead of CIP-156's indices-first
+     * order; it is not a conformant preview of the future builtin.
      *
      * @deprecated future/unreleased; not ledger-valid at PV11
      */

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
@@ -426,6 +426,7 @@ public final class StdlibRegistry implements StdlibLookup {
             {"dropList",                      DefaultFun.DropList},
             // PV11 Array operations (2-arg)
             {"indexArray",                    DefaultFun.IndexArray},
+            // Kept registered so UplcGenerator emits the centralized future/unreleased diagnostic.
             {"multiIndexArray",               DefaultFun.MultiIndexArray},
             // PV11 MaryEraValue operations (2-arg)
             {"unionValue",                    DefaultFun.UnionValue},

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/BlsLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/BlsLib.java
@@ -11,6 +11,8 @@ import java.math.BigInteger;
  * <p>
  * Provides ergonomic wrappers around the raw {@link Builtins} BLS12-381 stubs.
  * On-chain, calls compile to the corresponding UPLC BLS12-381 builtins.
+ * Base BLS operations are available on Plutus V3/PV10; the two multi-scalar
+ * multiplication methods require PV11.
  * <p>
  * <b>Off-chain testing:</b> These methods throw {@link UnsupportedOperationException} when
  * called directly on the JVM. To test code that uses this library:
@@ -115,12 +117,12 @@ public class BlsLib {
 
     // ---- Multi-Scalar Multiplication ----
 
-    /** Multi-scalar multiplication on G1. Takes a list of scalars and a list of G1 elements. */
+    /** Multi-scalar multiplication on G1. Takes scalar and point lists. PV11 only (CIP-133). */
     public static byte[] g1MultiScalarMul(PlutusData scalars, PlutusData points) {
         return Builtins.bls12_381_G1_multiScalarMul(scalars, points);
     }
 
-    /** Multi-scalar multiplication on G2. Takes a list of scalars and a list of G2 elements. */
+    /** Multi-scalar multiplication on G2. Takes scalar and point lists. PV11 only (CIP-133). */
     public static byte[] g2MultiScalarMul(PlutusData scalars, PlutusData points) {
         return Builtins.bls12_381_G2_multiScalarMul(scalars, points);
     }

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/MathLib.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/lib/MathLib.java
@@ -111,7 +111,7 @@ public class MathLib {
         return result;
     }
 
-    /** Returns (base^exp) mod modulus using the builtin ExpModInteger operation. */
+    /** Returns (base^exp) mod modulus using the PV11 Batch 6 ExpModInteger operation (CIP-109). */
     public static BigInteger expMod(BigInteger base, BigInteger exp, BigInteger mod) {
         return Builtins.expModInteger(base, exp, mod);
     }

--- a/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/JulcArrayTest.java
+++ b/julc-stdlib/src/test/java/com/bloxbean/cardano/julc/stdlib/lib/JulcArrayTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for {@link JulcArray} — PV11 array operations (CIP-156).
+ * Tests for {@link JulcArray} — PV11 base Array operations (CIP-138).
  * On-chain tests use JulcEval to compile and evaluate through the UPLC VM.
  * Off-chain tests use JulcArrayImpl directly.
  */
@@ -138,37 +138,6 @@ class JulcArrayTest {
                         new PlutusData.IntData(BigInteger.valueOf(20)),
                         new PlutusData.IntData(BigInteger.valueOf(30))));
                 assertEquals(20, eval.call("test", list).asLong());
-            }
-        }
-
-        @Nested
-        class MultiIndex {
-
-            @Test
-            @org.junit.jupiter.api.Disabled("MultiIndexArray not yet supported by Scalus VM backend — works with julc-vm-java")
-            void selectMultiple() {
-                var eval = JulcEval.forSource(IMPORTS + """
-                        class T {
-                            static BigInteger test(PlutusData data) {
-                                var list = Builtins.unListData(data);
-                                var arr = Builtins.listToArray(list);
-                                var indices = Builtins.mkCons(
-                                    Builtins.iData(0),
-                                    Builtins.mkCons(Builtins.iData(2), Builtins.mkNilData()));
-                                var result = Builtins.multiIndexArray(arr, indices);
-                                var first = Builtins.unIData(Builtins.headList(result));
-                                var rest = Builtins.tailList(result);
-                                var second = Builtins.unIData(Builtins.headList(rest));
-                                return first.add(second);
-                            }
-                        }
-                        """);
-                var list = new PlutusData.ListData(List.of(
-                        new PlutusData.IntData(BigInteger.valueOf(10)),
-                        new PlutusData.IntData(BigInteger.valueOf(20)),
-                        new PlutusData.IntData(BigInteger.valueOf(30))));
-                // arr[0] + arr[2] = 10 + 30 = 40
-                assertEquals(40, eval.call("test", list).asLong());
             }
         }
 

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/ArrayBuiltins.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/ArrayBuiltins.java
@@ -61,6 +61,8 @@ public final class ArrayBuiltins {
      * <p>
      * Experimental runtime support only: tag 101 is not ledger-valid in
      * Plutus V3/PV11.
+     * This legacy placeholder uses {@code (array, indices)} rather than the
+     * indices-first order proposed by CIP-156 and is not a conformant preview.
      */
     public static CekValue multiIndexArray(List<CekValue> args) {
         var ac = asArrayConst(args.get(0), "MultiIndexArray");

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/ArrayBuiltins.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/ArrayBuiltins.java
@@ -10,7 +10,8 @@ import java.util.List;
 import static com.bloxbean.cardano.julc.vm.java.builtins.BuiltinHelper.*;
 
 /**
- * Array operation builtins (PV11 Batch 6, CIP-156).
+ * Base Array operation builtins (PV11 Batch 6, CIP-138), plus the
+ * future/experimental CIP-156 multi-index operation.
  */
 public final class ArrayBuiltins {
 
@@ -57,6 +58,9 @@ public final class ArrayBuiltins {
     /**
      * MultiIndexArray: force=1, arity=2 → (array, indices_list)
      * Returns a list of elements at the given indices.
+     * <p>
+     * Experimental runtime support only: tag 101 is not ledger-valid in
+     * Plutus V3/PV11.
      */
     public static CekValue multiIndexArray(List<CekValue> args) {
         var ac = asArrayConst(args.get(0), "MultiIndexArray");

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/BuiltinTable.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/BuiltinTable.java
@@ -12,7 +12,9 @@ import java.util.Map;
 /**
  * Master registry mapping {@link DefaultFun} to its signature and runtime implementation.
  * <p>
- * Covers all V1/V2/V3 builtins including PV11 Batch 6.
+ * Covers all V1/V2/V3 builtins through PV11 Batch 6. The raw table also keeps
+ * an experimental implementation of future tag 101; protocol-profile views
+ * exclude it from Plutus V3/PV11 evaluation.
  * <p>
  * Use {@link #forLanguage(PlutusLanguage)} to get a version-gated view that only
  * includes builtins available in the specified Plutus language version.
@@ -143,16 +145,18 @@ public final class BuiltinTable {
         // === V3 RIPEMD-160 (CIP-127) ===
         reg(DefaultFun.Ripemd_160,              0, 1, CryptoBuiltins::ripemd_160);
 
-        // === V3 Modular exponentiation (CIP-109) ===
+        // === PV11 Batch 6: modular exponentiation (CIP-109) ===
         reg(DefaultFun.ExpModInteger,           0, 3, IntegerBuiltins::expModInteger);
 
-        // === PV11 Batch 6: List extensions (CIP-158) ===
+        // === PV11 Batch 6: List extensions (CIP-132) ===
         reg(DefaultFun.DropList,                1, 2, ListExtBuiltins::dropList);
 
-        // === PV11 Batch 6: Array operations (CIP-156) ===
+        // === PV11 Batch 6: base Array operations (CIP-138) ===
         reg(DefaultFun.LengthOfArray,           1, 1, ArrayBuiltins::lengthOfArray);
         reg(DefaultFun.ListToArray,             1, 1, ArrayBuiltins::listToArray);
         reg(DefaultFun.IndexArray,              1, 2, ArrayBuiltins::indexArray);
+
+        // === Future/unreleased: MultiIndexArray (CIP-156), experimental VM only ===
         reg(DefaultFun.MultiIndexArray,         1, 2, ArrayBuiltins::multiIndexArray);
 
         // === PV11 Batch 6: BLS12-381 multi-scalar multiplication (CIP-133) ===

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/ListExtBuiltins.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/builtins/ListExtBuiltins.java
@@ -7,7 +7,7 @@ import java.util.List;
 import static com.bloxbean.cardano.julc.vm.java.builtins.BuiltinHelper.*;
 
 /**
- * Extended list operation builtins (PV11 Batch 6, CIP-158).
+ * Extended list operation builtins (PV11 Batch 6, CIP-132).
  */
 public final class ListExtBuiltins {
 

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParser.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParser.java
@@ -16,9 +16,10 @@ import static com.bloxbean.cardano.julc.vm.java.cost.CostFunction.*;
  * into {@link MachineCosts} and {@link BuiltinCostModel}.
  * <p>
  * Each flat array follows the canonical ordering of its ledger language's
- * {@code PlutusLedgerApi.V<n>.ParamName} enumeration. The supported schemas are
- * pinned to cardano-node 11.0.1 / Plutus 1.63.0.0 at commit
- * {@code f92b7d7d82622a26caf456a6be33859f697e2cfc}.
+ * {@code PlutusLedgerApi.V<n>.ParamName} enumeration. Supported schemas extend
+ * through PV11; their ordering was verified against Plutus 1.63.0.0 at commit
+ * {@code f92b7d7d82622a26caf456a6be33859f697e2cfc}, as shipped by
+ * cardano-node 11.0.1.
  *
  * <p>The order is append-only rather than globally alphabetical. In particular,
  * V1, V2, and V3 have different legacy cost-function shapes and different
@@ -124,7 +125,8 @@ public final class CostModelParser {
     /**
      * Expected parameter count for PlutusV3 PV11 (post-Chang+2).
      * <p>
-     * Adds 53 params: ExpModInteger (5, moved from defaults-only to array) + 13 PV11 builtins (48).
+     * Adds 53 params: ExpModInteger (5, moved from defaults-only to array) + the
+     * remaining 13 PV11 Batch 6 builtins (48).
      * Canonical ordering from Haskell ParamName.hs.
      */
     public static final int PV11_PARAM_COUNT = 350;
@@ -1047,7 +1049,7 @@ public final class CostModelParser {
         return new IllegalArgumentException(
                 "Unsupported cost-model schema for " + language + " at protocol version "
                         + protocolMajorVersion
-                        + "; parser is pinned through cardano-node 11.0.1/PV11");
+                        + "; parser supports schemas through PV11");
     }
 
     // ========== V1/V2 authoritative ParamName writers ==========

--- a/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/DefaultCostModel.java
+++ b/julc-vm-java/src/main/java/com/bloxbean/cardano/julc/vm/java/cost/DefaultCostModel.java
@@ -570,19 +570,19 @@ public final class DefaultCostModel {
                 new LinearInX(1964219, 24520),
                 new ConstantCost(3)));
 
-        // === V3 Modular exponentiation (CIP-109) ===
+        // === PV11 Batch 6: modular exponentiation (CIP-109) ===
         costs.put(DefaultFun.ExpModInteger, pair(
                 new ExpModCost(607153, 231697, 53144),
                 new LinearInZ(0, 1)));
 
         // === PV11 Batch 6 builtins ===
 
-        // List extensions (CIP-158)
+        // List extensions (CIP-132)
         costs.put(DefaultFun.DropList, pair(
                 new LinearInX(116711, 1957),
                 new ConstantCost(4)));
 
-        // Array operations (CIP-156)
+        // Base Array operations (CIP-138)
         costs.put(DefaultFun.LengthOfArray, pair(
                 new ConstantCost(231883),
                 new ConstantCost(10)));
@@ -624,7 +624,8 @@ public final class DefaultCostModel {
                 new LinearInY(1000, 277577),
                 new LinearInY(12, 21)));
 
-        // MultiIndexArray — JuLC-specific (code 101), not in on-chain cost params.
+        // Future/unreleased MultiIndexArray (CIP-156, code 101). Experimental VM
+        // support only; absent from PV11 on-chain cost parameters.
         // Estimated costs based on IndexArray.
         costs.put(DefaultFun.MultiIndexArray, pair(
                 new ConstantCost(232010),

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/LanguageVersionTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/LanguageVersionTest.java
@@ -187,7 +187,7 @@ class LanguageVersionTest {
         @Test
         void v3_builtins_have_version_3() {
             assertEquals(3, DefaultFun.Bls12_381_G1_add.minLanguageVersion());
-            assertEquals(3, DefaultFun.ExpModInteger.minLanguageVersion()); // last V3 (code 87)
+            assertEquals(3, DefaultFun.ExpModInteger.minLanguageVersion()); // first Batch 6 tag (87)
         }
 
         @Test

--- a/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParserTest.java
+++ b/julc-vm-java/src/test/java/com/bloxbean/cardano/julc/vm/java/cost/CostModelParserTest.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.julc.core.text.UplcParser;
 import com.bloxbean.cardano.julc.vm.BuiltinSemanticsVariant;
 import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
 import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureRegistry;
 import com.bloxbean.cardano.julc.vm.java.JavaVmProvider;
 import org.junit.jupiter.api.Test;
 
@@ -254,7 +255,7 @@ class CostModelParserTest {
         for (var fun : DefaultFun.values()) {
             var defaultPair = defaultBcm.get(fun);
             if (defaultPair == null) continue;
-            // MultiIndexArray is JuLC-specific, not in PV11 flat array
+            // Future MultiIndexArray is not in the PV11 flat array.
             if (fun == DefaultFun.MultiIndexArray) continue;
 
             var parsedPair = parsedBcm.get(fun);
@@ -363,20 +364,29 @@ class CostModelParserTest {
     @Test
     void defaultCostModel_pv11BuiltinsHaveNonNullCosts() {
         var bcm = DefaultCostModel.defaultBuiltinCostModel(BuiltinSemanticsVariant.E);
-        DefaultFun[] pv11Builtins = {
-                DefaultFun.DropList, DefaultFun.LengthOfArray, DefaultFun.ListToArray,
+        DefaultFun[] releasedPv11Builtins = {
+                DefaultFun.ExpModInteger, DefaultFun.DropList,
+                DefaultFun.LengthOfArray, DefaultFun.ListToArray,
                 DefaultFun.IndexArray, DefaultFun.Bls12_381_G1_multiScalarMul,
                 DefaultFun.Bls12_381_G2_multiScalarMul, DefaultFun.InsertCoin,
                 DefaultFun.LookupCoin, DefaultFun.UnionValue, DefaultFun.ValueContains,
-                DefaultFun.ValueData, DefaultFun.UnValueData, DefaultFun.ScaleValue,
-                DefaultFun.MultiIndexArray
+                DefaultFun.ValueData, DefaultFun.UnValueData, DefaultFun.ScaleValue
         };
-        for (var fun : pv11Builtins) {
+        for (var fun : releasedPv11Builtins) {
             var pair = bcm.get(fun);
             assertNotNull(pair, "Missing cost pair for PV11 builtin: " + fun);
             assertNotNull(pair.cpu(), "Null CPU cost for " + fun);
             assertNotNull(pair.mem(), "Null mem cost for " + fun);
         }
+    }
+
+    @Test
+    void defaultCostModel_keepsFutureMultiIndexCostForExperimentalVmOnly() {
+        var bcm = DefaultCostModel.defaultBuiltinCostModel(BuiltinSemanticsVariant.E);
+        assertNotNull(bcm.get(DefaultFun.MultiIndexArray));
+        assertFalse(ProtocolFeatureRegistry.resolve(
+                        LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3))
+                .isBuiltinAvailable(DefaultFun.MultiIndexArray));
     }
 
     @Test

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/CostModelSchema.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/CostModelSchema.java
@@ -1,6 +1,6 @@
 package com.bloxbean.cardano.julc.vm;
 
-/** Known flat cost-model schemas at the cardano-node 11.0.1 compatibility baseline. */
+/** Known flat cost-model schemas through PV11. */
 public enum CostModelSchema {
     PLUTUS_V1_LEGACY(166),
     PLUTUS_V1_PV11(332),

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureRegistry.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureRegistry.java
@@ -7,10 +7,11 @@ import java.util.EnumSet;
 import java.util.Set;
 
 /**
- * Table-driven ledger feature mapping pinned to cardano-node 11.0.1 / Plutus
- * 1.63.0.0 ({@code f92b7d7d82622a26caf456a6be33859f697e2cfc}).
- * Protocol versions newer than PV11 are deliberately rejected until the
- * compatibility baseline is explicitly upgraded.
+ * Table-driven ledger feature mapping supported through PV11. The mapping was
+ * verified against Plutus 1.63.0.0
+ * ({@code f92b7d7d82622a26caf456a6be33859f697e2cfc}), as shipped by
+ * cardano-node 11.0.1. Protocol versions newer than PV11 are deliberately
+ * rejected until the supported protocol profile is explicitly upgraded.
  */
 public final class ProtocolFeatureRegistry {
 
@@ -32,7 +33,7 @@ public final class ProtocolFeatureRegistry {
         if (protocol > MAX_SUPPORTED_PROTOCOL_MAJOR) {
             throw new UnsupportedLedgerTargetException(
                     "Protocol version " + target.protocolVersion()
-                            + " is newer than the pinned cardano-node 11.0.1/PV11 baseline");
+                            + " is newer than the supported PV11 profile");
         }
 
         int introduced = introducedIn(target.ledgerLanguage());

--- a/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureRegistryTest.java
+++ b/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureRegistryTest.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.Term;
 import org.junit.jupiter.api.Test;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -56,6 +57,35 @@ class ProtocolFeatureRegistryTest {
         for (var language : PlutusLanguage.values()) {
             assertFalse(profile(language, 11).isBuiltinAvailable(DefaultFun.MultiIndexArray));
         }
+    }
+
+    @Test
+    void pv11Batch6ExactlyMatchesPinnedHaskellBaseline() {
+        // PlutusLedgerApi.Common.Versions.batch6 at f92b7d7d8.
+        var expected = Set.of(
+                DefaultFun.ExpModInteger,
+                DefaultFun.DropList,
+                DefaultFun.LengthOfArray,
+                DefaultFun.ListToArray,
+                DefaultFun.IndexArray,
+                DefaultFun.Bls12_381_G1_multiScalarMul,
+                DefaultFun.Bls12_381_G2_multiScalarMul,
+                DefaultFun.InsertCoin,
+                DefaultFun.LookupCoin,
+                DefaultFun.UnionValue,
+                DefaultFun.ValueContains,
+                DefaultFun.ValueData,
+                DefaultFun.UnValueData,
+                DefaultFun.ScaleValue);
+
+        var newlyAvailable = EnumSet.copyOf(
+                profile(PlutusLanguage.PLUTUS_V3, 11).availableBuiltins());
+        newlyAvailable.removeAll(
+                profile(PlutusLanguage.PLUTUS_V3, 10).availableBuiltins());
+
+        assertEquals(expected, newlyAvailable);
+        assertEquals(EnumSet.range(DefaultFun.ExpModInteger, DefaultFun.ScaleValue), newlyAvailable);
+        assertFalse(newlyAvailable.contains(DefaultFun.MultiIndexArray));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- define released PV11 Batch 6 exactly as FLAT tags 87-100, including ExpModInteger
- classify MultiIndexArray/tag 101 as future-only and reject it at the common compiler lowering boundary
- correct CIP references and distinguish the PV11 semantic target from the pinned node verification baseline
- retain tag 101 in AST/FLAT and experimental VM support without advertising it as ledger-valid
- add migration guidance and compiler/profile regression coverage

## Haskell verification

The PV11 builtin set and FLAT tags were checked against Plutus 1.63.0.0 at f92b7d7d82622a26caf456a6be33859f697e2cfc, as shipped by cardano-node 11.0.1:

- Versions.batch6 contains ExpModInteger through ScaleValue
- Default.Builtins assigns those builtins tags 87 through 100
- MultiIndexArray/tag 101 is absent from that released implementation

The compiler and public API target the Plutus V3/PV11 feature set. The node release and Plutus commit are retained only as verification and golden-vector provenance.

## Verification

- focused compiler, core, protocol-profile, and cost-model tests forced and passed
- full ./gradlew test passed
- documentation build passed (22 pages)
- relevant Javadocs passed
- git diff --check passed

Fixes #75
