### PR TITLE
fix(compiler): preserve nested early return control flow

### DIFF
--- a/adr/issues/pir-uplc-if-else-lowering.md
+++ b/adr/issues/pir-uplc-if-else-lowering.md
@@ -1,0 +1,569 @@
+# Understanding `if`/`else` Lowering in PIR and UPLC
+
+- **Type:** Explanatory compiler note
+- **Audience:** JuLC contributors and developers learning PIR/UPLC
+- **Scope:** Java control flow → PIR → UPLC
+- **Historical reference:** [PR #80](https://github.com/bloxbean/julc/pull/80) fixed the nested early-return lowering defect that motivated this guide.
+
+## Purpose
+
+Java, PIR, and UPLC express control flow differently:
+
+- Java is statement-oriented and has control-transfer statements such as `return`.
+- JuLC's PIR is expression-oriented: an `if` is an expression that produces a value.
+- UPLC is a small, strict functional language. It has functions, application, constants,
+  builtins, `delay`, and `force`, but no Java-style `return`, `break`, or mutable program counter.
+
+Understanding those differences is essential when changing statement lowering. A Java branch
+cannot merely *contain a value corresponding to a return*; the surrounding PIR structure must make
+that value the result of the complete execution path.
+
+This note introduces the relevant syntax and develops the lowering one step at a time.
+
+## 1. The three levels
+
+Consider a simple Java method:
+
+```java
+static boolean choose(boolean condition) {
+    if (condition) {
+        return true;
+    } else {
+        return false;
+    }
+}
+```
+
+Conceptually, JuLC translates it through three representations:
+
+```text
+Java statements
+    ↓
+PIR expressions with names and types
+    ↓
+UPLC functions, applications, constants, delays, and builtins
+```
+
+The important transition is from Java statements to a single expression representing the result
+of each path.
+
+## 2. PIR is expression-oriented
+
+The PIR form of `choose` is approximately:
+
+```text
+lam condition : Bool
+  if condition then
+    true
+  else
+    false
+```
+
+Read the syntax as follows:
+
+- `lam condition : Bool body` defines a function taking one Boolean argument.
+- `if condition then A else B` evaluates only the selected branch and produces its value.
+- `true` and `false` are the values returned by the function paths.
+
+There is no separate PIR `return` instruction here. The Java returns disappear during lowering.
+Their expressions become the final values of their respective branches.
+
+## 3. What `let ... in ...` means
+
+PIR uses `let` to bind a value and then evaluate another expression:
+
+```text
+let x = 10
+in x + 5
+```
+
+Read it as:
+
+1. Evaluate `10`.
+2. Bind it to the name `x`.
+3. Evaluate the expression after `in` using that binding.
+
+The result is `15`.
+
+In Java-like pseudocode:
+
+```java
+var x = 10;
+return x + 5;
+```
+
+The expression after `in` is the body of the binding. It is also the result of the complete `let`
+expression.
+
+### An unused binding
+
+This PIR is valid, although usually pointless:
+
+```text
+let ignored = expensiveCalculation
+in true
+```
+
+It evaluates `expensiveCalculation`, binds its result to `ignored`, and then returns `true`.
+The value of `expensiveCalculation` cannot affect the final result because the body does not use
+`ignored`.
+
+That distinction matters for control-flow lowering. A branch value may be discarded only when it
+does not represent the final result of an early-returning execution path.
+
+## 4. Ordinary `if` followed by more statements
+
+Consider Java where neither branch returns:
+
+```java
+static boolean ordinary(boolean condition) {
+    if (condition) {
+        traceFirstPath();
+    } else {
+        traceSecondPath();
+    }
+
+    return true;
+}
+```
+
+A sequencing-oriented PIR shape is:
+
+```text
+let ignoredIfResult =
+  if condition then
+    traceFirstPath()
+  else
+    traceSecondPath()
+in
+  true
+```
+
+This shape is reasonable because both Java branches fall through to `return true`. The branch
+results are not method return values; the branches perform their work and execution continues.
+
+## 5. Early returns require a different shape
+
+Now consider:
+
+```java
+static boolean guard(boolean invalid) {
+    if (invalid) {
+        return false;
+    }
+
+    return true;
+}
+```
+
+The correct PIR is:
+
+```text
+lam invalid : Bool
+  if invalid then
+    false
+  else
+    true
+```
+
+The trailing `return true` becomes the continuation of the path that falls through the `if`.
+It must not be placed unconditionally after the `if`.
+
+The following lowering is wrong:
+
+```text
+lam invalid : Bool
+  let ignoredIfResult =
+    if invalid then false else unit
+  in
+    true
+```
+
+When `invalid` is true, the conditional produces `false`, but that value is assigned to an unused
+name. The expression after `in` still produces `true`.
+
+Here `unit`, normally written `()`, is a placeholder value comparable to Java's `void`. It does not
+mean “continue” or “return”; it is just an ordinary value.
+
+## 6. Fall-through continuations
+
+In compiler terminology, a continuation describes what should happen next.
+
+For the previous method:
+
+```java
+if (invalid) {
+    return false;
+}
+return true;
+```
+
+the continuation of the `if` is:
+
+```text
+true
+```
+
+Branch lowering then follows two rules:
+
+1. If a path encounters a method `return`, that path produces the returned value and does not use
+   the continuation.
+2. If a path reaches the end of its block, it evaluates the continuation.
+
+This produces:
+
+```text
+if invalid then
+  false          -- returned: stop this path
+else
+  true           -- fell through: run the continuation
+```
+
+The continuation is not a runtime object in this example. It is a compiler technique for building
+the correct expression tree.
+
+## 7. A nested example
+
+Consider a generic two-condition decision:
+
+```java
+static boolean decide(BigInteger x, BigInteger y) {
+    if (x.compareTo(BigInteger.ZERO) > 0) {
+        if (y.compareTo(BigInteger.ZERO) <= 0) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}
+```
+
+For readability, define:
+
+```text
+xPositive    = x.compareTo(0) > 0
+yNonPositive = y.compareTo(0) <= 0
+```
+
+The intended paths are:
+
+```text
+xPositive = false                         → false
+xPositive = true, yNonPositive = true    → false
+xPositive = true, yNonPositive = false   → true
+```
+
+### Correct PIR
+
+The correct expression tree is:
+
+```text
+lam x : Integer
+  lam y : Integer
+    if xPositive then
+      if yNonPositive then
+        false
+      else
+        true
+    else
+      false
+```
+
+The final Java `return true` has been inserted only on the path that can reach it.
+
+### Incorrect discarded-result shape
+
+This structure does not preserve Java return semantics:
+
+```text
+lam x : Integer
+  lam y : Integer
+    let ignoredIfResult =
+      if xPositive then
+        if yNonPositive then false else unit
+      else
+        false
+    in
+      true
+```
+
+All paths eventually evaluate the body after `in`, so the final result is `true` even when the
+conditional calculated `false`.
+
+## 8. PIR `let` becomes UPLC function application
+
+UPLC has no native `let` syntax. A PIR binding:
+
+```text
+let x = value
+in body
+```
+
+is represented using a function application:
+
+```text
+[(lam x body) value]
+```
+
+UPLC notation used by JuLC:
+
+- `(lam x body)` — a function accepting `x`.
+- `[function argument]` — apply a function to one argument.
+- `[[function a] b]` — apply a two-argument function one argument at a time.
+- `(con bool True)` — a Boolean constant.
+- `(builtin lessThanInteger)` — a Plutus builtin.
+
+For example:
+
+```text
+let ignoredIfResult = conditionalValue
+in true
+```
+
+becomes:
+
+```text
+[(lam ignoredIfResult (con bool True)) conditionalValue]
+```
+
+The function body never references `ignoredIfResult`. Therefore, after the argument has been
+evaluated, this application always produces `True`.
+
+## 9. UPLC is strict: why `delay` and `force` appear
+
+UPLC uses strict, call-by-value evaluation. Function arguments are normally evaluated before the
+function runs.
+
+For an `if`, evaluating both branches would be incorrect. Only the selected branch should run;
+the other branch may contain an error, a trace, or expensive work.
+
+JuLC therefore passes delayed branches to the `ifThenElse` builtin:
+
+```text
+force
+  [[[(force (builtin ifThenElse)) condition]
+    (delay thenBranch)]
+   (delay elseBranch)]
+```
+
+Read it in stages:
+
+1. `(builtin ifThenElse)` identifies the builtin.
+2. The first `force` instantiates the builtin's polymorphic result type.
+3. `condition` is evaluated normally.
+4. `thenBranch` and `elseBranch` are wrapped in `delay`, so neither runs immediately.
+5. `ifThenElse` selects one delayed branch.
+6. The outer `force` evaluates only the selected branch.
+
+For beginners, it is sufficient to read the complete structure as:
+
+```text
+if condition then thenBranch else elseBranch
+```
+
+while remembering that `delay` and `force` preserve the normal lazy behavior of conditional
+branches inside an otherwise strict language.
+
+## 10. Correct nested UPLC shape
+
+Using readable condition names, the nested decision becomes:
+
+```text
+lam x
+  lam y
+    force
+      [[[(force (builtin ifThenElse)) xPositive]
+        (delay
+          (force
+            [[[(force (builtin ifThenElse)) yNonPositive]
+              (delay (con bool False))]
+             (delay (con bool True))]))]
+       (delay (con bool False))]
+```
+
+The inner structure means:
+
+```text
+if yNonPositive then false else true
+```
+
+The outer structure means:
+
+```text
+if xPositive then <inner result> else false
+```
+
+No unused lambda receives and discards the conditional result.
+
+## 11. Names in PIR versus indices in UPLC
+
+PIR is designed to be readable and retains variable names:
+
+```text
+lam x
+  lam y
+    addInteger x y
+```
+
+JuLC's printed UPLC commonly uses De Bruijn indices such as `i1` and `i2`:
+
+```text
+lam x
+  lam y
+    addInteger i2 i1
+```
+
+The indices count outward through enclosing binders:
+
+- `i1` refers to the nearest binder, which is `y`.
+- `i2` refers to the next binder, which is `x`.
+
+The names printed beside `lam` are helpful labels, but variable references are encoded by position.
+This avoids name-capture problems and makes alpha-equivalent programs identical.
+
+## 12. Method argument wrappers
+
+When a standalone method is compiled for evaluation, JuLC may generate a wrapper around the typed
+method:
+
+```text
+let decide =
+  lam x : Integer
+    lam y : Integer
+      <decision body>
+in
+  lam xRaw : Data
+    let xDecoded = unIData(xRaw)
+    in
+      lam yRaw : Data
+        let yDecoded = unIData(yRaw)
+        in
+          decide xDecoded yDecoded
+```
+
+The wrapper exists because Plutus entry boundaries use `Data`. It:
+
+1. accepts raw `Data` arguments;
+2. decodes them to integers;
+3. calls the typed method.
+
+This wrapper is separate from `if`/`else` lowering, but it explains why complete PIR and UPLC dumps
+contain additional lambdas and `unIData` builtins around the method body.
+
+## 13. `BigInteger.compareTo` makes dumps look larger
+
+The Java expression:
+
+```java
+x.compareTo(BigInteger.ZERO)
+```
+
+produces `-1`, `0`, or `1`. JuLC may therefore lower it approximately as:
+
+```text
+if x < 0 then
+  -1
+else if x == 0 then
+  0
+else
+  1
+```
+
+A source condition such as:
+
+```java
+x.compareTo(BigInteger.ZERO) > 0
+```
+
+then compares that result with zero. This is why a literal PIR or UPLC dump can contain several
+nested integer comparisons before reaching the control-flow structure being studied.
+
+When reviewing lowering, it is often useful to temporarily name such subexpressions (`xPositive`,
+`yNonPositive`) and first verify the surrounding branch structure.
+
+## 14. Compiler invariants for conditional lowering
+
+The following rules are useful when reviewing or extending JuLC's statement compiler:
+
+1. Every PIR and UPLC function path must ultimately produce a value.
+2. A Java method `return` must become the final value of that path, not merely the value of an
+   inner expression.
+3. Statements after an `if` belong only to branches that can fall through.
+4. A branch that returns must not evaluate the fall-through continuation.
+5. Branch-local variables must remain scoped to their branch.
+6. Returns inside nested lambdas belong to those lambdas, not the enclosing method.
+7. UPLC conditional branches must remain delayed so only the selected branch evaluates.
+8. Discarding an `if` result is appropriate only when no branch result represents method-level
+   control transfer.
+
+## 15. Compact mental model
+
+When reading Java:
+
+```java
+if (condition) {
+    return A;
+}
+return B;
+```
+
+do not imagine PIR as executing a `return` instruction. Instead, rewrite the method mentally as
+one expression:
+
+```text
+if condition then A else B
+```
+
+For a nested example:
+
+```java
+if (first) {
+    if (second) {
+        return A;
+    }
+} else {
+    return B;
+}
+return C;
+```
+
+the expression is:
+
+```text
+if first then
+  if second then A else C
+else
+  B
+```
+
+That expression-tree view is the central idea behind correct Java-to-PIR and PIR-to-UPLC control
+flow lowering.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| PIR | JuLC's typed, named intermediate representation before UPLC generation |
+| UPLC | Untyped Plutus Core, the language executed by the Plutus VM |
+| Expression-oriented | Constructs such as `if` produce values rather than merely directing statements |
+| `lam` | Lambda: a function definition |
+| Application | Calling a function with an argument, printed as `[function argument]` |
+| `let ... in ...` | Bind a value and evaluate a body under that binding |
+| Continuation | The computation to perform when the current block falls through |
+| `unit` | The single `()` placeholder value, similar to a void result |
+| `delay` | Package an expression without evaluating it yet |
+| `force` | Evaluate a delayed expression, or instantiate a polymorphic builtin |
+| De Bruijn index | A variable reference encoded by binder distance, such as `i1` or `i2` |
+
+## Relevant JuLC implementation
+
+- `julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java`
+  lowers Java statements and expressions into PIR.
+- `julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirTerm.java`
+  defines PIR terms such as `Lam`, `Let`, and `IfThenElse`.
+- `julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java`
+  translates PIR into UPLC.
+- `julc-core/src/main/java/com/bloxbean/cardano/julc/core/text/UplcPrinter.java`
+  prints UPLC programs in textual form.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -42,6 +42,12 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Best Practices',
+          items: [
+            { label: 'Conditionals and Script Size', slug: 'best-practices/conditionals' },
+          ],
+        },
+        {
           label: 'Standard Library',
           items: [
             { label: 'Library Reference', slug: 'stdlib/stdlib-guide' },

--- a/docs/scripts/generate-llms-txt.mjs
+++ b/docs/scripts/generate-llms-txt.mjs
@@ -48,6 +48,10 @@ const SECTIONS = [
     ],
   },
   {
+    title: 'Best Practices',
+    files: ['best-practices/conditionals.md'],
+  },
+  {
     title: 'Standard Library',
     files: ['stdlib/stdlib-guide.md'],
   },

--- a/docs/src/content/docs/ai/starter-pack.md
+++ b/docs/src/content/docs/ai/starter-pack.md
@@ -76,6 +76,35 @@ Build artifact: `build/classes/META-INF/plutus/MyValidator.plutus.json` — the 
 - 🚫 **Same parameter name as a sealed-interface constructor field.** See limitation 6.4.
 - 🚫 **Calling `.hash()` on a value that is already a hash type** (double-unwrap).
 
+### 3.4 Conditional control flow and script size
+
+- An `if` does **not** need an `else`. Nested `if` statements and code following them
+  retain normal Java behavior.
+- Prefer linear guard clauses for independent validation rules:
+
+  ```java
+  if (!validAmount(datum)) {
+      return false;
+  }
+  if (!ownerSigned(ctx, datum)) {
+      return false;
+  }
+  return validateOutputs(ctx);
+  ```
+
+- Put cheap, safe checks before expensive checks so invalid transactions stop early.
+- When branches mix early returns with fallthrough, code after the conditional becomes
+  the continuation of every branch that can reach it. If several branches reach a large
+  common block, extract that block into a static helper so its generated body is defined
+  once.
+- Do **not** move unsafe operations (such as `list.head()`, division, indexing, or data
+  decoding) before their guards merely to reduce size. UPLC evaluation is strict.
+- For sealed types, prefer an exhaustive `switch` expression that produces a value.
+  Do not generate a statement-style switch containing `return` in its cases.
+
+Full examples and the reasoning behind these rules:
+[Conditionals and Script Size](/best-practices/conditionals/).
+
 ---
 
 ## 4. Validator annotation entrypoint shapes
@@ -585,6 +614,8 @@ For deeper patterns, consult [`julc-examples`](https://github.com/bloxbean/julc-
 - ❌ **`@Param PlutusData.BytesData/MapData/ListData/IntData`.** Banned.
 - ❌ **Three-way mutual recursion.** Refactor.
 - ❌ **Calling `.hash()` on a value that is already hash bytes.** Causes double-unwrap.
+- ❌ **Repeating a large common block after deeply branching early-return logic.** Keep
+  common work in one helper and use guard clauses where they express the rules clearly.
 
 ---
 
@@ -613,6 +644,7 @@ Before writing any JuLC code, verify the agent can answer "yes" to each:
 8. ✅ Are switch case binding names different from method parameter names?
 9. ✅ Am I using `@SpendingValidator` / `@MintingValidator` etc. correctly with a `static @Entrypoint` method?
 10. ✅ Have I imported from `com.bloxbean.cardano.julc.ledger.*` and `com.bloxbean.cardano.julc.stdlib.lib.*`?
+11. ✅ Have I used guard clauses and kept any large shared continuation in one helper?
 
 If yes to all → write the code. If unsure on any → re-read the relevant section above.
 

--- a/docs/src/content/docs/best-practices/conditionals.md
+++ b/docs/src/content/docs/best-practices/conditionals.md
@@ -289,6 +289,3 @@ Before optimizing a validator, ask:
 - Would one well-named helper keep that common block in one place?
 - Am I preserving guards before operations that can fail?
 - Have I measured both serialized script size and execution budget?
-
-For compiler-level PIR and UPLC examples, see
-[PIR and UPLC `if`/`else` lowering](https://github.com/bloxbean/julc/blob/main/adr/issues/pir-uplc-if-else-lowering.md).

--- a/docs/src/content/docs/best-practices/conditionals.md
+++ b/docs/src/content/docs/best-practices/conditionals.md
@@ -1,0 +1,294 @@
+---
+title: "Conditionals and Script Size"
+description: "How to write clear and compact if/else and switch expressions in JuLC contracts"
+---
+
+JuLC supports familiar Java conditionals: `if`, `else if`, `else`, the ternary
+operator, and exhaustive `switch` expressions. You do not need to rewrite normal,
+readable Java just because the contract eventually runs as UPLC.
+
+There is one on-chain detail worth knowing: code after a conditional may become part
+of every generated branch that can reach it. Usually this is small and harmless. If
+the shared code is large, however, the generated script can become larger than the
+Java source suggests.
+
+This page shows how to keep validation code readable while avoiding unnecessary
+script size and execution cost.
+
+## Short version
+
+- An `if` does **not** need an `else`.
+- Nested `if` statements work, including several levels of nesting.
+- Code after a nested `if` runs only when execution reaches it, just as it does in Java.
+- Prefer a sequence of guard clauses for independent validation rules.
+- Put cheap checks before expensive checks so failures stop early.
+- Keep large common work outside branch bodies.
+- If several branches reach the same large block, extract that block into a helper method.
+- Prefer exhaustive `switch` expressions for sealed types such as redeemers.
+- Measure script size and execution budget; do not optimize based only on appearance.
+
+## `else` is optional
+
+This is valid JuLC:
+
+```java
+static boolean validate(BigInteger amount) {
+    if (amount.compareTo(BigInteger.ZERO) <= 0) {
+        return false;
+    }
+
+    return true;
+}
+```
+
+When the condition is false, execution continues with `return true`. JuLC preserves
+that Java behavior when it creates the UPLC program.
+
+The same applies to nested conditionals:
+
+```java
+static boolean validate(BigInteger a, BigInteger b) {
+    if (a.compareTo(BigInteger.ZERO) > 0) {
+        if (b.compareTo(BigInteger.ZERO) <= 0) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}
+```
+
+This returns `true` only when both `a > 0` and `b > 0`. The inner `if` does not need
+an `else`: when `b > 0`, execution continues after the outer `if`.
+
+Four or more nesting levels are also supported. Deep nesting is mainly a readability
+concern; it is not necessary to add artificial `else` branches for the compiler.
+
+## Prefer guard clauses for validation rules
+
+A validator often checks several independent rules. A linear sequence is usually the
+clearest way to express them:
+
+```java
+record PaymentDatum(byte[] owner, BigInteger amount) {}
+
+static boolean validate(PaymentDatum datum, ScriptContext ctx) {
+    TxInfo txInfo = ctx.txInfo();
+
+    if (datum.amount().compareTo(BigInteger.ZERO) <= 0) {
+        return false;
+    }
+
+    if (!ContextsLib.signedBy(txInfo, datum.owner())) {
+        return false;
+    }
+
+    if (!hasRequiredPayment(txInfo, datum)) {
+        return false;
+    }
+
+    return true;
+}
+```
+
+This style has three useful properties:
+
+1. Each rule is visible on its own.
+2. A failed rule stops evaluation before later work.
+3. There is no deeply nested success path to read.
+
+The equivalent nested form is harder to scan:
+
+```java
+if (amountIsValid(datum)) {
+    if (ownerSigned(txInfo, datum)) {
+        if (hasRequiredPayment(txInfo, datum)) {
+            return true;
+        }
+    }
+}
+return false;
+```
+
+Both forms can be correct, but guard clauses communicate validator intent more directly.
+
+## Put cheap checks first
+
+Java's `if`, `&&`, and `||` retain their short-circuit behavior in JuLC. Work that is
+not reached is not evaluated.
+
+Use that to reject invalid transactions before running expensive operations:
+
+```java
+if (amount.compareTo(BigInteger.ZERO) <= 0) {
+    return false;                       // cheap integer comparison
+}
+
+if (!ContextsLib.signedBy(txInfo, owner)) {
+    return false;                       // list search
+}
+
+return verifyProof(proof, expectedRoot); // expensive work last
+```
+
+The order must still preserve the contract's meaning. Do not reorder checks when one
+depends on data validated by an earlier check.
+
+## Keep common work in one place
+
+Suppose mint and burn actions have different rules, followed by several common checks:
+
+```java
+if (isMint) {
+    if (!validMint(action, txInfo)) {
+        return false;
+    }
+} else {
+    if (!validBurn(action, txInfo)) {
+        return false;
+    }
+}
+
+TxInfo info = ctx.txInfo();
+var outputs = info.outputs();
+var signatories = info.signatories();
+// ...many more common calculations...
+return validateCommonRules(outputs, signatories);
+```
+
+At the UPLC level there is no Java-style instruction pointer that simply moves to the
+next statement. JuLC represents the remaining work as an expression—often called the
+**continuation**—and connects it to every branch that can continue.
+
+If several branches can continue into a large block, some of that generated structure
+may be repeated. The result remains correct, but its serialized script can be larger.
+
+A helper keeps the shared body in one generated binding:
+
+```java
+static boolean validate(Action action, ScriptContext ctx) {
+    TxInfo txInfo = ctx.txInfo();
+
+    if (isMint(action)) {
+        if (!validMint(action, txInfo)) {
+            return false;
+        }
+    } else {
+        if (!validBurn(action, txInfo)) {
+            return false;
+        }
+    }
+
+    return validateCommonRules(txInfo);
+}
+
+static boolean validateCommonRules(TxInfo txInfo) {
+    var outputs = txInfo.outputs();
+    var signatories = txInfo.signatories();
+    // ...the large common calculation exists here once...
+    return outputsAreValid(outputs) && signersAreValid(signatories);
+}
+```
+
+The helper call may appear on more than one generated path, but the helper's body is
+defined once. This matters most when the common block is large; extracting every
+two-line continuation usually makes code less readable without a meaningful size win.
+
+## Prefer a switch expression for variants
+
+For a sealed redeemer or another sum type, use a Java `switch` expression that produces
+a value:
+
+```java
+boolean actionIsValid = switch (action) {
+    case Mint mint -> validMint(mint, txInfo);
+    case Burn burn -> validBurn(burn, txInfo);
+};
+
+if (!actionIsValid) {
+    return false;
+}
+
+return validateCommonRules(txInfo);
+```
+
+JuLC switch expressions must be exhaustive: handle every permitted variant or provide
+a `default` branch. Statement-style switches with `return` inside cases are not the
+supported pattern; produce a value with a switch expression instead.
+
+For a multi-statement case, use `yield`:
+
+```java
+boolean actionIsValid = switch (action) {
+    case Mint mint -> {
+        boolean positive = mint.amount().compareTo(BigInteger.ZERO) > 0;
+        yield positive && validMint(mint, txInfo);
+    }
+    case Burn burn -> validBurn(burn, txInfo);
+};
+```
+
+## Do not move unsafe work earlier
+
+Do not move an operation before a guard merely to make the generated program look
+smaller:
+
+```java
+// Risky: head() is evaluated before the empty-list check.
+TxOut first = outputs.head();
+if (outputs.isEmpty()) {
+    return false;
+}
+```
+
+Keep the guard first:
+
+```java
+if (outputs.isEmpty()) {
+    return false;
+}
+TxOut first = outputs.head();
+```
+
+UPLC evaluation is strict. Moving `head()` earlier makes it run even for an empty list,
+where it can fail. The same warning applies to division, decoding data, indexing lists,
+and other operations that require validated input.
+
+## Measure instead of guessing
+
+Control-flow shape is only one part of script size. Compile the validator and inspect
+the actual result:
+
+```java
+CompileResult compiled = ValidatorTest.compileValidator(MyValidator.class);
+
+System.out.println(compiled.scriptSizeFormatted());
+System.out.println(compiled.scriptSizeBytes());
+```
+
+For important contracts, add a regression assertion:
+
+```java
+BudgetAssertions.assertScriptSizeUnder(compiled, 16_384);
+```
+
+Measure execution budget with representative successful and failing transactions too.
+A smaller script is not automatically cheaper on every execution path. See the
+[Testing Guide](/guides/testing-guide/#budget-regression-test-pattern) for budget tests
+and script analysis.
+
+## Review checklist
+
+Before optimizing a validator, ask:
+
+- Can independent validation rules be written as guard clauses?
+- Are cheap and safe rejection checks performed before expensive work?
+- Does a large block follow several branches that can all continue?
+- Would one well-named helper keep that common block in one place?
+- Am I preserving guards before operations that can fail?
+- Have I measured both serialized script size and execution budget?
+
+For compiler-level PIR and UPLC examples, see
+[PIR and UPLC `if`/`else` lowering](https://github.com/bloxbean/julc/blob/main/adr/issues/pir-uplc-if-else-lowering.md).

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/LoopBodyGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/LoopBodyGenerator.java
@@ -498,7 +498,7 @@ final class LoopBodyGenerator {
     private PirTerm handleNestedLoop(WhileStmt ws, List<Statement> stmts, int index,
                                       StmtContinuation continuation) {
         var innerAccs = gen.detectForEachAccumulators(ws.getBody());
-        var innerResult = gen.generateWhileStmt(ws, List.of(ws), 0);
+        var innerResult = gen.generateWhileStmt(ws, List.of(ws), 0, null);
         return bindNestedLoopResult(innerAccs, innerResult, stmts, index, continuation);
     }
 
@@ -506,7 +506,7 @@ final class LoopBodyGenerator {
     private PirTerm handleNestedForEach(ForEachStmt fes, List<Statement> stmts, int index,
                                          StmtContinuation continuation) {
         var innerAccs = gen.detectForEachAccumulators(fes.getBody());
-        var innerResult = gen.generateForEachStmt(fes, List.of(fes), 0);
+        var innerResult = gen.generateForEachStmt(fes, List.of(fes), 0, null);
         return bindNestedLoopResult(innerAccs, innerResult, stmts, index, continuation);
     }
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -21,6 +21,7 @@ import com.bloxbean.cardano.julc.compiler.util.StringUtils;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Compiles JavaParser AST to PIR terms.
@@ -302,8 +303,20 @@ public class PirGenerator {
     }
 
     private PirTerm generateStatements(List<Statement> stmts, int index) {
+        return generateStatements(stmts, index, null);
+    }
+
+    /**
+     * Generate a statement list with an explicit fall-through continuation.
+     *
+     * <p>{@code cont} is the term to run when execution falls off the end of this
+     * statement list without hitting a {@code return} (e.g. the statements after an
+     * enclosing if whose branch this list is). {@code null} means the legacy value
+     * position: falling off the end yields {@code unit}.
+     */
+    private PirTerm generateStatements(List<Statement> stmts, int index, Supplier<PirTerm> cont) {
         if (index >= stmts.size()) {
-            return new PirTerm.Const(Constant.unit());
+            return cont == null ? new PirTerm.Const(Constant.unit()) : cont.get();
         }
         var stmt = stmts.get(index);
         if (stmt instanceof ReturnStmt rs) {
@@ -325,7 +338,7 @@ public class PirGenerator {
                 var value = generateExpression(initExpr);
                 var pirType = inferType(decl.getType(), value, initExpr);
                 symbolTable.define(name, pirType);
-                var body = generateStatements(stmts, index + 1);
+                var body = generateStatements(stmts, index + 1, cont);
                 return new PirTerm.Let(name, value, body);
             }
             // Accumulator assignment in for-each fold: return value as the new accumulator
@@ -338,17 +351,17 @@ public class PirGenerator {
             }
             // Non-declaration expression statement: evaluate and continue
             var expr = generateExpression(es.getExpression());
-            var rest = generateStatements(stmts, index + 1);
+            var rest = generateStatements(stmts, index + 1, cont);
             return new PirTerm.Let("_", expr, rest);
         }
         if (stmt instanceof IfStmt is) {
-            return generateIfStmt(is, stmts, index);
+            return generateIfStmt(is, stmts, index, cont);
         }
         if (stmt instanceof ForEachStmt fes) {
-            return generateForEachStmt(fes, stmts, index);
+            return generateForEachStmt(fes, stmts, index, cont);
         }
         if (stmt instanceof WhileStmt ws) {
-            return generateWhileStmt(ws, stmts, index);
+            return generateWhileStmt(ws, stmts, index, cont);
         }
         if (stmt instanceof BreakStmt) {
             // break outside break-aware context: return current accumulator
@@ -363,33 +376,51 @@ public class PirGenerator {
                 "Only variable declarations, if/else, for-each, while, return, and expression statements are supported on-chain.",
                 stmt);
         // Skip unsupported statement and continue with remaining statements
-        return generateStatements(stmts, index + 1);
+        return generateStatements(stmts, index + 1, cont);
     }
 
-    private PirTerm generateIfStmt(IfStmt is, List<Statement> followingStmts, int followingIndex) {
+    private PirTerm generateIfStmt(IfStmt is, List<Statement> followingStmts, int followingIndex,
+            Supplier<PirTerm> cont) {
         boolean hasFollowing = followingIndex + 1 < followingStmts.size();
-        boolean noElse = is.getElseStmt().isEmpty();
-        boolean thenReturns = thenBranchReturns(is.getThenStmt());
+        boolean thenHasReturn = containsMethodReturn(is.getThenStmt());
+        boolean elseHasReturn = is.getElseStmt().map(PirGenerator::containsMethodReturn).orElse(false);
 
-        // If-fallthrough optimization: when the then-branch returns, there is no else,
-        // and there are following statements, use the following statements as the else-branch
-        // of the IfThenElse instead of wrapping in a Let (where rest would always execute).
-        // This makes `if (cond) { return X; } return Y;` work correctly.
-        if (hasFollowing && noElse && thenReturns) {
-            var rest = generateStatements(followingStmts, followingIndex + 1);
+        // Early-return-aware lowering: when a branch contains a `return`, the statements
+        // after the if (plus the enclosing fall-through continuation) become each branch's
+        // continuation. A path that returns short-circuits them; a path that falls through
+        // runs them. This subsumes the old `if (cond) { return X; } rest` fallthrough
+        // optimization and fixes the miscompilation where `Let("_if", ifExpr, rest)`
+        // discarded a branch's return value and ran `rest` unconditionally.
+        if (thenHasReturn || elseHasReturn) {
+            // Generate the after-if term eagerly in the CURRENT scope (not a branch scope),
+            // so names in it cannot resolve against branch-local variables. Both branches
+            // share the same term instance; only branches that actually fall through embed it.
+            symbolTable.pushScope();
+            var afterIfTerm = generateStatements(followingStmts, followingIndex + 1, cont);
+            symbolTable.popScope();
+            Supplier<PirTerm> afterIf = () -> afterIfTerm;
+
+            PirTerm result;
             if (is.getCondition() instanceof InstanceOfExpr ioe && ioe.getPattern().isPresent()
                     && ioe.getPattern().get() instanceof TypePatternExpr tpe) {
-                // For instanceof pattern, generate with rest as the else-branch
-                return generateInstanceOfIf(ioe, tpe, is.getThenStmt(), rest);
+                var elseTerm = is.getElseStmt()
+                        .map(e -> generateBranchWithCont(e, afterIf))
+                        .orElse(afterIfTerm);
+                result = generateInstanceOfIfCps(ioe, tpe, is.getThenStmt(), elseTerm, afterIf);
             } else {
                 var cond = generateExpression(is.getCondition());
-                var thenTerm = generateStatement(is.getThenStmt());
-                var result = new PirTerm.IfThenElse(cond, thenTerm, rest);
-                recordPosition(result, is);
-                return result;
+                var thenTerm = generateBranchWithCont(is.getThenStmt(), afterIf);
+                var elseTerm = is.getElseStmt()
+                        .map(e -> generateBranchWithCont(e, afterIf))
+                        .orElse(afterIfTerm);
+                result = new PirTerm.IfThenElse(cond, thenTerm, elseTerm);
             }
+            recordPosition(result, is);
+            return result;
         }
 
+        // No `return` anywhere in the branches: evaluate the if for effect and continue
+        // (legacy shape, preserved for generated-code stability).
         PirTerm ifExpr;
         if (is.getCondition() instanceof InstanceOfExpr ioe && ioe.getPattern().isPresent()
                 && ioe.getPattern().get() instanceof TypePatternExpr tpe) {
@@ -404,34 +435,50 @@ public class PirGenerator {
         }
         recordPosition(ifExpr, is);
 
-        // If there are statements following the if, wrap in a let
-        if (hasFollowing) {
-            var rest = generateStatements(followingStmts, followingIndex + 1);
+        // If there are statements following the if (or an enclosing continuation to
+        // fall through to), wrap in a let
+        if (hasFollowing || cont != null) {
+            var rest = generateStatements(followingStmts, followingIndex + 1, cont);
             return new PirTerm.Let("_if", ifExpr, rest);
         }
         return ifExpr;
     }
 
     /**
-     * Check if a then-branch contains a return statement, meaning execution should not
-     * fall through to subsequent statements when the condition is true.
+     * Generate an if-branch with an explicit fall-through continuation: statements in the
+     * branch that return produce their value; falling off the end of the branch continues
+     * with {@code cont}.
      */
-    private boolean thenBranchReturns(Statement thenStmt) {
-        if (thenStmt instanceof ReturnStmt) {
+    private PirTerm generateBranchWithCont(Statement branch, Supplier<PirTerm> cont) {
+        if (branch instanceof BlockStmt block) {
+            symbolTable.pushScope();
+            var result = generateStatements(block.getStatements(), 0, cont);
+            symbolTable.popScope();
+            return result;
+        }
+        return generateStatements(List.of(branch), 0, cont);
+    }
+
+    /**
+     * True when {@code stmt} contains a {@code return} belonging to the enclosing method
+     * (returns inside nested lambdas or local methods do not count).
+     */
+    private static boolean containsMethodReturn(Statement stmt) {
+        if (stmt instanceof ReturnStmt) {
             return true;
         }
-        if (thenStmt instanceof BlockStmt block) {
-            var stmts = block.getStatements();
-            if (!stmts.isEmpty()) {
-                var last = stmts.get(stmts.size() - 1);
-                if (last instanceof ReturnStmt) {
-                    return true;
+        for (var ret : stmt.findAll(ReturnStmt.class)) {
+            Node cur = ret.getParentNode().orElse(null);
+            boolean nested = false;
+            while (cur != null && cur != stmt) {
+                if (cur instanceof LambdaExpr || cur instanceof MethodDeclaration) {
+                    nested = true;
+                    break;
                 }
-                // Also check for nested if with return (e.g., if (a) { if (b) { return X; } return Y; })
-                if (last instanceof IfStmt nestedIf) {
-                    return thenBranchReturns(nestedIf.getThenStmt())
-                            && nestedIf.getElseStmt().map(this::thenBranchReturns).orElse(false);
-                }
+                cur = cur.getParentNode().orElse(null);
+            }
+            if (!nested) {
+                return true;
             }
         }
         return false;
@@ -503,6 +550,27 @@ public class PirGenerator {
     }
 
     /**
+     * Generate an instanceof if-statement whose then-branch has an explicit fall-through
+     * continuation (early-return-aware lowering).
+     */
+    private PirTerm generateInstanceOfIfCps(InstanceOfExpr ioe, TypePatternExpr tpe,
+            Statement thenStmt, PirTerm elseTerm, Supplier<PirTerm> cont) {
+        var condTerm = generateInstanceOf(ioe);
+
+        var varName = tpe.getName().asString();
+        var varType = typeResolver.resolve(tpe.getType());
+
+        symbolTable.pushScope();
+        symbolTable.define(varName, varType);
+        var scrutineeTerm = generateExpression(ioe.getExpression());
+        var thenBody = generateBranchWithCont(thenStmt, cont);
+        var thenTerm = new PirTerm.Let(varName, scrutineeTerm, thenBody);
+        symbolTable.popScope();
+
+        return new PirTerm.IfThenElse(condTerm, thenTerm, elseTerm);
+    }
+
+    /**
      * Generate an instanceof if-statement with a pre-computed else term.
      * Used by the fallthrough optimization to pass following statements as the else-branch.
      */
@@ -556,10 +624,10 @@ public class PirGenerator {
             return new PirTerm.IfThenElse(cond, thenTerm, elseTerm);
         }
         if (stmt instanceof ForEachStmt fes) {
-            return generateForEachStmt(fes, List.of(stmt), 0);
+            return generateForEachStmt(fes, List.of(stmt), 0, null);
         }
         if (stmt instanceof WhileStmt ws) {
-            return generateWhileStmt(ws, List.of(stmt), 0);
+            return generateWhileStmt(ws, List.of(stmt), 0, null);
         }
         throw enrichedError("Unsupported statement: " + stmt.getClass().getSimpleName(),
                 "Only variable declarations, if/else, for-each, while, return, and expression statements are supported on-chain.",
@@ -1294,7 +1362,8 @@ public class PirGenerator {
                 oce);
     }
 
-    PirTerm generateForEachStmt(ForEachStmt fes, List<Statement> followingStmts, int followingIndex) {
+    PirTerm generateForEachStmt(ForEachStmt fes, List<Statement> followingStmts, int followingIndex,
+            Supplier<PirTerm> cont) {
         if (containsReturn(fes.getBody())) {
             throw enrichedError(
                     "'return' is not supported inside for-each loop body",
@@ -1391,9 +1460,9 @@ public class PirGenerator {
             }
 
             // Rebind accumulator with fold result for following statements
-            if (followingIndex + 1 < followingStmts.size()) {
+            if (followingIndex + 1 < followingStmts.size() || cont != null) {
                 symbolTable.define(accName, accType);
-                var rest = generateStatements(followingStmts, followingIndex + 1);
+                var rest = generateStatements(followingStmts, followingIndex + 1, cont);
                 // Re-bind pre-loop variables to fix scope corruption from LetRec boundary
                 rest = rebindPreLoopVars(rest, preLoopVars, Set.of(accName));
                 return new PirTerm.Let(accName, foldResult, rest);
@@ -1470,11 +1539,11 @@ public class PirGenerator {
             }
 
             // After loop: unpack final tuple into individual vars for following statements
-            if (followingIndex + 1 < followingStmts.size()) {
+            if (followingIndex + 1 < followingStmts.size() || cont != null) {
                 for (int i = 0; i < accumulators.size(); i++) {
                     symbolTable.define(accumulators.get(i), accTypes.get(i));
                 }
-                var rest = generateStatements(followingStmts, followingIndex + 1);
+                var rest = generateStatements(followingStmts, followingIndex + 1, cont);
                 // Re-bind pre-loop variables to fix scope corruption from LetRec boundary
                 rest = rebindPreLoopVars(rest, preLoopVars, new LinkedHashSet<>(accumulators));
                 return unpackAccumulators(foldResult, accumulators, accTypes, rest);
@@ -1503,8 +1572,8 @@ public class PirGenerator {
                     new PirTerm.Const(Constant.unit()), new PirType.UnitType(),
                     bodyTerm, elemType);
 
-            if (followingIndex + 1 < followingStmts.size()) {
-                var rest = generateStatements(followingStmts, followingIndex + 1);
+            if (followingIndex + 1 < followingStmts.size() || cont != null) {
+                var rest = generateStatements(followingStmts, followingIndex + 1, cont);
                 return new PirTerm.Let("_forEach", forEachResult, rest);
             }
             return forEachResult;
@@ -1583,7 +1652,8 @@ public class PirGenerator {
         return loopBody.generateMultiAccBreakAwareBody(bodyStmt, accNames, accTypes, continueFn);
     }
 
-    PirTerm generateWhileStmt(WhileStmt ws, List<Statement> followingStmts, int followingIndex) {
+    PirTerm generateWhileStmt(WhileStmt ws, List<Statement> followingStmts, int followingIndex,
+            Supplier<PirTerm> cont) {
         if (containsReturn(ws.getBody())) {
             throw enrichedError(
                     "'return' is not supported inside while loop body",
@@ -1649,9 +1719,9 @@ public class PirGenerator {
             }
 
             // Rebind accumulator with while result for following statements
-            if (followingIndex + 1 < followingStmts.size()) {
+            if (followingIndex + 1 < followingStmts.size() || cont != null) {
                 symbolTable.define(accName, accType);
-                var rest = generateStatements(followingStmts, followingIndex + 1);
+                var rest = generateStatements(followingStmts, followingIndex + 1, cont);
                 // Re-bind pre-loop variables to fix scope corruption from LetRec boundary
                 rest = rebindPreLoopVars(rest, preLoopVars, Set.of(accName));
                 return new PirTerm.Let(accName, whileResult, rest);
@@ -1735,11 +1805,11 @@ public class PirGenerator {
             }
 
             // After loop: unpack final tuple into individual vars for following statements
-            if (followingIndex + 1 < followingStmts.size()) {
+            if (followingIndex + 1 < followingStmts.size() || cont != null) {
                 for (int i = 0; i < accumulators.size(); i++) {
                     symbolTable.define(accumulators.get(i), accTypes.get(i));
                 }
-                var rest = generateStatements(followingStmts, followingIndex + 1);
+                var rest = generateStatements(followingStmts, followingIndex + 1, cont);
                 // Re-bind pre-loop variables to fix scope corruption from LetRec boundary
                 rest = rebindPreLoopVars(rest, preLoopVars, new LinkedHashSet<>(accumulators));
                 return unpackAccumulators(whileResult, accumulators, accTypes, rest);
@@ -1753,8 +1823,8 @@ public class PirGenerator {
 
             var whileResult = desugarer.desugarWhile(condition, bodyTerm);
 
-            if (followingIndex + 1 < followingStmts.size()) {
-                var rest = generateStatements(followingStmts, followingIndex + 1);
+            if (followingIndex + 1 < followingStmts.size() || cont != null) {
+                var rest = generateStatements(followingStmts, followingIndex + 1, cont);
                 return new PirTerm.Let("_while", whileResult, rest);
             }
             return whileResult;

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/EarlyReturnLoweringTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/EarlyReturnLoweringTest.java
@@ -1,0 +1,139 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.testkit.JulcEval;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for early {@code return} inside if/else branches followed by
+ * more statements (cardano-templates AMM finding: "a return false inside an
+ * if/else block does not lower the way it reads, and silently let bad deposits
+ * through").
+ *
+ * <p>Every expectation here is plain Java semantics: when a branch returns, the
+ * statements after the if must not execute. The buggy lowering wrapped the
+ * if/else in {@code Let("_if", ifExpr, rest)}, discarding the branch's return
+ * value and unconditionally running {@code rest}.
+ */
+class EarlyReturnLoweringTest {
+
+    static final JulcEval eval = JulcEval.forSource("""
+            import java.math.BigInteger;
+
+            class EarlyReturns {
+
+                // Control: top-level early return, no else. Handled by the
+                // if-fallthrough path and has always been correct.
+                static boolean topLevelEarlyReturn(BigInteger a) {
+                    if (a.compareTo(BigInteger.ZERO) <= 0) {
+                        return false;
+                    }
+                    return true;
+                }
+
+                // Bug shape 1: else-branch returns, then-branch falls through.
+                static boolean elseBranchReturns(BigInteger a) {
+                    if (a.compareTo(BigInteger.ZERO) > 0) {
+                        BigInteger positive = a;
+                    } else {
+                        return false;
+                    }
+                    return true;
+                }
+
+                // Bug shape 2: then-branch returns but an else exists.
+                static boolean thenReturnsWithElse(BigInteger a) {
+                    if (a.compareTo(BigInteger.ZERO) <= 0) {
+                        return false;
+                    } else {
+                        BigInteger positive = a;
+                    }
+                    return true;
+                }
+
+                // Bug shape 3 (the AMM shape): return nested one level deeper,
+                // inside a branch of an if that has code after it.
+                static boolean nestedGuard(BigInteger a, BigInteger b) {
+                    if (a.compareTo(BigInteger.ZERO) > 0) {
+                        if (b.compareTo(BigInteger.ZERO) <= 0) {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
+                    return true;
+                }
+
+                // Bug shape 4: return mid-block with more statements after it
+                // in the same branch block.
+                static boolean returnThenMoreCodeInBranch(BigInteger a, BigInteger b) {
+                    if (a.compareTo(BigInteger.ZERO) > 0) {
+                        if (b.compareTo(BigInteger.ZERO) <= 0) {
+                            return false;
+                        }
+                        BigInteger sum = a.add(b);
+                    }
+                    return true;
+                }
+
+                // Bug shape 5: a non-boolean return from one branch must also
+                // short-circuit the value-producing statements after the if.
+                static BigInteger integerEarlyReturn(BigInteger a) {
+                    if (a.compareTo(BigInteger.ZERO) > 0) {
+                        BigInteger positive = a;
+                    } else {
+                        return BigInteger.valueOf(-1);
+                    }
+                    return a.add(BigInteger.TEN);
+                }
+            }
+            """);
+
+    @Test
+    void topLevelEarlyReturnControl() {
+        assertFalse(eval.call("topLevelEarlyReturn", BigInteger.valueOf(-5)).asBoolean());
+        assertTrue(eval.call("topLevelEarlyReturn", BigInteger.valueOf(5)).asBoolean());
+    }
+
+    @Test
+    void elseBranchReturnMustShortCircuit() {
+        assertFalse(eval.call("elseBranchReturns", BigInteger.valueOf(-5)).asBoolean(),
+                "else { return false; } must not fall through to the trailing return true");
+        assertTrue(eval.call("elseBranchReturns", BigInteger.valueOf(5)).asBoolean());
+    }
+
+    @Test
+    void thenBranchReturnWithElseMustShortCircuit() {
+        assertFalse(eval.call("thenReturnsWithElse", BigInteger.valueOf(-5)).asBoolean(),
+                "if (bad) { return false; } else { ... } must not fall through to return true");
+        assertTrue(eval.call("thenReturnsWithElse", BigInteger.valueOf(5)).asBoolean());
+    }
+
+    @Test
+    void nestedGuardMustShortCircuit() {
+        assertFalse(eval.call("nestedGuard", BigInteger.valueOf(1), BigInteger.valueOf(-1)).asBoolean(),
+                "nested return false inside a branch must reject");
+        assertFalse(eval.call("nestedGuard", BigInteger.valueOf(-1), BigInteger.valueOf(1)).asBoolean());
+        assertTrue(eval.call("nestedGuard", BigInteger.valueOf(1), BigInteger.valueOf(1)).asBoolean());
+    }
+
+    @Test
+    void returnFollowedByCodeInSameBranchMustShortCircuit() {
+        assertFalse(eval.call("returnThenMoreCodeInBranch", BigInteger.valueOf(1), BigInteger.valueOf(-1)).asBoolean(),
+                "return false followed by more code in the same branch block must reject");
+        assertTrue(eval.call("returnThenMoreCodeInBranch", BigInteger.valueOf(1), BigInteger.valueOf(1)).asBoolean());
+        assertTrue(eval.call("returnThenMoreCodeInBranch", BigInteger.valueOf(-1), BigInteger.valueOf(1)).asBoolean());
+    }
+
+    @Test
+    void nonBooleanEarlyReturnMustShortCircuit() {
+        org.junit.jupiter.api.Assertions.assertEquals(BigInteger.valueOf(-1),
+                eval.call("integerEarlyReturn", BigInteger.valueOf(-5)).asInteger());
+        org.junit.jupiter.api.Assertions.assertEquals(BigInteger.valueOf(15),
+                eval.call("integerEarlyReturn", BigInteger.valueOf(5)).asInteger());
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/EarlyReturnLoweringTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/EarlyReturnLoweringTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,6 +91,51 @@ class EarlyReturnLoweringTest {
                     }
                     return a.add(BigInteger.TEN);
                 }
+
+                // Four nested levels with returns in both then and else branches.
+                // Every rejecting path must bypass the final return true.
+                static boolean fourLevelMixedReturns(
+                        BigInteger a, BigInteger b, BigInteger c, BigInteger d) {
+                    if (a.compareTo(BigInteger.ZERO) > 0) {
+                        if (b.compareTo(BigInteger.ZERO) > 0) {
+                            if (c.compareTo(BigInteger.ZERO) > 0) {
+                                if (d.compareTo(BigInteger.ZERO) <= 0) {
+                                    return false;
+                                }
+                            } else {
+                                return false;
+                            }
+                        } else {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
+                    return true;
+                }
+
+                // Each nesting level has a different fall-through continuation.
+                // This verifies that continuations compose in lexical order and
+                // that the deepest return bypasses all enclosing continuations.
+                static BigInteger fourLevelContinuations(
+                        BigInteger a, BigInteger b, BigInteger c, BigInteger d) {
+                    if (a.compareTo(BigInteger.ZERO) > 0) {
+                        if (b.compareTo(BigInteger.ZERO) > 0) {
+                            if (c.compareTo(BigInteger.ZERO) > 0) {
+                                if (d.compareTo(BigInteger.ZERO) < 0) {
+                                    return BigInteger.valueOf(-1);
+                                }
+                                BigInteger afterD = d.add(BigInteger.ONE);
+                                return afterD;
+                            }
+                            BigInteger afterC = c.add(BigInteger.TEN);
+                            return afterC;
+                        }
+                        BigInteger afterB = b.add(BigInteger.valueOf(20));
+                        return afterB;
+                    }
+                    return BigInteger.valueOf(100);
+                }
             }
             """);
 
@@ -131,9 +177,37 @@ class EarlyReturnLoweringTest {
 
     @Test
     void nonBooleanEarlyReturnMustShortCircuit() {
-        org.junit.jupiter.api.Assertions.assertEquals(BigInteger.valueOf(-1),
+        assertEquals(BigInteger.valueOf(-1),
                 eval.call("integerEarlyReturn", BigInteger.valueOf(-5)).asInteger());
-        org.junit.jupiter.api.Assertions.assertEquals(BigInteger.valueOf(15),
+        assertEquals(BigInteger.valueOf(15),
                 eval.call("integerEarlyReturn", BigInteger.valueOf(5)).asInteger());
+    }
+
+    @Test
+    void fourLevelMixedReturnsMustShortCircuitAtEveryDepth() {
+        assertFalse(eval.call("fourLevelMixedReturns",
+                BigInteger.valueOf(-1), BigInteger.ONE, BigInteger.ONE, BigInteger.ONE).asBoolean());
+        assertFalse(eval.call("fourLevelMixedReturns",
+                BigInteger.ONE, BigInteger.valueOf(-1), BigInteger.ONE, BigInteger.ONE).asBoolean());
+        assertFalse(eval.call("fourLevelMixedReturns",
+                BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(-1), BigInteger.ONE).asBoolean());
+        assertFalse(eval.call("fourLevelMixedReturns",
+                BigInteger.ONE, BigInteger.ONE, BigInteger.ONE, BigInteger.ZERO).asBoolean());
+        assertTrue(eval.call("fourLevelMixedReturns",
+                BigInteger.ONE, BigInteger.ONE, BigInteger.ONE, BigInteger.ONE).asBoolean());
+    }
+
+    @Test
+    void fourLevelFallThroughContinuationsComposeInLexicalOrder() {
+        assertEquals(BigInteger.valueOf(100), eval.call("fourLevelContinuations",
+                BigInteger.valueOf(-1), BigInteger.ONE, BigInteger.ONE, BigInteger.ONE).asInteger());
+        assertEquals(BigInteger.valueOf(18), eval.call("fourLevelContinuations",
+                BigInteger.ONE, BigInteger.valueOf(-2), BigInteger.ONE, BigInteger.ONE).asInteger());
+        assertEquals(BigInteger.valueOf(7), eval.call("fourLevelContinuations",
+                BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(-3), BigInteger.ONE).asInteger());
+        assertEquals(BigInteger.valueOf(-1), eval.call("fourLevelContinuations",
+                BigInteger.ONE, BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(-4)).asInteger());
+        assertEquals(BigInteger.valueOf(6), eval.call("fourLevelContinuations",
+                BigInteger.ONE, BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(5)).asInteger());
     }
 }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/EarlyReturnLoweringTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/EarlyReturnLoweringTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.julc.compiler;
 
+import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.testkit.JulcEval;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,11 @@ class EarlyReturnLoweringTest {
             import java.math.BigInteger;
 
             class EarlyReturns {
+
+                sealed interface Action {
+                    record Mint(BigInteger amount) implements Action {}
+                    record Burn(BigInteger amount) implements Action {}
+                }
 
                 // Control: top-level early return, no else. Handled by the
                 // if-fallthrough path and has always been correct.
@@ -136,8 +142,58 @@ class EarlyReturnLoweringTest {
                     }
                     return BigInteger.valueOf(100);
                 }
+
+                // Two conditional levels: an instanceof pattern followed by a
+                // nested guard. The else returns, while the successful then-path
+                // uses the pattern variable and falls through to return true.
+                static boolean twoLevelInstanceOfReturns(Action action) {
+                    if (action instanceof Action.Mint mint) {
+                        if (mint.amount().compareTo(BigInteger.ZERO) <= 0) {
+                            return false;
+                        }
+                        BigInteger normalized = mint.amount().add(BigInteger.ONE);
+                    } else {
+                        return false;
+                    }
+                    return true;
+                }
+
+                // Five conditional levels, starting with an instanceof pattern.
+                // Every enclosing level has its own continuation, and each one
+                // uses the pattern variable to verify that its scope is preserved.
+                static BigInteger fiveLevelInstanceOfContinuations(
+                        Action action, BigInteger b, BigInteger c, BigInteger d) {
+                    if (action instanceof Action.Mint mint) {
+                        if (mint.amount().compareTo(BigInteger.ZERO) > 0) {
+                            if (b.compareTo(BigInteger.ZERO) > 0) {
+                                if (c.compareTo(BigInteger.ZERO) > 0) {
+                                    if (d.compareTo(BigInteger.ZERO) < 0) {
+                                        return BigInteger.valueOf(-1);
+                                    }
+                                    BigInteger afterD = mint.amount().add(d);
+                                    return afterD;
+                                }
+                                BigInteger afterC = mint.amount().add(c).add(BigInteger.valueOf(30));
+                                return afterC;
+                            }
+                            BigInteger afterB = mint.amount().add(b).add(BigInteger.valueOf(20));
+                            return afterB;
+                        }
+                        BigInteger afterAmount = mint.amount().add(BigInteger.TEN);
+                        return afterAmount;
+                    }
+                    return BigInteger.valueOf(100);
+                }
             }
             """);
+
+    private static PlutusData mint(long amount) {
+        return PlutusData.constr(0, PlutusData.integer(amount));
+    }
+
+    private static PlutusData burn(long amount) {
+        return PlutusData.constr(1, PlutusData.integer(amount));
+    }
 
     @Test
     void topLevelEarlyReturnControl() {
@@ -209,5 +265,31 @@ class EarlyReturnLoweringTest {
                 BigInteger.ONE, BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(-4)).asInteger());
         assertEquals(BigInteger.valueOf(6), eval.call("fourLevelContinuations",
                 BigInteger.ONE, BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(5)).asInteger());
+    }
+
+    @Test
+    void twoLevelInstanceOfReturnAndFallThroughPreservePatternScope() {
+        assertFalse(eval.call("twoLevelInstanceOfReturns", mint(0)).asBoolean(),
+                "nested return inside the instanceof branch must reject");
+        assertTrue(eval.call("twoLevelInstanceOfReturns", mint(3)).asBoolean(),
+                "the Mint branch must use its pattern variable and then fall through");
+        assertFalse(eval.call("twoLevelInstanceOfReturns", burn(3)).asBoolean(),
+                "the returning else branch must bypass the trailing return true");
+    }
+
+    @Test
+    void fiveLevelInstanceOfContinuationsComposeAndPreservePatternScope() {
+        assertEquals(BigInteger.valueOf(100), eval.call("fiveLevelInstanceOfContinuations",
+                burn(5), BigInteger.ONE, BigInteger.ONE, BigInteger.ONE).asInteger());
+        assertEquals(BigInteger.valueOf(8), eval.call("fiveLevelInstanceOfContinuations",
+                mint(-2), BigInteger.ONE, BigInteger.ONE, BigInteger.ONE).asInteger());
+        assertEquals(BigInteger.valueOf(23), eval.call("fiveLevelInstanceOfContinuations",
+                mint(5), BigInteger.valueOf(-2), BigInteger.ONE, BigInteger.ONE).asInteger());
+        assertEquals(BigInteger.valueOf(32), eval.call("fiveLevelInstanceOfContinuations",
+                mint(5), BigInteger.ONE, BigInteger.valueOf(-3), BigInteger.ONE).asInteger());
+        assertEquals(BigInteger.valueOf(-1), eval.call("fiveLevelInstanceOfContinuations",
+                mint(5), BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(-4)).asInteger());
+        assertEquals(BigInteger.valueOf(11), eval.call("fiveLevelInstanceOfContinuations",
+                mint(5), BigInteger.ONE, BigInteger.ONE, BigInteger.valueOf(6)).asInteger());
     }
 }


### PR DESCRIPTION
## Summary

Fix conditional lowering so an early method `return` inside a nested `if`/`else` branch actually terminates that execution path.

Previously, an affected validator could silently continue after `return false` and accept a transition that the Java source rejected. This PR makes fall-through explicit and adds regression coverage for the affected control-flow shapes.

Closes #79.

## The bug

Given this source:

```java
static boolean validate(BigInteger a, BigInteger b) {
    if (a.compareTo(BigInteger.ZERO) > 0) {
        if (b.compareTo(BigInteger.ZERO) <= 0) {
            return false;
        }
    } else {
        return false;
    }

    return true;
}
```

both rejecting paths could compile to `true`:

```java
validate(BigInteger.ONE, BigInteger.valueOf(-1)); // was true, should be false
validate(BigInteger.valueOf(-1), BigInteger.ONE); // was true, should be false
```

The already-special-cased top-level form remained correct:

```java
if (badCondition) {
    return false;
}
return true;
```

That distinction made the defect easy to miss in ordinary tests.

## Root cause

PIR/UPLC control flow is expression-based; there is no JVM-style jump instruction for a Java `return`.

`PirGenerator.generateIfStmt` previously special-cased only a no-`else` conditional whose `then` branch returned. Other conditionals followed by more statements were lowered conceptually as:

```text
let _if = if condition then branchResult else branchResult
in remainingStatements
```

This is valid when the branch value may be discarded. It is incorrect when that value represents a method return: binding it to `_if` discards the return value and runs `remainingStatements` unconditionally.

Nested blocks had the same hole because they were generated in isolation. Falling off the end of a nested block did not carry the enclosing method's remaining control flow.

## Fix

- Add an explicit fall-through continuation to statement-list generation. In plain terms, each block now knows what should run next if it reaches its end without returning.
- Detect method-level returns in either conditional branch while excluding returns belonging to nested lambdas or methods.
- Generate returning branches directly inside `IfThenElse`:
  - a `return` path produces its return value and stops;
  - a path that reaches the end of the branch evaluates the after-`if` continuation.
- Preserve branch scopes so branch-local declarations cannot leak into following code.
- Thread continuations through declarations, expression statements, nested conditionals, `instanceof` pattern conditionals, `for-each`, and `while` tails.
- Keep the previous lowering shape for branches with no method return, avoiding unrelated generated-code changes.

For the example above, the effective shape is now:

```text
if a > 0 then
    if b <= 0 then false else true
else
    false
```

## Trade-off

If multiple branches can fall through, the after-`if` continuation can appear in more than one generated branch. This may increase script size for deeply mixed control flow, but it preserves the source semantics. Return-free conditionals retain the previous lowering.

## Tests

Added `EarlyReturnLoweringTest` covering:

- the previously working top-level early-return control;
- a return in an `else` branch;
- a returning `then` branch with an `else`;
- the nested AMM-style guard;
- a return followed by more statements in the same branch;
- a non-boolean early return.

Verification:

```text
./gradlew :julc-compiler:test --tests com.bloxbean.cardano.julc.compiler.EarlyReturnLoweringTest
./gradlew test
```

All enabled tests pass, including all golden UPLC tests. No golden output changed.
