### PR TITLE
feat(verification): show CLI progress during proof runs

### DIFF
--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/AnnotatedVerificationWorkflow.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/AnnotatedVerificationWorkflow.java
@@ -33,20 +33,6 @@ final class AnnotatedVerificationWorkflow {
             Path requestedOutput,
             int fuel,
             int recursiveDepth,
-            boolean force) throws Exception {
-        return run(projectDirectory, validatorTitle, requestedPurpose, backend,
-                requestedOutput, fuel, recursiveDepth, force,
-                VerificationProgress.silent());
-    }
-
-    Execution run(
-            Path projectDirectory,
-            String validatorTitle,
-            VerificationPurpose requestedPurpose,
-            VerificationBackendKind backend,
-            Path requestedOutput,
-            int fuel,
-            int recursiveDepth,
             boolean force,
             VerificationProgress progress) throws Exception {
         Path project = projectDirectory.toAbsolutePath().normalize();

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/AnnotatedVerificationWorkflow.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/AnnotatedVerificationWorkflow.java
@@ -34,6 +34,21 @@ final class AnnotatedVerificationWorkflow {
             int fuel,
             int recursiveDepth,
             boolean force) throws Exception {
+        return run(projectDirectory, validatorTitle, requestedPurpose, backend,
+                requestedOutput, fuel, recursiveDepth, force,
+                VerificationProgress.silent());
+    }
+
+    Execution run(
+            Path projectDirectory,
+            String validatorTitle,
+            VerificationPurpose requestedPurpose,
+            VerificationBackendKind backend,
+            Path requestedOutput,
+            int fuel,
+            int recursiveDepth,
+            boolean force,
+            VerificationProgress progress) throws Exception {
         Path project = projectDirectory.toAbsolutePath().normalize();
         if (!Files.isRegularFile(ProjectLayout.tomlFile(project))) {
             throw new IllegalArgumentException("Not a JuLC project: " + project);
@@ -43,65 +58,75 @@ final class AnnotatedVerificationWorkflow {
             throw new IllegalStateException("Ordinary JuLC build failed; verification was not run");
         }
 
-        var scan = ProjectScanner.scan(ProjectLayout.srcDir(project));
-        String source = scan.validators().get(validatorTitle);
-        if (source == null) {
-            throw new IllegalArgumentException("Expected exactly one Java validator named '"
-                    + validatorTitle + "'; available: " + scan.validators().keySet());
-        }
-        var pool = ProjectSourceResolver.buildPool(scan.libraries());
-        var resolvedLibraries = ProjectSourceResolver.resolve(source, pool);
-        var compiled = new JulcCompiler(StdlibRegistry.defaultRegistry())
-                .compileContract(source, resolvedLibraries);
-        if (compiled.compileResult().hasErrors()) {
-            throw new CompilerException(compiled.compileResult().diagnostics());
-        }
-        ContractSchema selectedSchema = selectSchema(
-                compiled.contractSchema(), requestedPurpose, validatorTitle);
-        String sourceFile = sourceFileName(project, validatorTitle);
-        VerificationProperty property = ControlledMintResolver.resolve(
-                        source, sourceFile, validatorTitle, selectedSchema)
-                .<VerificationProperty>map(value -> value)
-                .orElseGet(() -> StatefulSpendingResolver.resolve(
-                        source, sourceFile, validatorTitle, selectedSchema)
-                .<VerificationProperty>map(value -> value)
-                .orElseGet(() -> RequiresSignerResolver.resolve(
-                                source, sourceFile, validatorTitle,
-                                selectedSchema)
-                        .orElseThrow(() -> new IllegalArgumentException("Validator '"
-                                + validatorTitle + "' has no supported verification profile"))));
-
+        progress.heading("Preparing formal verification for " + validatorTitle + " ...");
         Path blueprint = ProjectLayout.plutusDir(project).resolve("plutus.json");
-        var propertyPurpose = VerificationPurpose.fromUserName(property.scriptPurpose());
-        var artifact = ArtifactCommand.inspectForPurpose(
-                blueprint, validatorTitle, propertyPurpose.cip57Name()).artifact();
-        String observedCompiledCode = JulcScriptAdapter
-                .fromProgram(compiled.compileResult().program()).getCborHex();
-        if (!artifact.compiledCode().equalsIgnoreCase(observedCompiledCode)) {
-            throw new IllegalStateException("Observational metadata compile does not match the "
-                    + "exact blueprint compiledCode for " + validatorTitle);
-        }
-        String observedScriptHash = JulcScriptAdapter.scriptHash(
-                compiled.compileResult().program());
-        if (!artifact.cardanoScriptHash().equalsIgnoreCase(observedScriptHash)) {
-            throw new IllegalStateException("Observational metadata compile script hash mismatch");
+        VerificationProperty property;
+        ArtifactCommand.ArtifactMetadata artifact;
+        try (var task = progress.start("Resolving property and exact script artifact")) {
+            var scan = ProjectScanner.scan(ProjectLayout.srcDir(project));
+            String source = scan.validators().get(validatorTitle);
+            if (source == null) {
+                throw new IllegalArgumentException("Expected exactly one Java validator named '"
+                        + validatorTitle + "'; available: " + scan.validators().keySet());
+            }
+            var pool = ProjectSourceResolver.buildPool(scan.libraries());
+            var resolvedLibraries = ProjectSourceResolver.resolve(source, pool);
+            var compiled = new JulcCompiler(StdlibRegistry.defaultRegistry())
+                    .compileContract(source, resolvedLibraries);
+            if (compiled.compileResult().hasErrors()) {
+                throw new CompilerException(compiled.compileResult().diagnostics());
+            }
+            ContractSchema selectedSchema = selectSchema(
+                    compiled.contractSchema(), requestedPurpose, validatorTitle);
+            String sourceFile = sourceFileName(project, validatorTitle);
+            property = ControlledMintResolver.resolve(
+                            source, sourceFile, validatorTitle, selectedSchema)
+                    .<VerificationProperty>map(value -> value)
+                    .orElseGet(() -> StatefulSpendingResolver.resolve(
+                            source, sourceFile, validatorTitle, selectedSchema)
+                    .<VerificationProperty>map(value -> value)
+                    .orElseGet(() -> RequiresSignerResolver.resolve(
+                                    source, sourceFile, validatorTitle,
+                                    selectedSchema)
+                            .orElseThrow(() -> new IllegalArgumentException("Validator '"
+                                    + validatorTitle + "' has no supported verification profile"))));
+
+            var propertyPurpose = VerificationPurpose.fromUserName(property.scriptPurpose());
+            artifact = ArtifactCommand.inspectForPurpose(
+                    blueprint, validatorTitle, propertyPurpose.cip57Name()).artifact();
+            String observedCompiledCode = JulcScriptAdapter
+                    .fromProgram(compiled.compileResult().program()).getCborHex();
+            if (!artifact.compiledCode().equalsIgnoreCase(observedCompiledCode)) {
+                throw new IllegalStateException("Observational metadata compile does not match the "
+                        + "exact blueprint compiledCode for " + validatorTitle);
+            }
+            String observedScriptHash = JulcScriptAdapter.scriptHash(
+                    compiled.compileResult().program());
+            if (!artifact.cardanoScriptHash().equalsIgnoreCase(observedScriptHash)) {
+                throw new IllegalStateException("Observational metadata compile script hash mismatch");
+            }
+            task.succeed(property.template());
         }
 
         Path output = requestedOutput == null
                 ? project.resolve("verification").resolve(artifact.artifactId())
                 : requestedOutput.toAbsolutePath().normalize();
-        if (property instanceof ControlledMintProperty controlled) {
-            VerificationProjectGenerator.generateControlledMint(
-                    blueprint, controlled, fuel, recursiveDepth, output, force);
-        } else if (property instanceof StatefulSpendingProperty stateful) {
-            VerificationProjectGenerator.generateStatefulSpending(
-                    blueprint, stateful, fuel, recursiveDepth, output, force);
-        } else {
-            VerificationProjectGenerator.generateRequiresSigner(
-                    blueprint, (RequiresSignerProperty) property,
-                    fuel, recursiveDepth, output, force);
+        try (var task = progress.start("Generating hash-bound verification workspace")) {
+            if (property instanceof ControlledMintProperty controlled) {
+                VerificationProjectGenerator.generateControlledMint(
+                        blueprint, controlled, fuel, recursiveDepth, output, force);
+            } else if (property instanceof StatefulSpendingProperty stateful) {
+                VerificationProjectGenerator.generateStatefulSpending(
+                        blueprint, stateful, fuel, recursiveDepth, output, force);
+            } else {
+                VerificationProjectGenerator.generateRequiresSigner(
+                        blueprint, (RequiresSignerProperty) property,
+                        fuel, recursiveDepth, output, force);
+            }
+            task.succeed(output.toString());
         }
-        var run = new VerificationRunner().run(output, backend);
+        progress.heading("Running verification ...");
+        var run = new VerificationRunner().run(output, backend, progress);
         return new Execution(output, property, run);
     }
 

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgress.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgress.java
@@ -1,0 +1,103 @@
+package com.bloxbean.julc.cli.cmd.verify;
+
+import java.io.PrintStream;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.LongSupplier;
+
+/** Small, line-oriented progress reporter for long verification operations. */
+final class VerificationProgress {
+
+    private static final VerificationProgress SILENT =
+            new VerificationProgress(null, System::nanoTime);
+
+    private final PrintStream out;
+    private final LongSupplier nanoTime;
+
+    private VerificationProgress(PrintStream out, LongSupplier nanoTime) {
+        this.out = out;
+        this.nanoTime = Objects.requireNonNull(nanoTime);
+    }
+
+    static VerificationProgress silent() {
+        return SILENT;
+    }
+
+    static VerificationProgress console(PrintStream out) {
+        return new VerificationProgress(Objects.requireNonNull(out), System::nanoTime);
+    }
+
+    static VerificationProgress testing(PrintStream out, LongSupplier nanoTime) {
+        return new VerificationProgress(Objects.requireNonNull(out), nanoTime);
+    }
+
+    void heading(String message) {
+        if (out != null) out.println(message);
+    }
+
+    Task start(String message) {
+        if (out != null) {
+            out.print("  " + oneLine(message) + " ... ");
+            out.flush();
+        }
+        return new Task(nanoTime.getAsLong());
+    }
+
+    private static String oneLine(String value) {
+        if (value == null || value.isBlank()) return "Verification step";
+        return value.replaceAll("[\\r\\n\\t]+", " ").trim();
+    }
+
+    private static String elapsed(long nanos) {
+        long millis = Math.max(0L, nanos / 1_000_000L);
+        if (millis < 1_000L) return millis + " ms";
+        if (millis < 60_000L) {
+            return String.format(Locale.ROOT, "%.1f s", millis / 1_000.0);
+        }
+        long seconds = millis / 1_000L;
+        return (seconds / 60L) + "m " + (seconds % 60L) + "s";
+    }
+
+    final class Task implements AutoCloseable {
+        private final long startedAt;
+        private boolean finished;
+
+        private Task(long startedAt) {
+            this.startedAt = startedAt;
+        }
+
+        void succeed() {
+            succeed(null);
+        }
+
+        void succeed(String detail) {
+            finish("OK", detail);
+        }
+
+        void complete(String detail) {
+            finish("DONE", detail);
+        }
+
+        void fail() {
+            fail(null);
+        }
+
+        void fail(String detail) {
+            finish("FAILED", detail);
+        }
+
+        private void finish(String status, String detail) {
+            if (finished) return;
+            finished = true;
+            if (out == null) return;
+            String suffix = detail == null || detail.isBlank()
+                    ? "" : " - " + oneLine(detail);
+            out.println(status + " [" + elapsed(nanoTime.getAsLong() - startedAt) + "]" + suffix);
+        }
+
+        @Override
+        public void close() {
+            if (!finished) fail();
+        }
+    }
+}

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgress.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgress.java
@@ -35,6 +35,13 @@ final class VerificationProgress {
         if (out != null) out.println(message);
     }
 
+    void skipped(String message, String detail) {
+        if (out == null) return;
+        String suffix = detail == null || detail.isBlank()
+                ? "" : " - " + oneLine(detail);
+        out.println("  " + oneLine(message) + " ... SKIPPED" + suffix);
+    }
+
     Task start(String message) {
         if (out != null) {
             out.print("  " + oneLine(message) + " ... ");

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunner.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunner.java
@@ -48,41 +48,65 @@ public final class VerificationRunner {
 
     public RunExecution run(Path workspaceDirectory, VerificationBackendKind requestedBackend)
             throws IOException, InterruptedException {
-        Path workspace = requireWorkspace(workspaceDirectory);
-        // A result is evidence for one run. Never leave an older success in place
-        // while validating a new or tampered plan.
-        Files.deleteIfExists(workspace.resolve(RESULT_FILE));
-        Path logs = workspace.resolve("verification-results");
-        VerificationFiles.deleteTree(logs);
-        Path planFile = VerificationFiles.containedRegularFile(workspace, PLAN_FILE, false);
-        VerificationRunPlan plan = STRICT_JSON.readValue(planFile.toFile(), VerificationRunPlan.class);
-        validatePlan(plan, workspace);
-        if (plan.resultManifest() != null) {
-            Files.deleteIfExists(VerificationFiles.containedPath(
-                    workspace, plan.resultManifest()));
+        return run(workspaceDirectory, requestedBackend, VerificationProgress.silent());
+    }
+
+    RunExecution run(
+            Path workspaceDirectory,
+            VerificationBackendKind requestedBackend,
+            VerificationProgress progress) throws IOException, InterruptedException {
+        Path workspace;
+        Path logs;
+        Path planFile;
+        VerificationRunPlan plan;
+        Path manifestFile;
+        JsonNode manifest;
+        try (var task = progress.start("Validating workspace and runner plan")) {
+            workspace = requireWorkspace(workspaceDirectory);
+            // A result is evidence for one run. Never leave an older success in place
+            // while validating a new or tampered plan.
+            Files.deleteIfExists(workspace.resolve(RESULT_FILE));
+            logs = workspace.resolve("verification-results");
+            VerificationFiles.deleteTree(logs);
+            planFile = VerificationFiles.containedRegularFile(workspace, PLAN_FILE, false);
+            plan = STRICT_JSON.readValue(planFile.toFile(), VerificationRunPlan.class);
+            validatePlan(plan, workspace);
+            if (plan.resultManifest() != null) {
+                Files.deleteIfExists(VerificationFiles.containedPath(
+                        workspace, plan.resultManifest()));
+            }
+            manifestFile = VerificationFiles.containedRegularFile(
+                    workspace, plan.manifest(), false);
+            manifest = VerificationFiles.JSON.readTree(manifestFile.toFile());
+            Files.createDirectories(logs);
+            task.succeed();
         }
-        Path manifestFile = VerificationFiles.containedRegularFile(
-                workspace, plan.manifest(), false);
-        JsonNode manifest = VerificationFiles.JSON.readTree(manifestFile.toFile());
-        Files.createDirectories(logs);
         var phases = new ArrayList<VerificationRunResult.Phase>();
         var properties = new ArrayList<VerificationRunResult.Property>();
         var diagnostic = new StringBuilder();
         Map<String, Object> artifact;
-        try {
-            artifact = preflight(workspace, plan, manifest);
-        } catch (IOException e) {
-            String reason = preflightReason(e.getMessage());
-            return writeEarlyFailure(workspace, requestedBackend, artifactFallback(manifest),
-                    planFile, manifestFile, logs, "preflight", reason, e.getMessage());
+        try (var task = progress.start("Checking artifact, property, and generated-source hashes")) {
+            try {
+                artifact = preflight(workspace, plan, manifest);
+                task.succeed();
+            } catch (IOException e) {
+                String reason = preflightReason(e.getMessage());
+                task.fail(reason);
+                return writeEarlyFailure(workspace, requestedBackend, artifactFallback(manifest),
+                        planFile, manifestFile, logs, "preflight", reason, e.getMessage());
+            }
         }
         VerificationExecutionBackend backend;
-        try {
-            backend = selectBackend(requestedBackend, plan, workspace);
-        } catch (IOException e) {
-            return writeEarlyFailure(workspace, requestedBackend, artifact,
-                    planFile, manifestFile, logs, "backend-selection",
-                    "backend-unavailable", e.getMessage());
+        try (var task = progress.start("Selecting verification backend")) {
+            try {
+                backend = selectBackend(requestedBackend, plan, workspace);
+                task.succeed(backend.name());
+            } catch (IOException e) {
+                task.fail("backend-unavailable");
+                return writeEarlyFailure(workspace, requestedBackend, artifact,
+                        planFile, manifestFile, logs, "backend-selection",
+                        "backend-unavailable", e.getMessage());
+            }
         }
         VerificationExecutionBackend.BackendContext backendContext = null;
         Map<String, String> verifiedDependencies = Map.of();
@@ -92,26 +116,38 @@ public final class VerificationRunner {
 
         try {
             Path setupLog = logs.resolve("backend.log");
-            try {
-                backendContext = backend.prepare(workspace, process, timeout, setupLog);
-                phases.add(phase("backend", "acquire", "PASSED", 0, workspace, setupLog));
-            } catch (IOException e) {
-                reason = "backend-unavailable";
-                diagnostic.append(e.getMessage() == null ? "Backend setup failed" : e.getMessage());
-                phases.add(phase("backend", "acquire", "FAILED", null, workspace, setupLog));
+            String backendSetup = "docker".equals(backend.name())
+                    ? "Preparing Docker backend (first run may take several minutes)"
+                    : "Checking local Lean and Z3 toolchain";
+            try (var task = progress.start(backendSetup)) {
+                try {
+                    backendContext = backend.prepare(workspace, process, timeout, setupLog);
+                    phases.add(phase("backend", "acquire", "PASSED", 0, workspace, setupLog));
+                    task.succeed(backendContext.identity());
+                } catch (IOException e) {
+                    reason = "backend-unavailable";
+                    diagnostic.append(e.getMessage() == null ? "Backend setup failed" : e.getMessage());
+                    phases.add(phase("backend", "acquire", "FAILED", null, workspace, setupLog));
+                    task.fail("see verification-results/backend.log");
+                }
             }
 
             if (backendContext != null) {
                 StepFailure failure = executeSteps(
                         plan.acquire(), "acquire", false, backend, backendContext,
-                        workspace, logs, timeout, phases, properties);
+                        workspace, logs, timeout, phases, properties, progress);
                 if (failure != null) {
                     reason = failure.reason();
                     diagnostic.append(failure.diagnostic());
                 } else {
-                    StepFailure revisions = validateDependencyRevisions(
-                            manifest, plan.kind(), backend, backendContext,
-                            workspace, logs, timeout, phases);
+                    StepFailure revisions;
+                    try (var task = progress.start("Checking pinned dependency revisions")) {
+                        revisions = validateDependencyRevisions(
+                                manifest, plan.kind(), backend, backendContext,
+                                workspace, logs, timeout, phases);
+                        if (revisions == null) task.succeed();
+                        else task.fail(revisions.reason());
+                    }
                     if (revisions != null) {
                         reason = revisions.reason();
                         diagnostic.append(revisions.diagnostic());
@@ -119,7 +155,7 @@ public final class VerificationRunner {
                         verifiedDependencies = dependencyPins(manifest, plan.kind());
                         failure = executeSteps(
                                 plan.verify(), "verify", true, backend, backendContext,
-                                workspace, logs, timeout, phases, properties);
+                                workspace, logs, timeout, phases, properties, progress);
                         if (failure != null) {
                             reason = failure.reason();
                             diagnostic.append(failure.diagnostic());
@@ -252,58 +288,97 @@ public final class VerificationRunner {
             Path logs,
             Duration timeout,
             List<VerificationRunResult.Phase> phases,
-            List<VerificationRunResult.Property> properties)
+            List<VerificationRunResult.Property> properties,
+            VerificationProgress progress)
             throws IOException, InterruptedException {
         for (int stepIndex = 0; stepIndex < steps.size(); stepIndex++) {
             var step = steps.get(stepIndex);
-            int displayIndex = stepIndex + 1;
-            Path log = logs.resolve("%s-%02d-%s.log".formatted(
-                    phase, displayIndex, step.id()));
-            List<String> command = backend.command(step.command(), workspace, offline);
-            int maxAttempts = step.maxAttempts() == null ? 1 : step.maxAttempts();
-            VerificationProcess.ProcessResult result = null;
-            var attemptLogs = new ArrayList<Path>();
-            for (int attempt = 1; attempt <= maxAttempts; attempt++) {
-                Path attemptLog = maxAttempts == 1 ? log : logs.resolve(
-                        "%s-%02d-%s-attempt-%d.log".formatted(
-                                phase, displayIndex, step.id(), attempt));
-                attemptLogs.add(attemptLog);
-                result = process.execute(command, workspace,
-                        backend.environment(backendContext, offline), timeout, attemptLog);
-                boolean complete = !result.timedOut() && observedOutcome(step, result) != null;
-                if (complete || result.timedOut()) break;
-            }
-            if (maxAttempts > 1) combineAttemptLogs(log, attemptLogs);
-            VerificationRunPlan.ObservedOutcome observed = observedOutcome(step, result);
-            boolean exitMatches = expectedExitCodes(step).contains(result.exitCode());
-            boolean markerMatches = observed != null;
-            String status = result.timedOut() ? "TIMED-OUT"
-                    : exitMatches && markerMatches ? "PASSED" : "FAILED";
-            phases.add(phase(step.id(), phase, status, result.exitCode(), workspace, log));
-            if (result.timedOut()) {
-                return new StepFailure("acquire".equals(phase)
-                        ? "acquisition-timeout" : "verification-timeout",
-                        "Step '" + step.id() + "' exceeded " + timeout.toSeconds() + " seconds");
-            }
-            if (!exitMatches) {
-                return new StepFailure("unexpected-exit-code",
-                        "Step '" + step.id() + "' exited " + result.exitCode());
-            }
-            if (!markerMatches) {
-                return new StepFailure("missing-result-marker",
-                        "Step '" + step.id() + "' did not emit its required result marker");
-            }
-            if ("verify".equals(phase) && step.propertyId() != null) {
-                var outcome = VerificationOutcome.parse(observed.result());
-                properties.add(new VerificationRunResult.Property(
-                        step.propertyId(), outcome.externalName(), observed.reason()));
-                if ("property-vacuous".equals(observed.reason())) {
-                    appendVacuitySkippedSteps(steps, stepIndex + 1, phase, phases, properties);
-                    break;
+            try (var task = progress.start(stepDescription(step.id(), phase))) {
+                int displayIndex = stepIndex + 1;
+                Path log = logs.resolve("%s-%02d-%s.log".formatted(
+                        phase, displayIndex, step.id()));
+                List<String> command = backend.command(step.command(), workspace, offline);
+                int maxAttempts = step.maxAttempts() == null ? 1 : step.maxAttempts();
+                VerificationProcess.ProcessResult result = null;
+                var attemptLogs = new ArrayList<Path>();
+                for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+                    Path attemptLog = maxAttempts == 1 ? log : logs.resolve(
+                            "%s-%02d-%s-attempt-%d.log".formatted(
+                                    phase, displayIndex, step.id(), attempt));
+                    attemptLogs.add(attemptLog);
+                    result = process.execute(command, workspace,
+                            backend.environment(backendContext, offline), timeout, attemptLog);
+                    boolean complete = !result.timedOut() && observedOutcome(step, result) != null;
+                    if (complete || result.timedOut()) break;
+                }
+                if (maxAttempts > 1) combineAttemptLogs(log, attemptLogs);
+                VerificationRunPlan.ObservedOutcome observed = observedOutcome(step, result);
+                boolean exitMatches = expectedExitCodes(step).contains(result.exitCode());
+                boolean markerMatches = observed != null;
+                String status = result.timedOut() ? "TIMED-OUT"
+                        : exitMatches && markerMatches ? "PASSED" : "FAILED";
+                phases.add(phase(step.id(), phase, status, result.exitCode(), workspace, log));
+                if (result.timedOut()) {
+                    task.fail("timed out; see " + workspace.relativize(log));
+                    return new StepFailure("acquire".equals(phase)
+                            ? "acquisition-timeout" : "verification-timeout",
+                            "Step '" + step.id() + "' exceeded " + timeout.toSeconds() + " seconds");
+                }
+                if (!exitMatches) {
+                    task.fail("exit " + result.exitCode() + "; see " + workspace.relativize(log));
+                    return new StepFailure("unexpected-exit-code",
+                            "Step '" + step.id() + "' exited " + result.exitCode());
+                }
+                if (!markerMatches) {
+                    task.fail("missing result marker; see " + workspace.relativize(log));
+                    return new StepFailure("missing-result-marker",
+                            "Step '" + step.id() + "' did not emit its required result marker");
+                }
+                if ("verify".equals(phase)) {
+                    task.complete(verificationDetail(step, observed));
+                } else {
+                    task.succeed();
+                }
+                if ("verify".equals(phase) && step.propertyId() != null) {
+                    var outcome = VerificationOutcome.parse(observed.result());
+                    properties.add(new VerificationRunResult.Property(
+                            step.propertyId(), outcome.externalName(), observed.reason()));
+                    if ("property-vacuous".equals(observed.reason())) {
+                        appendVacuitySkippedSteps(steps, stepIndex + 1, phase, phases, properties);
+                        break;
+                    }
                 }
             }
         }
         return null;
+    }
+
+    private static String stepDescription(String id, String phase) {
+        if ("verify".equals(phase) && id.startsWith("prove-")) {
+            return "Proving " + id.substring("prove-".length()).replace('-', ' ');
+        }
+        return switch (id) {
+            case "lake-update" -> "Acquiring pinned Lean dependencies";
+            case "build-pinned-dependencies" -> "Building pinned Lean dependencies";
+            case "check-non-vacuity" -> "Checking property non-vacuity";
+            case "compile-unspecialized-property" -> "Checking generated property workspace";
+            default -> "verify".equals(phase)
+                    ? "Running proof step '" + id + "'"
+                    : "Running acquisition step '" + id + "'";
+        };
+    }
+
+    private static String verificationDetail(
+            VerificationRunPlan.Step step,
+            VerificationRunPlan.ObservedOutcome observed) {
+        if ("check-non-vacuity".equals(step.id())) {
+            return "property-vacuous".equals(observed.reason())
+                    ? "COULD-NOT-EVALUATE - property is vacuous"
+                    : "non-vacuous";
+        }
+        String reason = observed.reason() == null
+                ? "classified" : observed.reason().replace('-', ' ');
+        return observed.result() + " - " + reason;
     }
 
     private static void appendVacuitySkippedSteps(

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunner.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunner.java
@@ -118,7 +118,7 @@ public final class VerificationRunner {
             Path setupLog = logs.resolve("backend.log");
             String backendSetup = "docker".equals(backend.name())
                     ? "Preparing Docker backend (first run may take several minutes)"
-                    : "Checking local Lean and Z3 toolchain";
+                    : "Checking local Lean and Z3 toolchain (may download Z3)";
             try (var task = progress.start(backendSetup)) {
                 try {
                     backendContext = backend.prepare(workspace, process, timeout, setupLog);
@@ -344,7 +344,8 @@ public final class VerificationRunner {
                     properties.add(new VerificationRunResult.Property(
                             step.propertyId(), outcome.externalName(), observed.reason()));
                     if ("property-vacuous".equals(observed.reason())) {
-                        appendVacuitySkippedSteps(steps, stepIndex + 1, phase, phases, properties);
+                        appendVacuitySkippedSteps(
+                                steps, stepIndex + 1, phase, phases, properties, progress);
                         break;
                     }
                 }
@@ -372,9 +373,12 @@ public final class VerificationRunner {
             VerificationRunPlan.Step step,
             VerificationRunPlan.ObservedOutcome observed) {
         if ("check-non-vacuity".equals(step.id())) {
-            return "property-vacuous".equals(observed.reason())
-                    ? "COULD-NOT-EVALUATE - property is vacuous"
-                    : "non-vacuous";
+            if ("expected-negative-control".equals(observed.reason())) {
+                return "non-vacuous";
+            }
+            if ("property-vacuous".equals(observed.reason())) {
+                return "COULD-NOT-EVALUATE - property is vacuous";
+            }
         }
         String reason = observed.reason() == null
                 ? "classified" : observed.reason().replace('-', ' ');
@@ -386,7 +390,8 @@ public final class VerificationRunner {
             int firstSkipped,
             String phase,
             List<VerificationRunResult.Phase> phases,
-            List<VerificationRunResult.Property> properties) {
+            List<VerificationRunResult.Property> properties,
+            VerificationProgress progress) {
         for (int index = firstSkipped; index < steps.size(); index++) {
             var skipped = steps.get(index);
             phases.add(new VerificationRunResult.Phase(
@@ -397,6 +402,7 @@ public final class VerificationRunner {
                         VerificationOutcome.COULD_NOT_EVALUATE.externalName(),
                         "not-evaluated-vacuous"));
             }
+            progress.skipped(stepDescription(skipped.id(), phase), "property is vacuous");
         }
     }
 

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerifyCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerifyCommand.java
@@ -57,10 +57,12 @@ public class VerifyCommand implements Callable<Integer> {
             return 0;
         }
         try {
+            var progress = VerificationProgress.console(System.out);
             var execution = new AnnotatedVerificationWorkflow().run(
                     projectDir, validatorTitle, purpose, backend, outputDirectory,
-                    fuel, recursiveDepth, force);
+                    fuel, recursiveDepth, force, progress);
             var result = execution.run().result();
+            System.out.println();
             System.out.println(result.outcome() + ": " + result.reason());
             System.out.println("Property: " + execution.property().template()
                     + " (" + execution.property().sourcePath() + ")");

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerifyRunCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/verify/VerifyRunCommand.java
@@ -22,8 +22,11 @@ public class VerifyRunCommand implements Callable<Integer> {
     @Override
     public Integer call() {
         try {
-            var execution = new VerificationRunner().run(workspace, backend);
+            var progress = VerificationProgress.console(System.out);
+            progress.heading("Running verification ...");
+            var execution = new VerificationRunner().run(workspace, backend, progress);
             var result = execution.result();
+            System.out.println();
             System.out.println(result.outcome() + ": " + result.reason());
             System.out.println("Backend: " + result.backend() + " (" + result.backendIdentity() + ")");
             System.out.println("Result: " + workspace.toAbsolutePath().normalize()

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgressTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgressTest.java
@@ -1,0 +1,47 @@
+package com.bloxbean.julc.cli.cmd.verify;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VerificationProgressTest {
+
+    @Test
+    void rendersLineOrientedStatusAndElapsedTime() {
+        var bytes = new ByteArrayOutputStream();
+        var clock = new AtomicLong();
+        var progress = VerificationProgress.testing(
+                new PrintStream(bytes, true, StandardCharsets.UTF_8), clock::get);
+
+        progress.heading("Running verification ...");
+        try (var task = progress.start("Selecting verification backend")) {
+            clock.set(1_250_000_000L);
+            task.succeed("local");
+        }
+
+        assertEquals("""
+                Running verification ...
+                  Selecting verification backend ... OK [1.3 s] - local
+                """, bytes.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void unfinishedTaskFailsInsteadOfLeavingAnOpenProgressLine() {
+        var bytes = new ByteArrayOutputStream();
+        var clock = new AtomicLong();
+        var progress = VerificationProgress.testing(
+                new PrintStream(bytes, true, StandardCharsets.UTF_8), clock::get);
+
+        try (var ignored = progress.start("Preparing Docker backend\nplease wait")) {
+            clock.set(65_000_000_000L);
+        }
+
+        assertEquals("  Preparing Docker backend please wait ... FAILED [1m 5s]\n",
+                bytes.toString(StandardCharsets.UTF_8));
+    }
+}

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgressTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationProgressTest.java
@@ -44,4 +44,17 @@ class VerificationProgressTest {
         assertEquals("  Preparing Docker backend please wait ... FAILED [1m 5s]\n",
                 bytes.toString(StandardCharsets.UTF_8));
     }
+
+    @Test
+    void rendersSkippedStepAsACompleteLine() {
+        var bytes = new ByteArrayOutputStream();
+        var progress = VerificationProgress.testing(
+                new PrintStream(bytes, true, StandardCharsets.UTF_8), () -> 0L);
+
+        progress.skipped("Proving required signer", "property is vacuous\nnot attempted");
+
+        assertEquals("  Proving required signer ... SKIPPED"
+                        + " - property is vacuous not attempted\n",
+                bytes.toString(StandardCharsets.UTF_8));
+    }
 }

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunnerTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunnerTest.java
@@ -5,13 +5,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -212,6 +216,46 @@ class VerificationRunnerTest {
         assertEquals("COULD-NOT-EVALUATE", result.result().outcome());
         assertEquals("backend-unavailable", result.result().reason());
         assertEquals("FAILED", result.result().phases().getFirst().status());
+    }
+
+    @Test
+    void backendPreparationFailureClosesProgressLineAndPointsToLog() throws Exception {
+        Path workspace = workspace("backend-progress-failure", VerificationOutcome.SMT_VALID, false);
+        var bytes = new ByteArrayOutputStream();
+        var progress = VerificationProgress.testing(
+                new PrintStream(bytes, true, StandardCharsets.UTF_8), () -> 0L);
+        var runner = new VerificationRunner(new FakeProcess(false, true),
+                ignored -> new FailingBackend());
+
+        runner.run(workspace, VerificationBackendKind.LOCAL, progress);
+
+        assertTrue(bytes.toString(StandardCharsets.UTF_8).contains(
+                "Checking local Lean and Z3 toolchain ... FAILED [0 ms]"
+                        + " - see verification-results/backend.log"));
+    }
+
+    @Test
+    void reportsLongRunningStagesWithoutStreamingAuthenticatedLogs() throws Exception {
+        Path workspace = workspace("progress", VerificationOutcome.SMT_VALID, false);
+        var bytes = new ByteArrayOutputStream();
+        var clock = new AtomicLong();
+        var progress = VerificationProgress.testing(
+                new PrintStream(bytes, true, StandardCharsets.UTF_8),
+                () -> clock.getAndAdd(1_000_000_000L));
+
+        var result = runner(new FakeProcess(false, true))
+                .run(workspace, VerificationBackendKind.LOCAL, progress);
+
+        assertEquals("SMT-VALID", result.result().outcome());
+        String output = bytes.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("Validating workspace and runner plan ... OK"));
+        assertTrue(output.contains("Checking artifact, property, and generated-source hashes ... OK"));
+        assertTrue(output.contains("Selecting verification backend ... OK"));
+        assertTrue(output.contains("Checking local Lean and Z3 toolchain ... OK"));
+        assertTrue(output.contains("Running acquisition step 'acquire' ... OK"));
+        assertTrue(output.contains("Checking pinned dependency revisions ... OK"));
+        assertTrue(output.contains("Running proof step 'verify' ... DONE"));
+        assertFalse(output.contains("RESULT-MARKER"));
     }
 
     @Test

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunnerTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/verify/VerificationRunnerTest.java
@@ -144,8 +144,11 @@ class VerificationRunnerTest {
         VerificationFiles.JSON.writeValue(planFile.toFile(), plan);
         bindPlan(workspace);
         var process = new FakeProcess(false, true, 4);
+        var bytes = new ByteArrayOutputStream();
+        var progress = VerificationProgress.testing(
+                new PrintStream(bytes, true, StandardCharsets.UTF_8), () -> 0L);
 
-        var result = runner(process).run(workspace, VerificationBackendKind.LOCAL);
+        var result = runner(process).run(workspace, VerificationBackendKind.LOCAL, progress);
 
         assertEquals("COULD-NOT-EVALUATE", result.result().outcome());
         assertEquals("property-vacuous", result.result().reason());
@@ -157,6 +160,41 @@ class VerificationRunnerTest {
         assertTrue(result.result().phases().stream().anyMatch(phaseResult ->
                 phaseResult.id().equals("prove-property")
                         && phaseResult.status().equals("SKIPPED")));
+        assertTrue(bytes.toString(StandardCharsets.UTF_8).contains(
+                "Proving property ... SKIPPED - property is vacuous"));
+    }
+
+    @Test
+    void nonVacuityUndeterminedIsNotReportedAsNonVacuous() throws Exception {
+        Path workspace = workspace("non-vacuity-undetermined", VerificationOutcome.SMT_VALID, false);
+        Path planFile = workspace.resolve(VerificationRunner.PLAN_FILE);
+        var plan = (com.fasterxml.jackson.databind.node.ObjectNode)
+                VerificationFiles.JSON.readTree(planFile.toFile());
+        plan.put("schemaVersion", 2);
+        var step = (com.fasterxml.jackson.databind.node.ObjectNode) plan.path("verify").get(0);
+        step.put("id", "check-non-vacuity");
+        step.put("propertyId", "example.non-vacuity");
+        step.remove(List.of("expectedExitCodes", "requiredOutput", "result", "reason"));
+        step.putArray("outcomes").addObject()
+                .put("exitCode", 2)
+                .put("requiredOutput", "RESULT-MARKER")
+                .put("result", "COULD-NOT-EVALUATE")
+                .put("reason", "non-vacuity-undetermined");
+        VerificationFiles.JSON.writeValue(planFile.toFile(), plan);
+        bindPlan(workspace);
+        var bytes = new ByteArrayOutputStream();
+        var progress = VerificationProgress.testing(
+                new PrintStream(bytes, true, StandardCharsets.UTF_8), () -> 0L);
+
+        var result = runner(new FakeProcess(false, true, 2))
+                .run(workspace, VerificationBackendKind.LOCAL, progress);
+
+        assertEquals("COULD-NOT-EVALUATE", result.result().outcome());
+        assertEquals("non-vacuity-undetermined", result.result().properties().getFirst().reason());
+        String output = bytes.toString(StandardCharsets.UTF_8);
+        assertTrue(output.contains("Checking property non-vacuity ... DONE [0 ms]"
+                + " - COULD-NOT-EVALUATE - non vacuity undetermined"));
+        assertFalse(output.contains(" - non-vacuous"));
     }
 
     @Test
@@ -230,7 +268,7 @@ class VerificationRunnerTest {
         runner.run(workspace, VerificationBackendKind.LOCAL, progress);
 
         assertTrue(bytes.toString(StandardCharsets.UTF_8).contains(
-                "Checking local Lean and Z3 toolchain ... FAILED [0 ms]"
+                "Checking local Lean and Z3 toolchain (may download Z3) ... FAILED [0 ms]"
                         + " - see verification-results/backend.log"));
     }
 
@@ -251,7 +289,8 @@ class VerificationRunnerTest {
         assertTrue(output.contains("Validating workspace and runner plan ... OK"));
         assertTrue(output.contains("Checking artifact, property, and generated-source hashes ... OK"));
         assertTrue(output.contains("Selecting verification backend ... OK"));
-        assertTrue(output.contains("Checking local Lean and Z3 toolchain ... OK"));
+        assertTrue(output.contains(
+                "Checking local Lean and Z3 toolchain (may download Z3) ... OK"));
         assertTrue(output.contains("Running acquisition step 'acquire' ... OK"));
         assertTrue(output.contains("Checking pinned dependency revisions ... OK"));
         assertTrue(output.contains("Running proof step 'verify' ... DONE"));

--- a/verification/GETTING_STARTED.md
+++ b/verification/GETTING_STARTED.md
@@ -168,11 +168,31 @@ image and acquires exact Lean package commits. A successful run prints output
 similar to:
 
 ```text
+Preparing formal verification for AuthorizedStateValidator ...
+  Resolving property and exact script artifact ... OK [64 ms] - julc.requires-signer/v1
+  Generating hash-bound verification workspace ... OK [40 ms] - .../verification/authorized-state-validator
+Running verification ...
+  Validating workspace and runner plan ... OK [17 ms]
+  Checking artifact, property, and generated-source hashes ... OK [55 ms]
+  Selecting verification backend ... OK [0 ms] - docker
+  Preparing Docker backend (first run may take several minutes) ... OK [294 ms] - sha256:...
+  Acquiring pinned Lean dependencies ... OK [2.8 s]
+  Building pinned Lean dependencies ... OK [2m 1s]
+  Checking pinned dependency revisions ... OK [600 ms]
+  Checking property non-vacuity ... DONE [12.6 s] - non-vacuous
+  Proving required signer ... DONE [1.8 s] - SMT-VALID - required signer established
+
 SMT-VALID: all-properties-established
 Property: julc.requires-signer/v1 (datum.owner)
 Workspace: .../verification/authorized-state-validator
 Certificate: .../verification-result.json
 ```
+
+Local and Docker runs show the same line-oriented stages and elapsed times, so
+a long dependency build or proof does not look stalled. Tool output remains in
+the hash-accounted files under `verification-results/`; on failure the progress
+line points to the relevant log instead of mixing unauthenticated subprocess
+output into the console result.
 
 The certificate records `backend: docker`, the immutable built image ID, exact
 artifact and script hashes, dependency commits, fuel, generated-source hashes,

--- a/verification/README.md
+++ b/verification/README.md
@@ -111,6 +111,10 @@ The normal command performs the build, property resolution, deterministic
 workspace generation, non-vacuity check, proof/counterexample query, and
 certificate generation. Developers do not edit Lean or invoke Lake. The
 result is written under `verification/<artifact-id>/verification-result.json`.
+Both local and Docker backends print the current stage and elapsed time while
+backend preparation, dependency acquisition, pinned builds, and proof steps
+run. Detailed subprocess output remains in `verification-results/` so the
+certificate and diagnostic logs retain their existing trust boundary.
 The manifest binds the exact artifact, typed property IR, runner scripts, and
 generated Lean source hash; post-generation edits fail closed.
 


### PR DESCRIPTION
## Summary
- show line-oriented progress and elapsed time during workspace preparation, backend setup, dependency acquisition, and proof execution
- keep subprocess output isolated in authenticated verification logs and point failures to the relevant log
- document the local and Docker console experience

## Verification
- ./gradlew :julc-cli:test --rerun-tasks --no-daemon (390 tests, zero failures)
- real local backend required-signer run completed and classified successfully
- real Docker backend required-signer run completed and classified successfully
- git diff --check