### PR TITLE
feat(compiler): implement explicit PV11 compiler target (ADR-031)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@
 
 *Pronounced “jool-see” (J-U-L-C), or simply “jules”*
 
-Write Cardano smart contracts in Java and compile them to the pinned Plutus V3 / protocol 11 /
-UPLC 1.1.0 target. julc provides a complete
+Write Cardano smart contracts in Java and compile them to Plutus V3 UPLC. JuLC provides a complete
 toolchain: a Java-subset compiler, a pluggable VM for local evaluation, a standard library of on-chain
 operations, and first-class integration with [cardano-client-lib](https://github.com/bloxbean/cardano-client-lib).
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,22 @@ dependencies {
     // Annotation processor -- compiles validators during javac
     annotationProcessor "com.bloxbean.cardano:julc-annotation-processor:${julcVersion}"
 
-    // Test: VM for local evaluation
+    // Test: choose a VM backend for local evaluation
     testImplementation "com.bloxbean.cardano:julc-testkit:${julcVersion}"
     testImplementation "com.bloxbean.cardano:julc-vm:${julcVersion}"
+
+    // Java VM: supports CompileResult-aware protocol target propagation
     testRuntimeOnly "com.bloxbean.cardano:julc-vm-java:${julcVersion}"
+
+    // Scalus VM: supported alternative for direct UPLC evaluation and cross-checking
+    // testRuntimeOnly "com.bloxbean.cardano:julc-vm-scalus:${julcVersion}"
 }
 ```
+
+Only one VM backend is required. If both are present, JuLC selects the Java VM
+by default; select `Scalus` explicitly when an independent evaluation is
+desired. Protocol-target propagation through the Scalus adapter is tracked in
+[issue #74](https://github.com/bloxbean/julc/issues/74).
 
 For detailed dependencies, check the [getting started](docs/src/content/docs/getting-started.md) guide or the `julc-helloworld` example at https://github.com/bloxbean/julc-helloworld.
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ UPLC 1.1.0 target. julc provides a complete
 toolchain: a Java-subset compiler, a pluggable VM for local evaluation, a standard library of on-chain
 operations, and first-class integration with [cardano-client-lib](https://github.com/bloxbean/cardano-client-lib).
 
-## Powered by Scalus
+## Evaluation backends
 
-JuLC includes a pure-Java VM and a [Scalus](https://scalus.org/) backend. The
-pure-Java VM implements the canonical protocol-aware evaluation path used when
-`CompileResult` target provenance is available. Scalus remains available for
-language-only compatibility evaluation and cross-checking. Huge thanks to the
-Scalus team for building and open-sourcing a high-quality Plutus VM that made
-this project possible.
+JuLC supports two VM choices for local evaluation: its pure-Java VM and the
+[Scalus](https://scalus.org/) backend. Both can evaluate JuLC-generated UPLC.
+The Java VM additionally integrates with JuLC's complete compiler-target
+provenance for explicit protocol-aware evaluation and cost selection. Scalus is
+a supported alternative evaluator and provides a valuable independent
+cross-check of generated programs. Users can choose the backend that best fits
+their application. Huge thanks to the Scalus team for building and
+open-sourcing a high-quality Plutus VM that made this project possible.
 
 ## Features
 
@@ -52,7 +54,7 @@ this project possible.
 - **JulcList/JulcMap** — typed collection interfaces with IDE autocomplete for on-chain methods
 - **Multi-validator** — `@MultiValidator` for handling multiple script purposes (mint + spend + withdraw, etc.) in a single compiled script
 - **Annotation processor** — `@SpendingValidator`, `@MintingValidator`, `@MultiValidator`, `@Entrypoint` for compile-time code generation
-- **Pluggable VM** — evaluate UPLC programs locally via SPI (Scalus backend included)
+- **Pluggable VM** — choose the pure-Java VM or Scalus backend for local UPLC evaluation
 - **Testkit** — test validators locally without a running node
 - **Gradle plugin** — compile validators and bundle on-chain sources as part of your build
 - **cardano-client-lib integration** — deploy and submit transactions with compiled scripts

--- a/README.md
+++ b/README.md
@@ -283,13 +283,28 @@ if (!result.hasErrors()) {
 ### Test Locally
 
 ```java
+// Java VM: preferred target-aware evaluation. This passes result.target()
+// through to the VM. With only the Scalus VM on the classpath, this currently
+// throws UnsupportedOperationException; Scalus target propagation is tracked
+// in issue #74.
 var evalResult = ValidatorTest.evaluate(result, datum, redeemer, scriptContext);
+
+// Scalus VM alternative: replace the line above with the language-compatible
+// Program overload for now.
+// The Java VM also supports this overload, but it does not retain the explicit
+// compiler-target provenance carried by CompileResult.
+// var evalResult = ValidatorTest.evaluate(
+//         result.program(), datum, redeemer, scriptContext);
+
 assertTrue(evalResult.isSuccess());
 ```
 
 Passing the `CompileResult` lets `julc-testkit` hand the exact compiler target
 to the VM. Raw `Program` evaluation overloads remain available for compatibility
-when target provenance is not available.
+when target provenance is not available. The Scalus adapter currently supports
+the `Program` overload but not the explicit-target `CompileResult` overload;
+that integration is tracked in
+[issue #74](https://github.com/bloxbean/julc/issues/74).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@
 
 *Pronounced “jool-see” (J-U-L-C), or simply “jules”*
 
-Write Cardano smart contracts in Java and compile them to Plutus V3 UPLC. julc provides a complete
+Write Cardano smart contracts in Java and compile them to the pinned Plutus V3 / protocol 11 /
+UPLC 1.1.0 target. julc provides a complete
 toolchain: a Java-subset compiler, a pluggable VM for local evaluation, a standard library of on-chain
 operations, and first-class integration with [cardano-client-lib](https://github.com/bloxbean/cardano-client-lib).
 
 ## Powered by Scalus
 
-JuLC's end-to-end experience — from local testing to script evaluation — is powered by
-[Scalus](https://scalus.org/), a Scala implementation of the Plutus VM (CEK machine).
-JuLC uses the Scalus VM as its evaluation backend for local validator testing, cost estimation,
-and the testkit. Huge thanks to the Scalus team for building and open-sourcing a high-quality
-Plutus VM that made this project possible.
+JuLC includes a pure-Java VM and a [Scalus](https://scalus.org/) backend. The
+pure-Java VM implements the canonical protocol-aware evaluation path used when
+`CompileResult` target provenance is available. Scalus remains available for
+language-only compatibility evaluation and cross-checking. Huge thanks to the
+Scalus team for building and open-sourcing a high-quality Plutus VM that made
+this project possible.
 
 ## Features
 
@@ -101,11 +103,37 @@ dependencies {
     // Test: VM for local evaluation
     testImplementation "com.bloxbean.cardano:julc-testkit:${julcVersion}"
     testImplementation "com.bloxbean.cardano:julc-vm:${julcVersion}"
-    testRuntimeOnly "com.bloxbean.cardano:julc-vm-scalus:${julcVersion}"
+    testRuntimeOnly "com.bloxbean.cardano:julc-vm-java:${julcVersion}"
 }
 ```
 
 For detailed dependencies, check the [getting started](docs/src/content/docs/getting-started.md) guide or the `julc-helloworld` example at https://github.com/bloxbean/julc-helloworld.
+
+### Compiler target
+
+JuLC currently compiles exactly one profile:
+`plutus-v3-pv11-uplc-1.1.0`. Existing APIs default to that named profile;
+“latest” is intentionally not a target, and unknown future protocol versions
+fail closed.
+
+```java
+var options = new CompilerOptions()
+        .setTarget(CompilerTarget.PLUTUS_V3_PV11);
+var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry(), options);
+```
+
+The Gradle plugin accepts the same stable profile ID:
+
+```groovy
+julc {
+    target = 'plutus-v3-pv11-uplc-1.1.0'
+}
+```
+
+For direct annotation-processor configuration, pass
+`-Ajulc.target=plutus-v3-pv11-uplc-1.1.0`. Supporting a later protocol version
+will add a separately pinned compiler target and feature matrix; it will not
+silently change this default.
 
 ### Current Preview Version
 
@@ -236,19 +264,21 @@ var compiler = new JulcCompiler(stdlib);
 var result = compiler.compile(javaSource);
 if (!result.hasErrors()) {
     Program program = result.program();
-    // Ready for serialization and on-chain deployment
+    CompilerTarget target = result.target();
+    // Ready for serialization and on-chain deployment with explicit provenance
 }
 ```
 
 ### Test Locally
 
 ```java
-var vm = JulcVm.create();
-var evalResult = vm.evaluateWithArgs(program, datum, redeemer, scriptContext);
+var evalResult = ValidatorTest.evaluate(result, datum, redeemer, scriptContext);
 assertTrue(evalResult.isSuccess());
 ```
 
-`julc-testkit` provides utilities for unit testing your validators locally.
+Passing the `CompileResult` lets `julc-testkit` hand the exact compiler target
+to the VM. Raw `Program` evaluation overloads remain available for compatibility
+when target provenance is not available.
 
 ## Requirements
 

--- a/adr/031-pv11-first-compiler-target-and-future-protocol-evolution.md
+++ b/adr/031-pv11-first-compiler-target-and-future-protocol-evolution.md
@@ -6,7 +6,7 @@
 
 **Related issue:** [#76 — Add an explicit V3/PV11 compiler target and diagnostics](https://github.com/bloxbean/julc/issues/76)
 
-**Related roadmap:** [ADR-029 — PV11 ledger readiness and optimization roadmap](029-pv11-ledger-readiness-and-optimization-roadmap.md)
+**Related roadmap:** [#65 — ADR-029 PV11 ledger-conformant evaluation readiness tracker](https://github.com/bloxbean/julc/issues/65)
 
 **Evaluator foundation:** [ADR-030 — Protocol version propagation and PV11 builtin semantics](030-protocol-version-propagation-and-pv11-builtin-semantics.md)
 

--- a/adr/031-pv11-first-compiler-target-and-future-protocol-evolution.md
+++ b/adr/031-pv11-first-compiler-target-and-future-protocol-evolution.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-29
 
-**Status:** Proposed (design only; implementation requires a separate reviewed PR)
+**Status:** Accepted and implemented (pending merge of the reviewed implementation PR)
 
 **Related issue:** [#76 — Add an explicit V3/PV11 compiler target and diagnostics](https://github.com/bloxbean/julc/issues/76)
 
@@ -647,16 +647,39 @@ entry path.
 
 ## Open questions
 
-1. Should `CompileResult` remain a record with an added component, or migrate to
-   a class to make future provenance fields additive?
-2. Which standard generated artifact, if any, can carry target metadata without
+The initial implementation resolved the previously open design choices as
+follows:
+
+- `CompileResult` remains a record with a target component and compatibility
+  constructors that use the documented PV11 default.
+- Initial CLI, Gradle, annotation-processor, and MCP configuration accepts only
+  the stable profile ID. Structured language/protocol/UPLC input is deferred
+  until a second compiler target creates a concrete need.
+- Named protocol capabilities live in the backend-neutral `julc-vm` contract
+  layer and are derived from `ProtocolFeatureProfile`; compiler passes do not
+  duplicate version thresholds.
+- Target provenance is carried by `CompileResult`, logs, lifecycle output, and
+  structured MCP results. No non-standard field or sidecar is added to UPLC,
+  CIP-57, or text-envelope artifacts in this implementation.
+- Testkit paths that retain `CompileResult` use the exact ledger target. The
+  protocol-aware Java VM is used for those paths; the Scalus provider continues
+  to fail closed on explicit targets until it independently satisfies the
+  ADR-030 parity requirements.
+- `julc-cardano-client-lib` has no compile-and-evaluate handoff API to update;
+  its existing protocol-aware decode and transaction-evaluation paths remain
+  unchanged and covered by their module tests.
+
+The remaining questions below apply to later profile or artifact-format work,
+not to the initial PV11 implementation.
+
+1. If later provenance fields grow beyond the initial target, should
+   `CompileResult` migrate from a record to a class in a versioned API change?
+2. Which future standard generated artifact, if any, can carry target metadata without
    violating its schema? Otherwise, should tooling emit a sidecar file?
-3. Should Gradle and annotation-processor target configuration initially accept
-   only the stable profile ID or also structured language/PV/UPLC components?
-4. Which named capability representation best covers term forms without
-   duplicating `ProtocolFeatureProfile` fields?
-5. Should a future protocol-contract module extraction preserve the existing
+3. Should a future protocol-contract module extraction preserve the existing
    package names or use a versioned public API migration?
+4. What conformance evidence is required before Scalus may implement the
+   explicit `LedgerEvaluationTarget` SPI instead of remaining compatibility-only?
 
 These questions do not change the initial support matrix or fail-closed future
 version policy.

--- a/adr/031-pv11-first-compiler-target-and-future-protocol-evolution.md
+++ b/adr/031-pv11-first-compiler-target-and-future-protocol-evolution.md
@@ -1,0 +1,662 @@
+# ADR-031: PV11-First Compiler Target and Future Protocol Evolution
+
+**Date:** 2026-08-29
+
+**Status:** Proposed (design only; implementation requires a separate reviewed PR)
+
+**Related issue:** [#76 — Add an explicit V3/PV11 compiler target and diagnostics](https://github.com/bloxbean/julc/issues/76)
+
+**Related roadmap:** [ADR-029 — PV11 ledger readiness and optimization roadmap](029-pv11-ledger-readiness-and-optimization-roadmap.md)
+
+**Evaluator foundation:** [ADR-030 — Protocol version propagation and PV11 builtin semantics](030-protocol-version-propagation-and-pv11-builtin-semantics.md)
+
+**Normative initial baseline:** cardano-node 11.0.1 / Plutus 1.63.0.0 at
+[`f92b7d7d82622a26caf456a6be33859f697e2cfc`](https://github.com/IntersectMBO/plutus/tree/f92b7d7d82622a26caf456a6be33859f697e2cfc)
+
+---
+
+## Context
+
+JuLC currently compiles one effective ledger profile: Plutus V3, protocol
+version 11, UPLC 1.1.0. That profile is encoded as implementation assumptions
+rather than represented as a first-class compiler value:
+
+- `CompilerOptions` has no language, protocol, or UPLC target;
+- `UplcGenerator` accepts builtins through tag 100 and rejects later tags with
+  a fixed `LAST_RELEASED_PV11_BUILTIN_TAG` boundary;
+- final programs are always constructed as Plutus V3 / UPLC 1.1.0;
+- `CompileResult` does not retain the ledger target that justified the output;
+- the CLI, Gradle plugin, and annotation processor do not report a resolved
+  target;
+- optimizer output is not checked against the protocol feature registry.
+
+The fixed checks produce legal output for the current V3/PV11 contract, but
+they are not a durable compiler invariant. Adding a later protocol version by
+changing the tag ceiling would allow compiler stages, stdlib mappings, and
+optimizers to disagree about which features are legal.
+
+ADR-030 already established a canonical evaluator-side model:
+
+```text
+LedgerEvaluationTarget
+    -> ProtocolFeatureRegistry
+    -> ProtocolFeatureProfile
+         - available builtins
+         - available UPLC versions
+         - case-on-builtin availability
+         - semantics variant
+         - decode limits
+         - cost-model schema
+```
+
+The compiler must consume that source of truth rather than create an
+independent protocol table.
+
+## Problem
+
+A successful compilation must establish all of the following:
+
+1. the requested ledger language is supported for compilation;
+2. the requested protocol version is a pinned, known compiler profile;
+3. the selected UPLC version is legal for that ledger target;
+4. every emitted builtin and term form is legal for that target;
+5. every optimizer rewrite remains legal for that target;
+6. downstream tooling can discover and reuse the resolved target;
+7. an unknown future version fails closed instead of inheriting the newest
+   behavior known to this build of JuLC.
+
+An evaluator knowing how to execute a profile does not imply that the compiler
+knows how to generate it. Evaluation and compilation have different support
+matrices. For example, JuLC can evaluate V1/V2 profiles without promising V1/V2
+source compilation or alternate lowerings.
+
+## Goals
+
+1. Make the initial compiler profile explicitly V3/PV11/UPLC 1.1.0.
+2. Preserve existing source-level compile entry points with a documented PV11
+   default.
+3. Use the canonical `ProtocolFeatureRegistry` for feature legality.
+4. Reject all unsupported targets before source lowering begins.
+5. Carry one immutable resolved target through every stage that can select or
+   introduce UPLC features.
+6. Validate the final `Program`, including optimized output, against the same
+   target.
+7. Record target provenance without changing UPLC bytes or script hashes.
+8. Define an explicit, repeatable process for supporting the next protocol
+   version and later ledger languages.
+
+## Non-goals
+
+- Implementing PV10 fallbacks.
+- Compiling Plutus V1 or V2 validators.
+- Treating evaluator support as compiler support.
+- Enabling a future builtin merely because its enum tag or runtime
+  implementation exists.
+- Selecting builtin semantics independently in the compiler; the evaluator
+  profile remains authoritative.
+- Implementing Phase 5 optimizations. Their target contract is defined here,
+  while optimization decisions are defined by ADR-032.
+- Changing serialized UPLC solely to embed provenance.
+
+## Compiler invariants
+
+The implementation must preserve these invariants:
+
+1. **One target per compilation.** A compilation resolves exactly one ledger
+   language, protocol version, and UPLC version.
+2. **Resolve once.** The requested target is validated once at the compiler
+   boundary and passed as an immutable value. Stages do not reconstruct it.
+3. **Separate support from legality.** The protocol registry answers whether a
+   feature is ledger-legal; a compiler support policy answers whether JuLC has
+   implemented all required lowerings for that target.
+4. **No implicit future aliases.** PV12 or later never behaves as PV11 unless a
+   reviewed profile explicitly says so. Unknown targets fail closed.
+5. **One feature registry.** Compiler, VM, stdlib feature metadata, and final
+   validation do not maintain competing builtin-availability tables.
+6. **Optimizer containment.** An optimizer may remove features or introduce
+   target-authorized features only. Its output is validated again.
+7. **Deterministic output.** The same source, compiler version, target, options,
+   and bundled libraries produce the same program bytes.
+8. **Provenance is out-of-band.** Recording the target in results or artifact
+   metadata does not alter UPLC encoding.
+9. **No silent fallback.** An unsupported requested target reports an
+   actionable error; it never compiles using the default target.
+10. **Evaluation handoff is exact.** Downstream evaluation uses the
+    `LedgerEvaluationTarget` represented by the compiler target.
+
+## Decision
+
+### D1. Introduce an immutable `CompilerTarget`
+
+Add a public compiler value with the conceptual shape:
+
+```java
+public record CompilerTarget(
+        LedgerEvaluationTarget ledgerTarget,
+        UplcVersion uplcVersion) {
+
+    public static final CompilerTarget PLUTUS_V3_PV11 =
+            new CompilerTarget(
+                    LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3),
+                    UplcVersion.V1_1_0);
+
+    public String profileId() {
+        return "plutus-v3-pv11-uplc-1.1.0";
+    }
+}
+```
+
+The final naming may follow local Java conventions, but the value must contain
+the complete triple. A protocol number or UPLC version alone is not a compiler
+target.
+
+`profileId()` is stable, lower-case metadata for logs, build output, test
+fixtures, and future artifact sidecars. It is not serialized into the UPLC
+program.
+
+### D2. Reuse the VM protocol contract layer
+
+`julc-vm` is a pure-Java SPI and protocol-contract module; it has no dependency
+on the Java, Truffle, or Scalus backends. `julc-compiler` will add an API
+dependency on `julc-vm` and reuse:
+
+- `PlutusLanguage`;
+- `ProtocolVersion`;
+- `UplcVersion`;
+- `LedgerEvaluationTarget`;
+- `ProtocolFeatureProfile`;
+- `ProtocolFeatureRegistry`.
+
+This avoids parallel compiler copies of protocol data. A new shared module is
+not justified for the initial change. If the protocol contract later gains
+additional non-VM consumers or `julc-vm` layering becomes a concrete problem,
+extracting these existing types intact can be proposed separately.
+
+### D3. Add a compiler support policy distinct from the feature registry
+
+The protocol registry contains every profile the VM can evaluate. The compiler
+needs a narrower table of profiles it can generate.
+
+Conceptually:
+
+```java
+public final class CompilerTargetRegistry {
+    private static final Set<CompilerTarget> SUPPORTED =
+            Set.of(CompilerTarget.PLUTUS_V3_PV11);
+
+    public static ResolvedCompilerTarget resolve(CompilerTarget requested) {
+        // 1. exact compiler-support lookup
+        // 2. ProtocolFeatureRegistry.resolve(requested.ledgerTarget())
+        // 3. verify requested.uplcVersion() is available
+        // 4. return immutable target + feature profile
+    }
+}
+```
+
+`ResolvedCompilerTarget` is an internal compiler value containing the public
+target and its canonical `ProtocolFeatureProfile`. Compiler stages receive the
+resolved value, not loose booleans or version numbers.
+
+The initial matrix is intentionally narrow:
+
+| Requested target | Compiler result |
+|---|---|
+| V3 / PV11 / UPLC 1.1.0 | Supported |
+| V3 / PV11 / UPLC 1.0.0 | Rejected: compiler lowering targets UPLC 1.1.0 |
+| V3 / PV10 / any UPLC | Rejected: no PV10 compiler lowerings |
+| V1 or V2 / any PV | Rejected: no V1/V2 compiler output |
+| PV12 or later | Rejected until a pinned compiler profile is added |
+| PV11 with `MultiIndexArray` | Rejected: feature is not released for PV11 |
+
+### D4. Default existing entry points to the named PV11 target
+
+`CompilerOptions` gains:
+
+```java
+private CompilerTarget target = CompilerTarget.PLUTUS_V3_PV11;
+
+public CompilerOptions setTarget(CompilerTarget target) { ... }
+public CompilerTarget getTarget() { ... }
+```
+
+Existing source-compatible entry points continue to compile against
+`PLUTUS_V3_PV11`. The default is documented as a pinned target, not “current,”
+“latest,” or “mainnet.”
+
+Passing an unsupported explicit target fails before parsing or library
+discovery performs target-sensitive work. Explicit input is never replaced by
+the default.
+
+### D5. Carry a compilation context through target-sensitive stages
+
+Create an internal immutable `CompilationContext` containing at least:
+
+```text
+ResolvedCompilerTarget
+CompilerOptions snapshot
+diagnostic sink
+```
+
+It is created per compilation and passed explicitly. Target information must
+reach:
+
+```text
+JulcCompiler orchestration
+    -> subset/type validation where feature-bearing APIs are recognized
+    -> PirGenerator
+    -> TypeMethodRegistry and StdlibRegistry lowering
+    -> UplcGenerator
+    -> UplcOptimizer
+    -> final Program construction
+    -> UplcTargetValidator
+    -> CompileResult
+```
+
+No static mutable “current target” or thread-local target is allowed.
+
+Parsing itself is target-independent, but target resolution occurs before
+parsing so invalid configurations fail deterministically and cheaply.
+
+### D6. Replace tag ceilings with capability checks
+
+Every `PirTerm.Builtin` lowered to UPLC is checked with:
+
+```java
+resolvedTarget.featureProfile().isBuiltinAvailable(fun)
+```
+
+The current tag-100 ceiling is removed once all emission paths use the
+capability check. `MultiIndexArray` remains in the AST/runtime for future work,
+but the PV11 profile rejects it because it is absent from the canonical
+available-builtin set.
+
+Term-form validation also checks:
+
+- the program UPLC version;
+- `Constr`/`Case` availability;
+- case-on-builtin use when the compiler emits that form;
+- future constant universes or term constructors added to the compiler.
+
+Raw checks such as `protocolMajor >= 11` are not permitted in compiler passes.
+Passes ask the resolved profile about named capabilities.
+
+### D7. Attach requirements to feature-bearing lowerings
+
+Stdlib and type-method mappings that can emit protocol-gated features declare
+requirements in metadata rather than relying only on late failure. The
+conceptual form is:
+
+```java
+record LoweringRequirements(
+        Set<DefaultFun> builtins,
+        Set<CompilerFeature> features) {}
+```
+
+This metadata provides early, source-located diagnostics. Final validation is
+still mandatory because direct PIR, public `Builtins` calls, and optimizer
+rewrites can bypass a high-level mapping.
+
+The initial metadata covers at least:
+
+- `DropList`;
+- base Array operations;
+- BLS MSM;
+- `ExpModInteger`;
+- native Value operations;
+- case-on-builtin lowerings introduced by ADR-032.
+
+### D8. Validate final optimized output
+
+Add a target validator that walks the final `Program` after optimization and
+before `CompileResult` construction. It validates:
+
+1. the program version equals the compiler target UPLC version;
+2. every builtin is in the target profile;
+3. every term form is legal for the target;
+4. compiler-known case-on-builtin forms are authorized;
+5. no future/unreleased feature survives a lower-level route.
+
+Validation runs whether optimization is enabled or disabled. Source-map builds
+that currently skip optimization are not exempt.
+
+An illegal optimizer result is reported as an internal compiler invariant
+failure with the optimizer rule/pass identity. An illegal user-requested
+feature is reported as a source diagnostic. These are different error classes.
+
+### D9. Record target provenance
+
+`CompileResult` gains the resolved public `CompilerTarget`. All constructors
+must either accept the target or use the documented PV11 default only in
+backward-compatible overloads.
+
+Tooling reports the stable profile ID:
+
+- verbose compiler output;
+- `julc build` success output;
+- Gradle task lifecycle output;
+- annotation-processor notes when verbose diagnostics are enabled;
+- MCP compile results;
+- generated artifact metadata where the format permits extension.
+
+The standard script envelope, CBOR, FLAT, and script hash do not change merely
+to carry this metadata. If a standard artifact format has no target field,
+JuLC may add a deterministic adjacent metadata file in a later tooling slice;
+it must not insert non-standard fields without an explicit schema decision.
+
+### D10. Add catalog-backed target diagnostics
+
+ADR-021's diagnostic catalog remains authoritative. Add stable catalog entries
+for at least:
+
+| Diagnostic family | Required content |
+|---|---|
+| Unsupported compiler target | requested target and supported targets |
+| UPLC version unavailable | requested UPLC version and legal versions |
+| Builtin unavailable | builtin, required capability, selected target |
+| Term form unavailable | term/feature and selected target |
+| Future/unreleased feature | feature, selected target, migration guidance |
+| Optimizer invariant violation | rule/pass and illegal emitted feature |
+| Compile/evaluate target mismatch | compiled target and requested evaluation target |
+
+Where a Java source node exists, the diagnostic includes file, line, column,
+and remediation. Lower-level validation without a source mapping still reports
+the feature and stable profile ID.
+
+## Supporting the next protocol version
+
+“Support the next version” means adding a new pinned profile, not increasing a
+maximum integer. For a future protocol major `N`, the following sequence is
+required.
+
+### 1. Pin the authoritative ledger baseline
+
+Record:
+
+- cardano-node release;
+- Plutus package version and commit;
+- protocol major/minor used as provenance;
+- supported ledger languages;
+- UPLC versions;
+- builtin batches and exact tags;
+- semantics variant mapping;
+- decode bounds;
+- cost-model schemas.
+
+Later Plutus `master` is not a substitute for the revision shipped by the
+supported node release.
+
+### 2. Extend and verify the protocol feature registry
+
+Add an exact profile entry and positive/negative matrix tests. Remove or raise
+`MAX_SUPPORTED_PROTOCOL_MAJOR` only in the same change. The registry must not
+use an open-ended `protocol >= N` branch that treats all later versions as the
+same profile.
+
+If the next protocol introduces no Plutus change, it still receives an
+explicit alias entry backed by evidence that its feature profile is identical.
+
+### 3. Decide compiler support independently
+
+Audit every compiler emission route and Phase 5 optimization against the new
+profile. Then either:
+
+- add the exact target to `CompilerTargetRegistry`; or
+- keep it evaluator-only and return an unsupported compiler target diagnostic.
+
+This prevents a newly evaluatable profile from becoming compilable by
+accident.
+
+### 4. Define lowering compatibility
+
+Each target-sensitive lowering chooses one of:
+
+```text
+same lowering remains legal
+new target-specific lowering
+portable fallback
+feature rejected for this target
+```
+
+The choice is encoded in a target-aware lowering registry or pass, not spread
+across source visitors as raw version comparisons.
+
+### 5. Revalidate optimizations and profitability
+
+An optimization legal at PV11 may be illegal, semantically different, or no
+longer profitable under the next profile. ADR-032 rules are enabled by named
+capabilities and, where cost-directed, an explicit cost profile. No PV11
+profitability threshold is inherited silently.
+
+### 6. Add conformance, differential, and golden tests
+
+Required evidence includes:
+
+- valid/invalid feature matrices;
+- final compiler-output validation;
+- Java/Truffle evaluation of emitted programs under the same target;
+- exact failure behavior at target boundaries;
+- deterministic output and recorded script-hash changes;
+- example and plugin compilation.
+
+### 7. Make default-target changes explicit
+
+Adding support for protocol `N` does not change existing no-target compile
+calls. `PLUTUS_V3_PV11` remains the default until a separate release decision
+changes it.
+
+A default change requires:
+
+- release notes and migration guidance;
+- before/after script bytes and hashes for representative contracts;
+- an explicit compatibility statement;
+- a documented way to pin the old target while it remains supported;
+- versioning appropriate to JuLC's public API stability at that time.
+
+There is never a `LATEST` target because it makes builds depend on library
+upgrade timing rather than explicit configuration.
+
+## Affected modules and stages
+
+| Module | Change |
+|---|---|
+| `julc-vm` | Remains canonical protocol feature/profile layer; may gain named capability queries needed by compiler validation |
+| `julc-compiler` | `CompilerTarget`, target registry, compilation context, target-aware lowering/optimizer, final validator, result provenance, diagnostics |
+| `julc-stdlib` | Requirement metadata for target-gated intrinsics and libraries |
+| `julc-cli` | Target selection/reporting and metadata output |
+| `julc-gradle-plugin` | Target property and resolved-target logging |
+| `julc-annotation-processor` | Processor option and target provenance in generated build information |
+| `julc-testkit` | Compile/evaluate target handoff helpers |
+| `julc-cardano-client-lib` | Use the compiled target for canonical evaluation where available |
+| examples/docs | Document PV11 default, explicit pinning, and future-target migration |
+
+## Issue #76 traceability
+
+| Issue task | ADR decisions and milestones |
+|---|---|
+| PV11-040 — compiler target/configuration | D1–D5; Milestones A and B |
+| PV11-041 — compile-time feature enforcement | D6–D8; Milestone C |
+| PV11-042 — feature metadata and diagnostics | D7 and D10; Milestone C |
+| PV11-043 — target provenance | D9; Milestones B and D |
+
+The first implementation is not complete if it adds only the public target
+record. Resolution, propagation, final validation, and provenance are parts of
+the same correctness contract even when delivered as separate reviewable PRs.
+
+## Compatibility
+
+### Source compatibility
+
+Existing compile entry points continue working and resolve to the named
+V3/PV11 target. New overloads/options are additive.
+
+### Binary compatibility
+
+Changing the canonical components of the public `CompileResult` record is a
+binary and source compatibility concern. Implementation must assess one of:
+
+1. add a target component and retain compatibility constructors; or
+2. convert provenance to an additive method backed by a private field/class
+   redesign in a versioned API change.
+
+Because Java record accessors are public API, this choice must be documented in
+the implementation PR and release notes.
+
+### Generated scripts
+
+Introducing target representation and validation alone must not change script
+bytes. ADR-032 optimizations can change bytes and hashes, and carry their own
+rollout policy.
+
+### Unsupported requests
+
+Code that previously had no way to request PV10, V1/V2, or a future protocol
+can now request it and receive a deterministic diagnostic. No fallback is
+provided.
+
+## Alternatives considered
+
+### Keep V3/PV11 implicit until a second target exists
+
+Rejected. Phase 5 passes need a legality contract now, and retrofitting it
+after target-specific rewrites exist would make auditing harder.
+
+### Replace the tag ceiling with a higher constant for each fork
+
+Rejected. Tags do not describe UPLC forms, case-on-builtin behavior, semantics,
+or compiler support, and the existence of a tag does not establish release
+availability.
+
+### Duplicate a feature table in `julc-compiler`
+
+Rejected. Compiler and evaluator acceptance could drift, creating locally
+accepted scripts that the selected evaluator rejects.
+
+### Make `julc-compiler` depend only on `julc-core` by copying protocol enums
+
+Rejected. Parallel representations violate the single-profile invariant. The
+existing `julc-vm` contract module is backend-neutral and already has two
+concrete consumers once the compiler becomes target-aware.
+
+### Move protocol contracts into a new module immediately
+
+Deferred. It adds module and public-package churn without changing semantics.
+Extraction remains possible if more consumers justify it.
+
+### Infer the compiler target from emitted builtins
+
+Rejected. Programs without PV11-only builtins would be ambiguous, and target
+selection also controls UPLC forms and optimization legality.
+
+### Default to the newest profile known to the installed JuLC version
+
+Rejected. A dependency upgrade could change script bytes, hashes, failure
+behavior, or deployment validity without a source/configuration change.
+
+### Support PV10 fallbacks in the initial target change
+
+Rejected. It multiplies lowering and test scope before PV11 target enforcement
+is established. A later target ADR may add PV10 deliberately if there is a
+concrete user need.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Compiler gains a public dependency on `julc-vm` | `julc-vm` is backend-neutral and depends only on `julc-core`; expose only protocol-contract types |
+| Target is resolved differently by stages | Resolve once into immutable `CompilationContext` |
+| Optimizer introduces an unavailable feature | Require target-aware passes and final validation |
+| Unknown future PV is treated as PV11 | Exact supported-target table and fail-closed registry |
+| Diagnostics lose source locations at final validation | Early lowering metadata plus PIR/UPLC source maps; final validator remains a safety net |
+| Provenance alters script hashes | Keep target metadata out of UPLC encoding |
+| Default changes unexpectedly in a later release | No `LATEST`; default change requires a separate release decision |
+| Existing `CompileResult` consumers break | Compatibility constructors or a separately reviewed public API migration |
+
+## Implementation milestones
+
+### Milestone A — Target values and policy
+
+- Add the compiler dependency on the protocol contract layer.
+- Add `CompilerTarget`, `CompilerTargetRegistry`, and internal resolved target.
+- Add PV11 default to `CompilerOptions`.
+- Add unsupported-target diagnostics and matrix tests.
+
+### Milestone B — Propagation and provenance
+
+- Add immutable per-compilation context.
+- Thread it through PIR, stdlib/type-method lowering, UPLC generation, and
+  optimization.
+- Add target to `CompileResult` and compiler logs.
+- Preserve generated program bytes for existing fixtures.
+
+### Milestone C — Feature metadata and final enforcement
+
+- Replace the hard-coded tag ceiling with canonical capability checks.
+- Add lowering requirement metadata.
+- Add final `Program` target validation after optimization.
+- Cover direct builtin, stdlib, type-method, optimizer, and low-level PIR paths.
+
+### Milestone D — Tooling integration
+
+- Add CLI target selection/reporting.
+- Add Gradle and annotation-processor target options.
+- Add MCP and testkit provenance/handoff.
+- Update public docs and examples.
+
+Each milestone requires focused tests and independent review. Milestone C must
+land before ADR-032 Phase 5 optimizations are enabled.
+
+## Verification strategy
+
+### Target resolution tests
+
+- V3/PV11/UPLC 1.1.0 resolves successfully.
+- V3/PV10, V1, V2, future PV, UPLC 1.0.0, and unknown UPLC versions fail with
+  stable diagnostics.
+- Explicit unsupported requests never fall back to PV11.
+
+### Feature-route tests
+
+For every target-gated feature, cover:
+
+- Java syntax or typed method route;
+- stdlib mapping;
+- direct `Builtins` call;
+- direct PIR construction;
+- optimizer-introduced term;
+- final-program validator.
+
+Tags 87–100 must compile for V3/PV11. Tag 101 must fail through every public
+entry path.
+
+### Semantic and integration tests
+
+- Evaluate emitted scripts with Java and Truffle using
+  `result.target().ledgerTarget()`.
+- Test success, failure, evaluation order, and boundary behavior for
+  target-gated constructs.
+- Verify source-located diagnostics.
+- Verify CLI, Gradle, annotation-processor, MCP, and testkit target provenance.
+
+### Determinism and compatibility tests
+
+- Golden existing script bytes and hashes before target plumbing.
+- Compile the same input repeatedly and across entry points.
+- Verify target metadata does not alter CBOR/FLAT.
+- Run focused module tests, affected integration tests, examples, and the full
+  repository build.
+
+## Open questions
+
+1. Should `CompileResult` remain a record with an added component, or migrate to
+   a class to make future provenance fields additive?
+2. Which standard generated artifact, if any, can carry target metadata without
+   violating its schema? Otherwise, should tooling emit a sidecar file?
+3. Should Gradle and annotation-processor target configuration initially accept
+   only the stable profile ID or also structured language/PV/UPLC components?
+4. Which named capability representation best covers term forms without
+   duplicating `ProtocolFeatureProfile` fields?
+5. Should a future protocol-contract module extraction preserve the existing
+   package names or use a versioned public API migration?
+
+These questions do not change the initial support matrix or fail-closed future
+version policy.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -75,7 +75,8 @@ dependencies {
     // Test: VM for local evaluation
     testImplementation "com.bloxbean.cardano:julc-testkit:${julcVersion}"
     testImplementation "com.bloxbean.cardano:julc-vm:${julcVersion}"
-    testRuntimeOnly "com.bloxbean.cardano:julc-vm-scalus:${julcVersion}"
+    // Protocol-aware handoff from CompileResult.target()
+    testRuntimeOnly "com.bloxbean.cardano:julc-vm-java:${julcVersion}"
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/docs/src/content/docs/reference/release-notes.md
+++ b/docs/src/content/docs/reference/release-notes.md
@@ -39,6 +39,43 @@ See the [formal verification guide](/guides/formal-verification/) for annotation
 and DSL workflows, local/Docker backends, exact certificate scope, outcome
 classification, and CI guidance.
 
+## Upcoming preview: explicit PV11 compiler target
+
+JuLC compilation now resolves one explicit, immutable compiler profile:
+`plutus-v3-pv11-uplc-1.1.0`. The profile covers the Plutus language, ledger
+protocol version, and UPLC version together. Existing compile entry points
+select this named profile by default; unknown profiles, future protocol
+versions, and a `latest` alias are rejected rather than interpreted as PV11.
+
+`CompileResult` now has a public `target()` record component containing this
+provenance. Compatibility constructors preserve existing constructor call
+sites by assigning the documented PV11 target, but code that inspects the
+record shape, uses record patterns, or depends on generated record equality or
+string representation must account for the additional component. Compiler
+target plumbing and validation alone do not change generated UPLC, FLAT bytes,
+or script hashes.
+
+Testkit operations that retain a `CompileResult` now pass its exact ledger
+target to the selected VM. With the Java VM, this means source-based validator
+and method evaluation uses explicit PV11 semantics and costs instead of the
+legacy language-only path, which defaults to PV10 when no protocol-aware cost
+model is configured. A caller may also provide an explicit evaluation target;
+it must match `CompileResult.target()` or evaluation fails before VM execution.
+
+The Scalus adapter does not yet implement JuLC's explicit-target VM SPI.
+Consequently, `ValidatorTest.evaluate(result, ...)` throws
+`UnsupportedOperationException` when Scalus is the only available provider.
+For a Scalus compatibility cross-check, evaluate `result.program()` through
+the language-only overload. The Java VM supports both forms, although the raw
+`Program` form cannot carry compiler-target provenance. Scalus target
+propagation is tracked in
+[#74](https://github.com/bloxbean/julc/issues/74).
+
+The CLI, Gradle plugin, annotation processor, JRL compiler, and MCP tools accept
+and report the same stable profile ID. Supporting a later protocol version will
+add and verify a separate pinned profile; it will not silently change the PV11
+default.
+
 ## Upcoming preview: strict typed datum/redeemer boundaries
 
 Typed validator boundaries now reject non-canonical `Data` before user code

--- a/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
+++ b/julc-annotation-processor/src/main/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessor.java
@@ -6,6 +6,8 @@ import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.clientlib.ValidatorOutput;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilerTarget;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetRegistry;
 import com.bloxbean.cardano.julc.compiler.JavaSourceIntrospector;
 import com.bloxbean.cardano.julc.compiler.LibrarySource;
 import com.bloxbean.cardano.julc.compiler.LibrarySourceResolver;
@@ -54,7 +56,7 @@ import java.util.stream.Collectors;
         "com.bloxbean.cardano.julc.stdlib.annotation.ProposingValidator",
         "com.bloxbean.cardano.julc.stdlib.annotation.MultiValidator"
 })
-@SupportedOptions({"julc.projectName", "julc.projectVersion", "julc.sourceMap", "julc.blueprint"})
+@SupportedOptions({"julc.projectName", "julc.projectVersion", "julc.sourceMap", "julc.blueprint", "julc.target"})
 @SupportedSourceVersion(SourceVersion.RELEASE_24)
 public class JulcAnnotationProcessor extends AbstractProcessor {
 
@@ -63,6 +65,7 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
     private boolean sourceMapEnabled;
     private boolean blueprintEnabled;
     private boolean processingFailed;
+    private CompilerTarget compilerTarget;
 
     /** Accumulated compiled validators for CIP-57 blueprint generation. */
     private final List<BlueprintGenerator.CompiledValidator> compiledValidators = new ArrayList<>();
@@ -85,6 +88,15 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
                 processingEnv.getOptions().get("julc.sourceMap"));
         this.blueprintEnabled = !"false".equalsIgnoreCase(
                 processingEnv.getOptions().get("julc.blueprint"));
+        var targetProfile = processingEnv.getOptions().getOrDefault(
+                "julc.target", CompilerTarget.PLUTUS_V3_PV11.profileId());
+        try {
+            this.compilerTarget = CompilerTargetRegistry.targetForProfileId(targetProfile);
+        } catch (CompilerException e) {
+            this.processingFailed = true;
+            processingEnv.getMessager().printMessage(
+                    Diagnostic.Kind.ERROR, e.getMessage());
+        }
     }
 
     @Override
@@ -103,6 +115,9 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (processingFailed) {
+            return true;
+        }
         // 1. Collect same-project @OnchainLibrary sources
         collectSameProjectLibraries(roundEnv);
 
@@ -188,7 +203,7 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
             List<String> librarySources = resolveLibrarySources(source);
 
             // 3. Compile with JulcCompiler (multi-file if libraries found)
-            var options = new CompilerOptions();
+            var options = new CompilerOptions().setTarget(compilerTarget);
             if (sourceMapEnabled) {
                 options.setSourceMapEnabled(true);
             }
@@ -269,7 +284,9 @@ public class JulcAnnotationProcessor extends AbstractProcessor {
 
             String libMsg = librarySources.isEmpty() ? "" : " (with " + librarySources.size() + " library file(s))";
             processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE,
-                    "Compiled Plutus validator: " + className + " (hash: " + scriptHash + ", size: " + sizeStr + ")" + libMsg,
+                    "Compiled Plutus validator: " + className + " (target: "
+                            + result.target().profileId() + ", hash: " + scriptHash
+                            + ", size: " + sizeStr + ")" + libMsg,
                     element);
 
         } catch (CompilerException e) {

--- a/julc-annotation-processor/src/test/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessorTest.java
+++ b/julc-annotation-processor/src/test/java/com/bloxbean/cardano/julc/processor/JulcAnnotationProcessorTest.java
@@ -260,6 +260,32 @@ class JulcAnnotationProcessorTest {
     }
 
     @Test
+    void targetOptionIsExactAndReported() throws Exception {
+        var source = """
+                import com.bloxbean.cardano.julc.stdlib.annotation.*;
+                import java.math.BigInteger;
+                @SpendingValidator class TargetValidator {
+                    @Entrypoint static boolean validate(BigInteger r, BigInteger c) {
+                        return true;
+                    }
+                }
+                """;
+
+        var success = compileWithProcessorAndOptions(source, "TargetValidator", List.of(
+                "-Ajulc.target=plutus-v3-pv11-uplc-1.1.0"));
+        assertTrue(success.success(), success.diagnostics().toString());
+        assertTrue(success.diagnostics().stream().anyMatch(diagnostic ->
+                diagnostic.getMessage(null).contains(
+                        "target: plutus-v3-pv11-uplc-1.1.0")));
+
+        var failure = compileWithProcessorAndOptions(source, "TargetValidator", List.of(
+                "-Ajulc.target=plutus-v3-pv12-uplc-1.1.0"));
+        assertFalse(failure.success());
+        assertTrue(failure.diagnostics().stream().anyMatch(diagnostic ->
+                diagnostic.getMessage(null).contains("not supported")));
+    }
+
+    @Test
     void blueprintDefaultsWhenNoOptions() throws Exception {
         var source = """
                 import com.bloxbean.cardano.julc.stdlib.annotation.*;

--- a/julc-cli/README.md
+++ b/julc-cli/README.md
@@ -33,6 +33,9 @@ julc new <project-name>
 # Build validators (compile Java to UPLC)
 julc build
 
+# Explicitly pin the compiler profile (also the current default)
+julc build --target plutus-v3-pv11-uplc-1.1.0
+
 # Compile raw deployable artifacts when no CIP-57 blueprint is wanted
 julc build --no-blueprint
 
@@ -89,6 +92,13 @@ mistaken for the new script. Schema-dependent commands such as
 A normal strict build also refreshes those raw files. Compilation and schema
 validation finish before any artifacts are published, so a failed strict build
 preserves the previous complete build rather than mixing old and new outputs.
+
+Every successful build reports its resolved compiler target. JuLC currently
+supports only `plutus-v3-pv11-uplc-1.1.0`; an unknown or future target is an
+error and never falls back to PV11. A later protocol version will be introduced
+as a new pinned profile after its ledger baseline, compiler lowerings,
+optimizations, and conformance tests are reviewed. Adding it will not change
+the no-option default automatically.
 
 ## Documentation
 

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/BuildCommand.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/cmd/BuildCommand.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetRegistry;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.core.text.UplcPrinter;
 import com.bloxbean.cardano.julc.jrl.JrlCompiler;
@@ -41,6 +42,11 @@ public class BuildCommand implements Callable<Integer> {
             description = "Compile raw artifacts without generating build/plutus/plutus.json")
     private boolean noBlueprint;
 
+    @Option(names = "--target",
+            defaultValue = "plutus-v3-pv11-uplc-1.1.0",
+            description = "Exact compiler target profile ID (default: ${DEFAULT-VALUE})")
+    private String targetProfile;
+
     @Override
     public Integer call() {
         try {
@@ -52,7 +58,9 @@ public class BuildCommand implements Callable<Integer> {
             }
 
             var config = TomlParser.parse(tomlFile);
-            System.out.println("Building " + AnsiColors.bold(config.name()) + " ...");
+            var compilerTarget = CompilerTargetRegistry.targetForProfileId(targetProfile);
+            System.out.println("Building " + AnsiColors.bold(config.name())
+                    + " for " + compilerTarget.profileId() + " ...");
 
             // Scan sources (single walk for .java + .jrl)
             var scanResult = ProjectScanner.scan(ProjectLayout.srcDir(root));
@@ -69,7 +77,9 @@ public class BuildCommand implements Callable<Integer> {
             var pool = ProjectSourceResolver.buildPool(scanResult.libraries());
 
             // Compile each validator
-            var options = new CompilerOptions().setVerbose(verbose);
+            var options = new CompilerOptions()
+                    .setTarget(compilerTarget)
+                    .setVerbose(verbose);
             var stdlib = StdlibRegistry.defaultRegistry();
             var compiledValidators = new ArrayList<BlueprintGenerator.CompiledValidator>();
             var compiledOutputs = new ArrayList<CompiledOutput>();
@@ -128,7 +138,7 @@ public class BuildCommand implements Callable<Integer> {
             }
 
             // Compile JRL files
-            var jrlCompiler = new JrlCompiler(stdlib);
+            var jrlCompiler = new JrlCompiler(stdlib, options);
             for (var entry : scanResult.jrlFiles().entrySet()) {
                 String name = entry.getKey();
                 String jrlSource = entry.getValue();
@@ -188,12 +198,20 @@ public class BuildCommand implements Callable<Integer> {
                             plutusDir.resolve("plutus.json"), blueprintJson);
                 }
                 System.out.println(AnsiColors.green("Build successful: "
-                        + compiledCount + " validator(s) compiled to build/plutus/"));
+                        + compiledCount + " validator(s) compiled for "
+                        + compilerTarget.profileId() + " to build/plutus/"));
                 return 0;
             } else {
                 System.out.println(AnsiColors.red("Build failed: " + errorCount + " error(s)"));
                 return 1;
             }
+        } catch (CompilerException e) {
+            if (!e.diagnostics().isEmpty()) {
+                System.err.println(DiagnosticFormatter.formatAll(e.diagnostics()));
+            } else {
+                System.err.println(AnsiColors.red("Build error: " + e.getMessage()));
+            }
+            return 1;
         } catch (IOException e) {
             System.err.println(AnsiColors.red("Build error: " + e.getMessage()));
             return 1;
@@ -216,7 +234,8 @@ public class BuildCommand implements Callable<Integer> {
         String hash = JulcScriptAdapter.scriptHash(result.program());
         String sizeStr = result.scriptSizeFormatted();
         System.out.println(AnsiColors.green("OK") + " "
-                + AnsiColors.dim("[" + sizeStr + ", " + hash.substring(0, 8) + "...]"));
+                + AnsiColors.dim("[" + result.target().profileId() + ", "
+                        + sizeStr + ", " + hash.substring(0, 8) + "...]"));
     }
 
     private void cleanupGeneratedArtifacts(Path plutusDir, Set<String> currentNames)

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/mcp/tools/CompileTool.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/mcp/tools/CompileTool.java
@@ -2,6 +2,9 @@ package com.bloxbean.julc.cli.mcp.tools;
 
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilerTarget;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetRegistry;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
@@ -25,6 +28,7 @@ import java.util.Map;
  * <pre>{@code
  * {
  *   "source": "string  // required — Java source of the validator class",
+ *   "target": "string  // optional — exact compiler target profile ID",
  *   "librarySources": "string[]  // optional — @OnchainLibrary source files",
  *   "includeUplc": "boolean  // optional, default false — include formatted UPLC",
  *   "includePir": "boolean  // optional, default false — include formatted PIR"
@@ -35,6 +39,7 @@ import java.util.Map;
  * <pre>{@code
  * {
  *   "ok": boolean,
+ *   "compilerTarget": "plutus-v3-pv11-uplc-1.1.0",
  *   "diagnostics": [
  *     { "level":"error|warning|info", "code":"JULC0003"?, "message":..., "line":..., "column":..., "suggestion":... }
  *   ],
@@ -61,6 +66,10 @@ public final class CompileTool {
                       "type": "array",
                       "items": { "type": "string" },
                       "description": "Optional @OnchainLibrary source files to make available."
+                    },
+                    "target": {
+                      "type": "string",
+                      "description": "Exact compiler target profile ID. Defaults to plutus-v3-pv11-uplc-1.1.0."
                     },
                     "includeUplc": {
                       "type": "boolean",
@@ -123,13 +132,21 @@ public final class CompileTool {
         }
         boolean includeUplc = Boolean.TRUE.equals(args.get("includeUplc"));
         boolean includePir = Boolean.TRUE.equals(args.get("includePir"));
+        Object targetObj = args.getOrDefault(
+                "target", CompilerTarget.PLUTUS_V3_PV11.profileId());
+        if (!(targetObj instanceof String targetProfile) || targetProfile.isBlank()) {
+            return errorResult("'target' must be a non-empty compiler target profile ID.");
+        }
 
         Map<String, Object> result = new LinkedHashMap<>();
         try {
-            var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
+            var target = CompilerTargetRegistry.targetForProfileId(targetProfile);
+            var options = new CompilerOptions().setTarget(target);
+            var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry(), options);
             CompileResult cr = compiler.compileWithDetails(src, librarySources);
 
             result.put("ok", !cr.hasErrors());
+            result.put("compilerTarget", cr.target().profileId());
             result.put("diagnostics", renderDiagnostics(cr.diagnostics()));
             if (!cr.hasErrors() && cr.program() != null) {
                 result.put("scriptSizeBytes", cr.scriptSizeBytes());

--- a/julc-cli/src/main/java/com/bloxbean/julc/cli/mcp/tools/EvaluateTool.java
+++ b/julc-cli/src/main/java/com/bloxbean/julc/cli/mcp/tools/EvaluateTool.java
@@ -2,11 +2,14 @@ package com.bloxbean.julc.cli.mcp.tools;
 
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilerTarget;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetRegistry;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.core.PlutusData;
-import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.ExBudget;
 import com.bloxbean.cardano.julc.vm.JulcVm;
 import com.bloxbean.cardano.julc.vm.TermExtractor;
@@ -60,6 +63,7 @@ import java.util.Map;
  * <pre>{@code
  * {
  *   "ok": boolean,
+ *   "compilerTarget": "plutus-v3-pv11-uplc-1.1.0",
  *   "result": <auto-extracted: number | hex-string | boolean | string | recursive PlutusData object>,
  *   "resultType": "integer|bytes|boolean|string|data|none",
  *   "cpu": number,
@@ -89,6 +93,7 @@ public final class EvaluateTool {
                   "properties": {
                     "source": { "type": "string", "description": "JuLC Java source." },
                     "method": { "type": "string", "description": "Name of the static method to compile and evaluate." },
+                    "target": { "type": "string", "description": "Exact compiler target profile ID. Defaults to plutus-v3-pv11-uplc-1.1.0." },
                     "args": {
                       "type": "array",
                       "description": "Arguments to apply. Each is a PlutusData JSON shape: {int:n}, {bytes:'0x..'}, {string:'..'}, {bool:b}, {unit:true}, {constr:{tag:int,fields:[..]}}, {list:[..]}, or {map:[{key,value}]}.",
@@ -148,10 +153,18 @@ public final class EvaluateTool {
                     ". Pass each parameter explicitly via the `args` array.");
         }
 
+        Object targetObj = args.getOrDefault(
+                "target", CompilerTarget.PLUTUS_V3_PV11.profileId());
+        if (!(targetObj instanceof String targetProfile) || targetProfile.isBlank()) {
+            return errorResult("'target' must be a non-empty compiler target profile ID.");
+        }
+
         // Compile (with diagnostic-fallback for bare CompilerException).
-        Program program;
+        CompileResult compiled;
         try {
-            var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
+            var target = CompilerTargetRegistry.targetForProfileId(targetProfile);
+            var options = new CompilerOptions().setTarget(target);
+            var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry(), options);
             CompileResult cr = compiler.compileMethod(src, method);
             if (cr.hasErrors() || cr.program() == null) {
                 Map<String, Object> body = new LinkedHashMap<>();
@@ -160,7 +173,7 @@ public final class EvaluateTool {
                 body.put("diagnostics", CompileTool.renderDiagnostics(cr.diagnostics()));
                 return buildResult(body, jsonMapper);
             }
-            program = cr.program();
+            compiled = cr;
         } catch (CompilerException ce) {
             Map<String, Object> body = new LinkedHashMap<>();
             body.put("ok", false);
@@ -182,13 +195,18 @@ public final class EvaluateTool {
         EvalResult result;
         try {
             result = pdArgs.isEmpty()
-                    ? vm.evaluate(program, DEFAULT_BUDGET)
-                    : vm.evaluateWithArgs(program, pdArgs, DEFAULT_BUDGET);
+                    ? vm.evaluate(
+                            compiled.program(), compiled.target().ledgerTarget(),
+                            DEFAULT_BUDGET, EvalOptions.DEFAULT)
+                    : vm.evaluateWithArgs(
+                            compiled.program(), compiled.target().ledgerTarget(), pdArgs,
+                            DEFAULT_BUDGET, EvalOptions.DEFAULT);
         } catch (Exception e) {
             return errorResult("VM error: " + e.getMessage());
         }
 
         Map<String, Object> body = new LinkedHashMap<>();
+        body.put("compilerTarget", compiled.target().profileId());
         if (result instanceof EvalResult.Success s) {
             body.put("ok", true);
             body.put("cpu", s.consumed().cpuSteps());

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/BuildCommandTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/cmd/BuildCommandTest.java
@@ -17,6 +17,18 @@ class BuildCommandTest {
     private static final ObjectMapper JSON = new ObjectMapper();
 
     @Test
+    void acceptsExactPv11TargetAndRejectsUnknownFutureTarget(@TempDir Path tempDir)
+            throws Exception {
+        Path project = tempDir.resolve("target-build");
+        ProjectScaffolder.scaffold(project, "target-build");
+
+        assertEquals(0, new CommandLine(new BuildCommand()).execute(
+                project.toString(), "--target", "plutus-v3-pv11-uplc-1.1.0"));
+        assertEquals(1, new CommandLine(new BuildCommand()).execute(
+                project.toString(), "--target", "plutus-v3-pv12-uplc-1.1.0"));
+    }
+
+    @Test
     void noBlueprintEmitsRawArtifactAndCannotLeaveStaleBlueprint(@TempDir Path tempDir)
             throws Exception {
         Path project = tempDir.resolve("raw-build");

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/mcp/tools/CompileToolTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/mcp/tools/CompileToolTest.java
@@ -196,6 +196,22 @@ class CompileToolTest {
         assertEquals(Boolean.TRUE, body.get("ok"));
         assertNotNull(body.get("uplc"),
                 "uplc must be present when includeUplc=true");
+        assertEquals("plutus-v3-pv11-uplc-1.1.0", body.get("compilerTarget"));
+    }
+
+    @Test
+    void rejectsUnknownCompilerTargetWithStableDiagnostic() {
+        var req = new McpSchema.CallToolRequest("julc_compile", Map.of(
+                "source", "class Empty {}",
+                "target", "plutus-v3-pv12-uplc-1.1.0"));
+        var res = CompileTool.handle(req, jsonMapper);
+        @SuppressWarnings("unchecked")
+        var body = (Map<String, Object>) res.structuredContent();
+        @SuppressWarnings("unchecked")
+        var diagnostics = (List<Map<String, Object>>) body.get("diagnostics");
+        assertEquals(Boolean.FALSE, body.get("ok"));
+        assertTrue(diagnostics.stream().anyMatch(
+                diagnostic -> "JULC0031".equals(diagnostic.get("code"))));
     }
 
     @Test

--- a/julc-cli/src/test/java/com/bloxbean/julc/cli/mcp/tools/EvaluateToolTest.java
+++ b/julc-cli/src/test/java/com/bloxbean/julc/cli/mcp/tools/EvaluateToolTest.java
@@ -45,6 +45,7 @@ class EvaluateToolTest {
         assertEquals(Boolean.TRUE, body.get("ok"), "evaluation failed: " + body);
         assertEquals("42", body.get("result"));
         assertEquals("integer", body.get("resultType"));
+        assertEquals("plutus-v3-pv11-uplc-1.1.0", body.get("compilerTarget"));
         assertTrue(((Number) body.get("cpu")).longValue() > 0, "cpu must be > 0");
     }
 
@@ -119,6 +120,22 @@ class EvaluateToolTest {
         ));
         var res = EvaluateTool.handle(req, jsonMapper);
         assertEquals(Boolean.TRUE, res.isError());
+    }
+
+    @Test
+    void rejects_unknown_future_compiler_target() {
+        var req = new McpSchema.CallToolRequest("julc_evaluate", Map.of(
+                "source", "class X { static BigInteger x() { return 1; } }",
+                "method", "x",
+                "target", "plutus-v3-pv12-uplc-1.1.0"));
+        var res = EvaluateTool.handle(req, jsonMapper);
+        @SuppressWarnings("unchecked")
+        var body = (Map<String, Object>) res.structuredContent();
+        @SuppressWarnings("unchecked")
+        var diagnostics = (List<Map<String, Object>>) body.get("diagnostics");
+        assertEquals(Boolean.FALSE, body.get("ok"));
+        assertTrue(diagnostics.stream().anyMatch(
+                diagnostic -> "JULC0031".equals(diagnostic.get("code"))));
     }
 
     @Test

--- a/julc-compiler/build.gradle
+++ b/julc-compiler/build.gradle
@@ -14,9 +14,9 @@ shadowJar {
 dependencies {
     api project(':julc-core')
     api project(':julc-ledger-api')
+    api project(':julc-vm')
     implementation 'com.github.javaparser:javaparser-core:3.26.3'
 
-    testImplementation project(':julc-vm')
     testImplementation project(':julc-stdlib')
     testImplementation project(':julc-testkit')
     testImplementation "net.jqwik:jqwik:${jqwikVersion}"

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilationContext.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilationContext.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.compiler;
 
 import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
+import com.bloxbean.cardano.julc.vm.ProtocolCapability;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +63,15 @@ public final class CompilationContext {
 
     public boolean isSourceMapEnabled() {
         return sourceMapEnabled;
+    }
+
+    /** Whether both the ledger profile and selected UPLC version support a capability. */
+    public boolean supports(ProtocolCapability capability) {
+        if (capability == ProtocolCapability.CONSTR_CASE
+                && !target().uplcVersion().supportsConstrAndCase()) {
+            return false;
+        }
+        return resolvedTarget.featureProfile().supports(capability);
     }
 
     /** Return an immutable snapshot of diagnostics reported in this compilation. */

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilationContext.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilationContext.java
@@ -1,0 +1,91 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Immutable configuration resolved for one compiler invocation.
+ *
+ * <p>The context snapshots mutable {@link CompilerOptions} at the compiler
+ * boundary. It is then passed through the pipeline so every target-sensitive
+ * stage observes the same target and options.
+ */
+public final class CompilationContext {
+
+    private final ResolvedCompilerTarget resolvedTarget;
+    private final boolean verbose;
+    private final boolean sourceMapEnabled;
+    private final Consumer<String> logger;
+    private final List<CompilerDiagnostic> diagnostics = new ArrayList<>();
+
+    private CompilationContext(
+            ResolvedCompilerTarget resolvedTarget,
+            boolean verbose,
+            boolean sourceMapEnabled,
+            Consumer<String> logger) {
+        this.resolvedTarget = Objects.requireNonNull(resolvedTarget, "resolvedTarget");
+        this.verbose = verbose;
+        this.sourceMapEnabled = sourceMapEnabled;
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    /** Resolve and snapshot options for one compilation. */
+    public static CompilationContext resolve(CompilerOptions options) {
+        var effectiveOptions = options != null ? options : new CompilerOptions();
+        return new CompilationContext(
+                CompilerTargetRegistry.resolve(effectiveOptions.getTarget()),
+                effectiveOptions.isVerbose(),
+                effectiveOptions.isSourceMapEnabled(),
+                effectiveOptions.getLogger());
+    }
+
+    /** Create a context for the documented pinned PV11 defaults. */
+    public static CompilationContext pv11Defaults() {
+        return resolve(new CompilerOptions());
+    }
+
+    public ResolvedCompilerTarget resolvedTarget() {
+        return resolvedTarget;
+    }
+
+    public CompilerTarget target() {
+        return resolvedTarget.target();
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public boolean isSourceMapEnabled() {
+        return sourceMapEnabled;
+    }
+
+    /** Return an immutable snapshot of diagnostics reported in this compilation. */
+    public List<CompilerDiagnostic> diagnostics() {
+        return List.copyOf(diagnostics);
+    }
+
+    List<CompilerDiagnostic> diagnosticBuffer() {
+        return diagnostics;
+    }
+
+    public void log(String message) {
+        if (verbose) {
+            logger.accept("[julc] " + message);
+        }
+    }
+
+    public void logf(String format, Object... args) {
+        if (verbose) {
+            logger.accept("[julc] " + String.format(format, args));
+        }
+    }
+
+    public void warnf(String format, Object... args) {
+        logger.accept("[julc] WARN: " + String.format(format, args));
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompileResult.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompileResult.java
@@ -10,6 +10,7 @@ import com.bloxbean.cardano.julc.core.source.SourceMap;
 import com.bloxbean.cardano.julc.core.text.UplcPrinter;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The result of compiling a Java validator to UPLC.
@@ -19,11 +20,22 @@ import java.util.List;
  * When created via the standard {@link JulcCompiler#compile(String)}, they are null.
  */
 public record CompileResult(Program program, List<CompilerDiagnostic> diagnostics, List<ParamInfo> params,
-                             PirTerm pirTerm, Term uplcTerm, SourceMap sourceMap) {
+                             PirTerm pirTerm, Term uplcTerm, SourceMap sourceMap,
+                             CompilerTarget target) {
 
     public CompileResult {
         diagnostics = List.copyOf(diagnostics);
         params = List.copyOf(params);
+        target = Objects.requireNonNull(target, "target");
+    }
+
+    /**
+     * Backward-compatible constructor using the documented pinned PV11 target.
+     */
+    public CompileResult(Program program, List<CompilerDiagnostic> diagnostics, List<ParamInfo> params,
+                         PirTerm pirTerm, Term uplcTerm, SourceMap sourceMap) {
+        this(program, diagnostics, params, pirTerm, uplcTerm, sourceMap,
+                CompilerTarget.PLUTUS_V3_PV11);
     }
 
     /**
@@ -31,21 +43,24 @@ public record CompileResult(Program program, List<CompilerDiagnostic> diagnostic
      */
     public CompileResult(Program program, List<CompilerDiagnostic> diagnostics, List<ParamInfo> params,
                          PirTerm pirTerm, Term uplcTerm) {
-        this(program, diagnostics, params, pirTerm, uplcTerm, null);
+        this(program, diagnostics, params, pirTerm, uplcTerm, null,
+                CompilerTarget.PLUTUS_V3_PV11);
     }
 
     /**
      * Backward-compatible constructor (no PIR/UPLC).
      */
     public CompileResult(Program program, List<CompilerDiagnostic> diagnostics, List<ParamInfo> params) {
-        this(program, diagnostics, params, null, null, null);
+        this(program, diagnostics, params, null, null, null,
+                CompilerTarget.PLUTUS_V3_PV11);
     }
 
     /**
      * Backward-compatible constructor for non-parameterized validators.
      */
     public CompileResult(Program program, List<CompilerDiagnostic> diagnostics) {
-        this(program, diagnostics, List.of(), null, null, null);
+        this(program, diagnostics, List.of(), null, null, null,
+                CompilerTarget.PLUTUS_V3_PV11);
     }
 
     /**

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerOptions.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerOptions.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.julc.compiler;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -11,7 +12,25 @@ import java.util.function.Consumer;
 public class CompilerOptions {
     private boolean verbose = false;
     private boolean sourceMapEnabled = false;
+    private CompilerTarget target = CompilerTarget.PLUTUS_V3_PV11;
     private Consumer<String> logger = System.out::println;
+
+    /**
+     * Select the ledger target for this compilation.
+     *
+     * <p>JuLC currently supports only {@link CompilerTarget#PLUTUS_V3_PV11}.
+     * Unsupported targets fail explicitly when compilation begins; they never
+     * fall back to this default.
+     */
+    public CompilerOptions setTarget(CompilerTarget target) {
+        this.target = Objects.requireNonNull(target, "target");
+        return this;
+    }
+
+    /** Return the requested compiler target. */
+    public CompilerTarget getTarget() {
+        return target;
+    }
 
     public CompilerOptions setVerbose(boolean verbose) {
         this.verbose = verbose;

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerOptions.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerOptions.java
@@ -55,8 +55,12 @@ public class CompilerOptions {
     }
 
     public CompilerOptions setLogger(Consumer<String> logger) {
-        this.logger = logger;
+        this.logger = Objects.requireNonNull(logger, "logger");
         return this;
+    }
+
+    Consumer<String> getLogger() {
+        return logger;
     }
 
     /**

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTarget.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTarget.java
@@ -1,0 +1,47 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.UplcVersion;
+
+import java.util.Objects;
+
+/**
+ * The complete ledger profile selected for one JuLC compilation.
+ *
+ * <p>A compiler target is deliberately more specific than a Plutus language:
+ * protocol and UPLC versions also control which terms and builtins are legal.
+ */
+public record CompilerTarget(
+        LedgerEvaluationTarget ledgerTarget,
+        UplcVersion uplcVersion) {
+
+    /** The sole compiler target supported by this release. */
+    public static final CompilerTarget PLUTUS_V3_PV11 = new CompilerTarget(
+            LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3),
+            UplcVersion.V1_1_0);
+
+    public CompilerTarget {
+        Objects.requireNonNull(ledgerTarget, "ledgerTarget");
+        Objects.requireNonNull(uplcVersion, "uplcVersion");
+    }
+
+    /** Stable identifier for diagnostics and build provenance. */
+    public String profileId() {
+        var language = switch (ledgerTarget.ledgerLanguage()) {
+            case PLUTUS_V1 -> "plutus-v1";
+            case PLUTUS_V2 -> "plutus-v2";
+            case PLUTUS_V3 -> "plutus-v3";
+        };
+        var protocol = ledgerTarget.protocolVersion();
+        var protocolId = protocol.minor() == 0
+                ? "pv" + protocol.major()
+                : "pv" + protocol.major() + "." + protocol.minor();
+        return language + "-" + protocolId + "-uplc-" + uplcVersion;
+    }
+
+    @Override
+    public String toString() {
+        return profileId();
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetDiagnostics.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetDiagnostics.java
@@ -1,0 +1,73 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
+import com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes;
+import com.bloxbean.cardano.julc.compiler.error.DiagnosticInfo;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.source.SourceLocation;
+import com.bloxbean.cardano.julc.vm.ProtocolCapability;
+import com.bloxbean.cardano.julc.vm.UplcVersion;
+
+/** Catalog-backed diagnostics shared by target-aware compiler stages. */
+public final class CompilerTargetDiagnostics {
+
+    private CompilerTargetDiagnostics() {
+    }
+
+    public static CompilerException unavailableBuiltin(
+            CompilationContext context,
+            DefaultFun builtin,
+            SourceLocation location) {
+        var display = builtin + " (FLAT tag " + builtin.flatCode() + ")";
+        var suffix = builtin == DefaultFun.MultiIndexArray
+                ? "; it is a future/unreleased CIP-156 builtin at protocol version 11. "
+                        + "Use IndexArray repeatedly for PV11"
+                : "";
+        var info = DiagnosticCodes.COMPILER_BUILTIN_UNAVAILABLE;
+        var message = info.format(display, context.target().profileId()) + suffix;
+        return exception(info, message, location);
+    }
+
+    public static CompilerException unavailableCapability(
+            CompilationContext context,
+            ProtocolCapability capability,
+            SourceLocation location) {
+        var info = DiagnosticCodes.COMPILER_FEATURE_UNAVAILABLE;
+        var message = info.format(capability, context.target().profileId());
+        return exception(info, message, location);
+    }
+
+    public static CompilerException programVersionMismatch(
+            CompilationContext context,
+            UplcVersion actual) {
+        var info = DiagnosticCodes.COMPILER_PROGRAM_VERSION_MISMATCH;
+        var message = info.format(
+                actual, context.target().profileId(), context.target().uplcVersion());
+        return exception(info, message, null);
+    }
+
+    public static CompilerException invariantViolation(
+            CompilationContext context,
+            String stage,
+            String feature) {
+        var info = DiagnosticCodes.COMPILER_TARGET_INVARIANT_VIOLATION;
+        var message = info.format(stage, feature, context.target().profileId());
+        return exception(info, message, null);
+    }
+
+    private static CompilerException exception(
+            DiagnosticInfo info,
+            String message,
+            SourceLocation location) {
+        var diagnostic = new CompilerDiagnostic(
+                info.level(),
+                message,
+                location != null && location.fileName() != null
+                        ? location.fileName() : "<compiler>",
+                location != null ? location.line() : 0,
+                location != null ? location.column() : 0,
+                info.fix(),
+                info.code());
+        return new CompilerException(message, diagnostic);
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetDiagnostics.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetDiagnostics.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes;
 import com.bloxbean.cardano.julc.compiler.error.DiagnosticInfo;
 import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
 import com.bloxbean.cardano.julc.vm.ProtocolCapability;
 import com.bloxbean.cardano.julc.vm.UplcVersion;
 
@@ -52,6 +53,16 @@ public final class CompilerTargetDiagnostics {
             String feature) {
         var info = DiagnosticCodes.COMPILER_TARGET_INVARIANT_VIOLATION;
         var message = info.format(stage, feature, context.target().profileId());
+        return exception(info, message, null);
+    }
+
+    /** Diagnostic for a caller attempting to evaluate compiled output under another ledger target. */
+    public static CompilerException evaluationTargetMismatch(
+            CompilerTarget compiledTarget,
+            LedgerEvaluationTarget requestedEvaluationTarget) {
+        var info = DiagnosticCodes.COMPILER_EVALUATION_TARGET_MISMATCH;
+        var message = info.format(
+                compiledTarget.profileId(), requestedEvaluationTarget);
         return exception(info, message, null);
     }
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistry.java
@@ -27,7 +27,8 @@ public final class CompilerTargetRegistry {
         return target != null && SUPPORTED.contains(target);
     }
 
-    static ResolvedCompilerTarget resolve(CompilerTarget requested) {
+    /** Resolve an exact compiler-supported target against the canonical feature registry. */
+    public static ResolvedCompilerTarget resolve(CompilerTarget requested) {
         Objects.requireNonNull(requested, "requested");
         if (!SUPPORTED.contains(requested)) {
             throw unsupported(requested);

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistry.java
@@ -1,0 +1,59 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
+import com.bloxbean.cardano.julc.compiler.error.DiagnosticCodes;
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureRegistry;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Exact, fail-closed set of ledger profiles JuLC can compile. */
+public final class CompilerTargetRegistry {
+
+    private static final Set<CompilerTarget> SUPPORTED =
+            Set.of(CompilerTarget.PLUTUS_V3_PV11);
+
+    private CompilerTargetRegistry() {
+    }
+
+    /** Return the immutable set of compiler targets supported by this release. */
+    public static Set<CompilerTarget> supportedTargets() {
+        return SUPPORTED;
+    }
+
+    /** Whether the exact language/protocol/UPLC target is supported. */
+    public static boolean isSupported(CompilerTarget target) {
+        return target != null && SUPPORTED.contains(target);
+    }
+
+    static ResolvedCompilerTarget resolve(CompilerTarget requested) {
+        Objects.requireNonNull(requested, "requested");
+        if (!SUPPORTED.contains(requested)) {
+            throw unsupported(requested);
+        }
+
+        var profile = ProtocolFeatureRegistry.resolve(requested.ledgerTarget());
+        if (!profile.isUplcVersionAvailable(requested.uplcVersion())) {
+            // The exact supported-target table should make this unreachable.
+            // Retain the check as an invariant against registry drift.
+            throw new IllegalStateException(
+                    "Supported compiler target " + requested
+                            + " selects unavailable UPLC " + requested.uplcVersion());
+        }
+        return new ResolvedCompilerTarget(requested, profile);
+    }
+
+    private static CompilerException unsupported(CompilerTarget requested) {
+        var info = DiagnosticCodes.UNSUPPORTED_COMPILER_TARGET;
+        var supported = SUPPORTED.stream()
+                .map(CompilerTarget::profileId)
+                .sorted()
+                .collect(Collectors.joining(", "));
+        var message = info.format(requested.profileId(), supported);
+        var diagnostic = new CompilerDiagnostic(
+                info.level(), message, "<configuration>", 0, 0,
+                info.fix(), info.code());
+        return new CompilerException(message, diagnostic);
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistry.java
@@ -27,6 +27,20 @@ public final class CompilerTargetRegistry {
         return target != null && SUPPORTED.contains(target);
     }
 
+    /**
+     * Resolve a stable profile ID to an exactly supported compiler target.
+     *
+     * <p>The lookup is deliberately exact and case-sensitive. Tooling must not
+     * reinterpret an unknown future profile as the current default.
+     */
+    public static CompilerTarget targetForProfileId(String profileId) {
+        Objects.requireNonNull(profileId, "profileId");
+        return SUPPORTED.stream()
+                .filter(target -> target.profileId().equals(profileId))
+                .findFirst()
+                .orElseThrow(() -> unsupported(profileId));
+    }
+
     /** Resolve an exact compiler-supported target against the canonical feature registry. */
     public static ResolvedCompilerTarget resolve(CompilerTarget requested) {
         Objects.requireNonNull(requested, "requested");
@@ -46,12 +60,16 @@ public final class CompilerTargetRegistry {
     }
 
     private static CompilerException unsupported(CompilerTarget requested) {
+        return unsupported(requested.profileId());
+    }
+
+    private static CompilerException unsupported(String requestedProfileId) {
         var info = DiagnosticCodes.UNSUPPORTED_COMPILER_TARGET;
         var supported = SUPPORTED.stream()
                 .map(CompilerTarget::profileId)
                 .sorted()
                 .collect(Collectors.joining(", "));
-        var message = info.format(requested.profileId(), supported);
+        var message = info.format(requestedProfileId, supported);
         var diagnostic = new CompilerDiagnostic(
                 info.level(), message, "<configuration>", 0, 0,
                 info.fix(), info.code());

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
@@ -18,7 +18,6 @@ import com.bloxbean.cardano.julc.compiler.uplc.UplcGenerator;
 import com.bloxbean.cardano.julc.compiler.uplc.UplcOptimizer;
 import com.bloxbean.cardano.julc.compiler.util.MethodDependencyResolver;
 import com.bloxbean.cardano.julc.compiler.validate.SubsetValidator;
-import com.bloxbean.cardano.julc.core.PlutusTarget;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.Term;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
@@ -116,18 +115,24 @@ public class JulcCompiler {
         this.options = options != null ? options : new CompilerOptions();
     }
 
+    private CompilationContext beginCompilation() {
+        var context = CompilationContext.resolve(options);
+        context.logf("Compiler target: %s", context.target().profileId());
+        return context;
+    }
+
     /**
      * Compile a single-file validator to a UPLC Program.
      * Auto-discovers @OnchainLibrary sources from classpath (META-INF/plutus-sources/).
      */
     public CompileResult compile(String javaSource) {
+        var context = beginCompilation();
         var availableLibs = LibrarySourceResolver.scanClasspathSources(
                 JulcCompiler.class.getClassLoader());
-        if (availableLibs.isEmpty()) {
-            return compile(javaSource, List.of());
-        }
-        var resolvedLibs = LibrarySourceResolver.resolve(javaSource, availableLibs);
-        return compile(javaSource, resolvedLibs);
+        var resolvedLibs = availableLibs.isEmpty()
+                ? List.<String>of()
+                : LibrarySourceResolver.resolve(javaSource, availableLibs);
+        return doCompile(javaSource, resolvedLibs, false, context);
     }
 
     /**
@@ -135,20 +140,20 @@ public class JulcCompiler {
      * The returned {@link CompileResult} will have non-null {@code pirTerm()} and {@code uplcTerm()}.
      */
     public CompileResult compileWithDetails(String javaSource) {
+        var context = beginCompilation();
         var availableLibs = LibrarySourceResolver.scanClasspathSources(
                 JulcCompiler.class.getClassLoader());
-        if (availableLibs.isEmpty()) {
-            return compileWithDetails(javaSource, List.of());
-        }
-        var resolvedLibs = LibrarySourceResolver.resolve(javaSource, availableLibs);
-        return compileWithDetails(javaSource, resolvedLibs);
+        var resolvedLibs = availableLibs.isEmpty()
+                ? List.<String>of()
+                : LibrarySourceResolver.resolve(javaSource, availableLibs);
+        return doCompile(javaSource, resolvedLibs, true, context);
     }
 
     /**
      * Compile a validator with library sources, capturing PIR and UPLC intermediate representations.
      */
     public CompileResult compileWithDetails(String validatorSource, List<String> librarySources) {
-        return doCompile(validatorSource, librarySources, true);
+        return doCompile(validatorSource, librarySources, true, beginCompilation());
     }
 
     /**
@@ -159,7 +164,7 @@ public class JulcCompiler {
      * @return the compile result containing the UPLC Program
      */
     public CompileResult compile(String validatorSource, List<String> librarySources) {
-        return doCompile(validatorSource, librarySources, false);
+        return doCompile(validatorSource, librarySources, false, beginCompilation());
     }
 
     /**
@@ -169,51 +174,63 @@ public class JulcCompiler {
      * Schema capture is observational and is intended for blueprint generation.</p>
      */
     public ContractCompileResult compileContract(String validatorSource) {
+        var context = beginCompilation();
         var availableLibs = LibrarySourceResolver.scanClasspathSources(
                 JulcCompiler.class.getClassLoader());
         var resolvedLibs = availableLibs.isEmpty()
                 ? List.<String>of()
                 : LibrarySourceResolver.resolve(validatorSource, availableLibs);
-        return compileContract(validatorSource, resolvedLibs);
+        var outcome = doCompileOutcome(validatorSource, resolvedLibs, false, true, context);
+        return new ContractCompileResult(outcome.compileResult(), outcome.contractSchema());
     }
 
     /** Compile a validator with library sources and capture its resolved contract schema. */
     public ContractCompileResult compileContract(
             String validatorSource, List<String> librarySources) {
-        var outcome = doCompileOutcome(validatorSource, librarySources, false, true);
+        var outcome = doCompileOutcome(
+                validatorSource, librarySources, false, true, beginCompilation());
         return new ContractCompileResult(outcome.compileResult(), outcome.contractSchema());
     }
 
     /** Compile with PIR/UPLC inspection details and resolved contract schema metadata. */
     public ContractCompileResult compileContractWithDetails(String validatorSource) {
+        var context = beginCompilation();
         var availableLibs = LibrarySourceResolver.scanClasspathSources(
                 JulcCompiler.class.getClassLoader());
         var resolvedLibs = availableLibs.isEmpty()
                 ? List.<String>of()
                 : LibrarySourceResolver.resolve(validatorSource, availableLibs);
-        return compileContractWithDetails(validatorSource, resolvedLibs);
+        var outcome = doCompileOutcome(validatorSource, resolvedLibs, true, true, context);
+        return new ContractCompileResult(outcome.compileResult(), outcome.contractSchema());
     }
 
     /** Compile with PIR/UPLC inspection details and resolved contract schema metadata. */
     public ContractCompileResult compileContractWithDetails(
             String validatorSource, List<String> librarySources) {
-        var outcome = doCompileOutcome(validatorSource, librarySources, true, true);
+        var outcome = doCompileOutcome(
+                validatorSource, librarySources, true, true, beginCompilation());
         return new ContractCompileResult(outcome.compileResult(), outcome.contractSchema());
     }
 
-    private CompileResult doCompile(String validatorSource, List<String> librarySources, boolean captureDetails) {
-        return doCompileOutcome(validatorSource, librarySources, captureDetails, false).compileResult();
+    private CompileResult doCompile(
+            String validatorSource,
+            List<String> librarySources,
+            boolean captureDetails,
+            CompilationContext context) {
+        return doCompileOutcome(
+                validatorSource, librarySources, captureDetails, false, context).compileResult();
     }
 
     private CompilationOutcome doCompileOutcome(
             String validatorSource,
             List<String> librarySources,
             boolean captureDetails,
-            boolean captureContractSchema) {
+            boolean captureContractSchema,
+            CompilationContext context) {
         StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
 
         // 1. Parse all sources
-        options.logf("Parsing %d source(s) (1 validator + %d libraries)",
+        context.logf("Parsing %d source(s) (1 validator + %d libraries)",
                 1 + librarySources.size(), librarySources.size());
         var validatorCu = parseSource(validatorSource, "validator");
         var libraryCus = new ArrayList<CompilationUnit>();
@@ -221,24 +238,27 @@ public class JulcCompiler {
             libraryCus.add(parseSource(librarySources.get(i), "library[" + i + "]"));
         }
 
-        return doCompileFromCus(validatorCu, libraryCus, captureDetails, captureContractSchema);
+        return doCompileFromCus(
+                validatorCu, libraryCus, captureDetails, captureContractSchema, context);
     }
 
     private CompilationOutcome doCompileFromCus(
             CompilationUnit validatorCu,
             List<CompilationUnit> libraryCus,
             boolean captureDetails,
-            boolean captureContractSchema) {
+            boolean captureContractSchema,
+            CompilationContext context) {
         // 2. Validate subset on all compilation units
         var subsetValidator = new SubsetValidator();
-        var diagnostics = new ArrayList<>(subsetValidator.validate(validatorCu));
+        var diagnostics = context.diagnosticBuffer();
+        diagnostics.addAll(subsetValidator.validate(validatorCu));
         for (var libCu : libraryCus) {
             diagnostics.addAll(subsetValidator.validate(libCu));
         }
         if (hasErrors(diagnostics)) {
             throw new CompilerException(diagnostics);
         }
-        options.log("Subset validation passed");
+        context.log("Subset validation passed");
 
         // 3. Validate: library CUs must not contain validator annotations
         for (var libCu : libraryCus) {
@@ -260,7 +280,7 @@ public class JulcCompiler {
         // 4. Find annotated validator class and determine purpose
         var validatorClass = findAnnotatedClass(validatorCu);
         var scriptPurpose = getScriptPurpose(validatorClass);
-        options.logf("Found @%sValidator: %s", scriptPurpose.name().charAt(0)
+        context.logf("Found @%sValidator: %s", scriptPurpose.name().charAt(0)
                 + scriptPurpose.name().substring(1).toLowerCase(), validatorClass.getNameAsString());
 
         // 5. Register types from ALL sources (topo-sorted)
@@ -272,14 +292,14 @@ public class JulcCompiler {
         new TypeRegistrar().registerAll(ledgerCus, typeResolver);
         // Add flat-FQCN aliases for inner variant types (backward compat with ImportResolver)
         typeResolver.addFlatVariantAliases("com.bloxbean.cardano.julc.ledger");
-        options.logf("Registered %d ledger type(s) dynamically", ledgerCus.size());
+        context.logf("Registered %d ledger type(s) dynamically", ledgerCus.size());
 
         // 5b. Register user-defined types from validator + library sources
         var allCus = new ArrayList<CompilationUnit>();
         allCus.addAll(libraryCus);
         allCus.add(validatorCu);
         registerTypesWithDiagnostics(allCus, typeResolver, diagnostics);
-        options.logf("Registered types from %d compilation unit(s)", allCus.size());
+        context.logf("Registered types from %d compilation unit(s)", allCus.size());
 
         // 5c. Build knownFqcns for ImportResolver (types + library classes + stdlib classes)
         var knownFqcns = new LinkedHashSet<String>();
@@ -311,7 +331,7 @@ public class JulcCompiler {
         }
 
         if (!paramFields.isEmpty()) {
-            options.logf("Found %d @Param field(s): %s", paramFields.size(),
+            context.logf("Found %d @Param field(s): %s", paramFields.size(),
                     paramFields.stream().map(pf -> pf.name + ": " + pf.javaType).toList());
         }
 
@@ -332,11 +352,12 @@ public class JulcCompiler {
         }
 
         // 8. Compile library static methods to PIR (progressive lookup: each library sees previous)
-        var libraryRegistry = new LibraryMethodRegistry(options);
+        var libraryRegistry = LibraryMethodRegistry.forCompilation(context);
         if (!libraryCus.isEmpty()) {
-            options.logf("Compiling %d library source(s)", libraryCus.size());
-            compileLibraryMethods(libraryCus, typeResolver, libraryRegistry, effectiveStdlibLookup, knownFqcns);
-            options.logf("Compiled %d library method(s)", libraryRegistry.allMethods().size());
+            context.logf("Compiling %d library source(s)", libraryCus.size());
+            compileLibraryMethods(
+                    libraryCus, typeResolver, libraryRegistry, effectiveStdlibLookup, knownFqcns, context);
+            context.logf("Compiled %d library method(s)", libraryRegistry.allMethods().size());
         }
 
         // Restore validator's import resolver after library compilation
@@ -363,8 +384,8 @@ public class JulcCompiler {
         }
 
         // 11. Generate PIR for helper methods
-        var pirGenerator = new PirGenerator(typeResolver, symbolTable, effectiveLookup,
-                TypeMethodRegistry.defaultRegistry(), null, options);
+        var pirGenerator = PirGenerator.forCompilation(typeResolver, symbolTable, effectiveLookup,
+                TypeMethodRegistry.defaultRegistry(), null, context);
 
         // 11b. Compile static field initializers
         var compiledStaticFields = new ArrayList<CompiledStaticField>();
@@ -382,7 +403,7 @@ public class JulcCompiler {
         }
 
         // Enable boolean return guard for entrypoint only (not helpers — they may legitimately return false)
-        if (options.isSourceMapEnabled()) {
+        if (context.isSourceMapEnabled()) {
             pirGenerator.setBooleanReturnGuard(true);
         }
 
@@ -409,7 +430,7 @@ public class JulcCompiler {
                 multiHandlers.put(ei.tag(), handlerPir);
                 multiParamCounts.put(ei.tag(), ei.method().getParameters().size());
             }
-            options.logf("PIR generation complete (%d auto-dispatch entrypoints)", entrypointInfos.size());
+            context.logf("PIR generation complete (%d auto-dispatch entrypoints)", entrypointInfos.size());
         } else if (scriptPurpose == ScriptPurpose.MULTI) {
             // Mode 2: Manual dispatch — single DEFAULT entrypoint
             entrypointMethod = entrypointInfos.get(0).method();
@@ -418,14 +439,14 @@ public class JulcCompiler {
                     validateFn, entrypointMethod, typeResolver);
             validateFn = transformed.function();
             strictRecordErrors.addAll(transformed.errors());
-            options.log("PIR generation complete (manual dispatch)");
+            context.log("PIR generation complete (manual dispatch)");
         } else {
             validateFn = pirGenerator.generateMethod(entrypointMethod);
             var transformed = transformStrictRecordEntrypoint(
                     validateFn, entrypointMethod, typeResolver);
             validateFn = transformed.function();
             strictRecordErrors.addAll(transformed.errors());
-            options.log("PIR generation complete");
+            context.log("PIR generation complete");
         }
 
         // Disable guard after entrypoint generation
@@ -546,7 +567,7 @@ public class JulcCompiler {
         }
 
         // 15b. Register wrapper Error terms in source map (points to @Entrypoint method)
-        if (options.isSourceMapEnabled() && !wrapper.getErrorTerms().isEmpty()) {
+        if (context.isSourceMapEnabled() && !wrapper.getErrorTerms().isEmpty()) {
             var pirPositions = pirGenerator.getPirPositions();
             // For multi-dispatch, use the first entrypoint; for single, use the entrypoint method
             var epMethod = entrypointMethod != null ? entrypointMethod : entrypointInfos.getFirst().method();
@@ -579,39 +600,40 @@ public class JulcCompiler {
         PirTerm capturedPir = captureDetails ? wrappedTerm : null;
 
         // 18. Lower to UPLC (with source map support)
-        var uplcGenerator = options.isSourceMapEnabled()
-                ? new UplcGenerator(pirGenerator.getPirPositions())
-                : new UplcGenerator();
+        var uplcGenerator = context.isSourceMapEnabled()
+                ? new UplcGenerator(context, pirGenerator.getPirPositions())
+                : new UplcGenerator(context, null);
         var uplcTerm = uplcGenerator.generate(wrappedTerm);
 
         // 19. Optimize UPLC (skip when source maps enabled to preserve Term identity)
         SourceMap sourceMap = null;
-        if (options.isSourceMapEnabled()) {
+        if (context.isSourceMapEnabled()) {
             sourceMap = SourceMap.of(uplcGenerator.getUplcPositions());
-            options.logf("Source map generated: %d entries (optimization skipped)", sourceMap.size());
+            context.logf("Source map generated: %d entries (optimization skipped)", sourceMap.size());
         } else {
-            var optimizer = new UplcOptimizer();
+            var optimizer = new UplcOptimizer(context);
             uplcTerm = optimizer.optimize(uplcTerm);
-            options.log("UPLC optimization complete");
+            context.log("UPLC optimization complete");
         }
 
         // 20. Capture UPLC if details requested
         Term capturedUplc = captureDetails ? uplcTerm : null;
 
         // 21. Create Program
-        var program = PlutusTarget.CURRENT.program(uplcTerm);
+        var program = createProgram(context, uplcTerm);
 
         // 22. Build ParamInfo list
         var paramInfos = paramFields.stream()
                 .map(pf -> new CompileResult.ParamInfo(pf.name, pf.javaType))
                 .toList();
 
-        var result = new CompileResult(program, diagnostics, paramInfos, capturedPir, capturedUplc, sourceMap);
+        var result = new CompileResult(
+                program, diagnostics, paramInfos, capturedPir, capturedUplc, sourceMap, context.target());
         ContractSchema contractSchema = captureContractSchema
                 ? buildContractSchema(scriptPurpose, entrypointMethod, entrypointInfos,
                         paramFields, typeResolver, validatorClass)
                 : null;
-        options.logf("Compilation complete: %s", result.scriptSizeFormatted());
+        context.logf("Compilation complete: %s", result.scriptSizeFormatted());
         return new CompilationOutcome(result, contractSchema);
     }
 
@@ -639,20 +661,25 @@ public class JulcCompiler {
     /** Compile a validator and library source files and capture contract schema metadata. */
     public ContractCompileResult compileContract(
             Path validatorFile, List<Path> libraryFiles) throws IOException {
-        var outcome = compileOutcomeFromPaths(validatorFile, libraryFiles, true);
+        var outcome = compileOutcomeFromPaths(
+                validatorFile, libraryFiles, true, beginCompilation());
         return new ContractCompileResult(outcome.compileResult(), outcome.contractSchema());
     }
 
     private CompileResult compileFromPaths(Path validatorFile, List<Path> libraryFiles) throws IOException {
-        return compileOutcomeFromPaths(validatorFile, libraryFiles, false).compileResult();
+        return compileOutcomeFromPaths(
+                validatorFile, libraryFiles, false, beginCompilation()).compileResult();
     }
 
     private CompilationOutcome compileOutcomeFromPaths(
-            Path validatorFile, List<Path> libraryFiles, boolean captureContractSchema)
+            Path validatorFile,
+            List<Path> libraryFiles,
+            boolean captureContractSchema,
+            CompilationContext context)
             throws IOException {
         StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
 
-        options.logf("Parsing %d source(s) (1 validator + %d libraries)",
+        context.logf("Parsing %d source(s) (1 validator + %d libraries)",
                 1 + libraryFiles.size(), libraryFiles.size());
         var validatorCu = parseSource(Files.readString(validatorFile), "validator", validatorFile);
         var libraryCus = new ArrayList<CompilationUnit>();
@@ -662,7 +689,7 @@ public class JulcCompiler {
         }
 
         return doCompileFromCus(
-                validatorCu, libraryCus, false, captureContractSchema);
+                validatorCu, libraryCus, false, captureContractSchema, context);
     }
 
     /**
@@ -677,25 +704,29 @@ public class JulcCompiler {
      * Non-validator/non-minting .java files in the same directory are treated as libraries.
      */
     public CompileResult compileWithSiblings(Path validatorFile) throws IOException {
+        var context = beginCompilation();
         var parentDir = validatorFile.getParent();
         if (parentDir == null) {
-            return compile(Files.readString(validatorFile));
+            return compileOutcomeFromPaths(
+                    validatorFile, List.of(), false, context).compileResult();
         }
         var libPaths = new ArrayList<Path>();
         try (var stream = Files.list(parentDir)) {
             stream.filter(p -> p.toString().endsWith(".java") && !p.equals(validatorFile))
                     .forEach(libPaths::add);
         }
-        return compile(validatorFile, libPaths);
+        return compileOutcomeFromPaths(
+                validatorFile, libPaths, false, context).compileResult();
     }
 
     /**
      * Compile a PIR expression directly to a UPLC Program (for testing).
      */
     public Program compilePirToProgram(PirTerm pirTerm) {
-        var uplcGenerator = new UplcGenerator();
+        var context = beginCompilation();
+        var uplcGenerator = new UplcGenerator(context, null);
         var uplcTerm = uplcGenerator.generate(pirTerm);
-        return PlutusTarget.CURRENT.program(uplcTerm);
+        return createProgram(context, uplcTerm);
     }
 
     // --- Method compilation (for expression evaluation) ---
@@ -710,13 +741,13 @@ public class JulcCompiler {
      * @return the compile result containing the UPLC Program
      */
     public CompileResult compileMethod(String javaSource, String methodName) {
+        var context = beginCompilation();
         var availableLibs = LibrarySourceResolver.scanClasspathSources(
                 Thread.currentThread().getContextClassLoader());
-        if (availableLibs.isEmpty()) {
-            return compileMethod(javaSource, methodName, List.of());
-        }
-        var resolvedLibs = LibrarySourceResolver.resolve(javaSource, availableLibs);
-        return compileMethod(javaSource, methodName, resolvedLibs);
+        var resolvedLibs = availableLibs.isEmpty()
+                ? List.<String>of()
+                : LibrarySourceResolver.resolve(javaSource, availableLibs);
+        return compileMethod(javaSource, methodName, resolvedLibs, context);
     }
 
     /**
@@ -728,6 +759,14 @@ public class JulcCompiler {
      * @return the compile result containing the UPLC Program
      */
     public CompileResult compileMethod(String javaSource, String methodName, List<String> librarySources) {
+        return compileMethod(javaSource, methodName, librarySources, beginCompilation());
+    }
+
+    private CompileResult compileMethod(
+            String javaSource,
+            String methodName,
+            List<String> librarySources,
+            CompilationContext context) {
         StaticJavaParser.getParserConfiguration().setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_21);
 
         // 1. Parse all sources
@@ -739,7 +778,8 @@ public class JulcCompiler {
 
         // 2. Validate subset
         var subsetValidator = new SubsetValidator();
-        var diagnostics = new ArrayList<>(subsetValidator.validate(cu));
+        var diagnostics = context.diagnosticBuffer();
+        diagnostics.addAll(subsetValidator.validate(cu));
         for (var libCu : libraryCus) {
             diagnostics.addAll(subsetValidator.validate(libCu));
         }
@@ -804,9 +844,10 @@ public class JulcCompiler {
         var staticFields = findStaticFields(targetClass, typeResolver);
 
         // 8. Compile libraries (if any)
-        var libraryRegistry = new LibraryMethodRegistry(options);
+        var libraryRegistry = LibraryMethodRegistry.forCompilation(context);
         if (!libraryCus.isEmpty()) {
-            compileLibraryMethods(libraryCus, typeResolver, libraryRegistry, effectiveStdlibLookup, knownFqcns);
+            compileLibraryMethods(
+                    libraryCus, typeResolver, libraryRegistry, effectiveStdlibLookup, knownFqcns, context);
         }
         typeResolver.setCurrentImportResolver(importResolver);
 
@@ -830,8 +871,8 @@ public class JulcCompiler {
         }
 
         // 10. Generate PIR for helper methods
-        var pirGenerator = new PirGenerator(typeResolver, symbolTable, effectiveLookup,
-                TypeMethodRegistry.defaultRegistry(), null, options);
+        var pirGenerator = PirGenerator.forCompilation(typeResolver, symbolTable, effectiveLookup,
+                TypeMethodRegistry.defaultRegistry(), null, context);
 
         var compiledStaticFields = new ArrayList<CompiledStaticField>();
         for (var sf : staticFields) {
@@ -910,32 +951,39 @@ public class JulcCompiler {
         }
 
         // 17. Lower to UPLC (with source map support)
-        var uplcGenerator = options.isSourceMapEnabled()
-                ? new UplcGenerator(pirGenerator.getPirPositions())
-                : new UplcGenerator();
+        var uplcGenerator = context.isSourceMapEnabled()
+                ? new UplcGenerator(context, pirGenerator.getPirPositions())
+                : new UplcGenerator(context, null);
         var uplcTerm = uplcGenerator.generate(body);
 
         SourceMap sourceMap = null;
-        if (options.isSourceMapEnabled()) {
+        if (context.isSourceMapEnabled()) {
             sourceMap = SourceMap.of(uplcGenerator.getUplcPositions());
         } else {
-            var optimizer = new UplcOptimizer();
+            var optimizer = new UplcOptimizer(context);
             uplcTerm = optimizer.optimize(uplcTerm);
         }
 
         var paramInfos = paramFields.stream()
                 .map(pf -> new CompileResult.ParamInfo(pf.name, pf.javaType))
                 .toList();
-        var program = PlutusTarget.CURRENT.program(uplcTerm);
-        return new CompileResult(program, diagnostics, paramInfos, body, uplcTerm, sourceMap);
+        var program = createProgram(context, uplcTerm);
+        return new CompileResult(
+                program, diagnostics, paramInfos, body, uplcTerm, sourceMap, context.target());
     }
 
     // --- Library compilation ---
 
     private void compileLibraryMethods(List<CompilationUnit> libCus, TypeResolver typeResolver,
                                        LibraryMethodRegistry registry, StdlibLookup effectiveLookup,
-                                       Set<String> knownFqcns) {
-        new LibraryCompiler(options).compile(libCus, typeResolver, registry, effectiveLookup, knownFqcns);
+                                       Set<String> knownFqcns, CompilationContext context) {
+        new LibraryCompiler(context).compile(
+                libCus, typeResolver, registry, effectiveLookup, knownFqcns);
+    }
+
+    private static Program createProgram(CompilationContext context, Term term) {
+        var version = context.target().uplcVersion();
+        return new Program(version.major(), version.minor(), version.patch(), term);
     }
 
     /** Delegate to PirHelpers for self-recursion detection. */

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/JulcCompiler.java
@@ -16,6 +16,7 @@ import com.bloxbean.cardano.julc.compiler.schema.ContractCompileResult;
 import com.bloxbean.cardano.julc.compiler.schema.ContractSchema;
 import com.bloxbean.cardano.julc.compiler.uplc.UplcGenerator;
 import com.bloxbean.cardano.julc.compiler.uplc.UplcOptimizer;
+import com.bloxbean.cardano.julc.compiler.uplc.UplcTargetValidator;
 import com.bloxbean.cardano.julc.compiler.util.MethodDependencyResolver;
 import com.bloxbean.cardano.julc.compiler.validate.SubsetValidator;
 import com.bloxbean.cardano.julc.core.Program;
@@ -607,12 +608,15 @@ public class JulcCompiler {
 
         // 19. Optimize UPLC (skip when source maps enabled to preserve Term identity)
         SourceMap sourceMap = null;
+        var producingStage = "UPLC lowering";
         if (context.isSourceMapEnabled()) {
             sourceMap = SourceMap.of(uplcGenerator.getUplcPositions());
             context.logf("Source map generated: %d entries (optimization skipped)", sourceMap.size());
         } else {
             var optimizer = new UplcOptimizer(context);
-            uplcTerm = optimizer.optimize(uplcTerm);
+            var optimization = optimizer.optimizeWithReport(uplcTerm);
+            uplcTerm = optimization.term();
+            producingStage = optimizerStage(optimization);
             context.log("UPLC optimization complete");
         }
 
@@ -621,6 +625,10 @@ public class JulcCompiler {
 
         // 21. Create Program
         var program = createProgram(context, uplcTerm);
+        UplcTargetValidator.validate(
+                program,
+                context,
+                producingStage);
 
         // 22. Build ParamInfo list
         var paramInfos = paramFields.stream()
@@ -726,7 +734,9 @@ public class JulcCompiler {
         var context = beginCompilation();
         var uplcGenerator = new UplcGenerator(context, null);
         var uplcTerm = uplcGenerator.generate(pirTerm);
-        return createProgram(context, uplcTerm);
+        var program = createProgram(context, uplcTerm);
+        UplcTargetValidator.validate(program, context, "UPLC lowering");
+        return program;
     }
 
     // --- Method compilation (for expression evaluation) ---
@@ -957,17 +967,24 @@ public class JulcCompiler {
         var uplcTerm = uplcGenerator.generate(body);
 
         SourceMap sourceMap = null;
+        var producingStage = "UPLC lowering";
         if (context.isSourceMapEnabled()) {
             sourceMap = SourceMap.of(uplcGenerator.getUplcPositions());
         } else {
             var optimizer = new UplcOptimizer(context);
-            uplcTerm = optimizer.optimize(uplcTerm);
+            var optimization = optimizer.optimizeWithReport(uplcTerm);
+            uplcTerm = optimization.term();
+            producingStage = optimizerStage(optimization);
         }
 
         var paramInfos = paramFields.stream()
                 .map(pf -> new CompileResult.ParamInfo(pf.name, pf.javaType))
                 .toList();
         var program = createProgram(context, uplcTerm);
+        UplcTargetValidator.validate(
+                program,
+                context,
+                producingStage);
         return new CompileResult(
                 program, diagnostics, paramInfos, body, uplcTerm, sourceMap, context.target());
     }
@@ -984,6 +1001,12 @@ public class JulcCompiler {
     private static Program createProgram(CompilationContext context, Term term) {
         var version = context.target().uplcVersion();
         return new Program(version.major(), version.minor(), version.patch(), term);
+    }
+
+    private static String optimizerStage(UplcOptimizer.OptimizationResult result) {
+        return result.appliedPasses().isEmpty()
+                ? "UPLC optimizer (no rewrites)"
+                : "UPLC optimizer passes " + result.appliedPasses();
     }
 
     /** Delegate to PirHelpers for self-recursion detection. */
@@ -1147,6 +1170,31 @@ public class JulcCompiler {
                 return base != null
                         ? base.lookup(className, methodName, args, argTypes)
                         : java.util.Optional.empty();
+            }
+
+            @Override
+            public java.util.Optional<PirTerm> lookup(
+                    CompilationContext context,
+                    String className,
+                    String methodName,
+                    java.util.List<PirTerm> args,
+                    java.util.List<PirType> argTypes) {
+                if (methodName.equals("of") && newTypeNames.contains(className)) {
+                    return lookup(className, methodName, args, argTypes);
+                }
+                return base != null
+                        ? base.lookup(context, className, methodName, args, argTypes)
+                        : java.util.Optional.empty();
+            }
+
+            @Override
+            public LoweringRequirements requirements(String className, String methodName) {
+                if (methodName.equals("of") && newTypeNames.contains(className)) {
+                    return LoweringRequirements.NONE;
+                }
+                return base != null
+                        ? base.requirements(className, methodName)
+                        : LoweringRequirements.NONE;
             }
 
             @Override

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibraryCompiler.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LibraryCompiler.java
@@ -22,10 +22,10 @@ import java.util.Set;
  */
 final class LibraryCompiler {
 
-    private final CompilerOptions options;
+    private final CompilationContext context;
 
-    LibraryCompiler(CompilerOptions options) {
-        this.options = options;
+    LibraryCompiler(CompilationContext context) {
+        this.context = context;
     }
 
     /**
@@ -51,7 +51,7 @@ final class LibraryCompiler {
                     // Unexpected: likely a compiler bug. Retry to avoid blocking the user,
                     // but warn so developers can investigate.
                     var cuName = libCu.getStorage().map(s -> s.getFileName()).orElse("<unknown>");
-                    options.warnf("Unexpected error compiling library %s (will retry): %s: %s",
+                    context.warnf("Unexpected error compiling library %s (will retry): %s: %s",
                             cuName, e.getClass().getSimpleName(), e.getMessage());
                     nextRemaining.add(libCu);
                 }
@@ -89,8 +89,9 @@ final class LibraryCompiler {
             }
 
             var composedLookup = new CompositeStdlibLookup(effectiveLookup, registry);
-            var libPirGenerator = new PirGenerator(typeResolver, libSymbolTable, composedLookup,
-                    TypeMethodRegistry.defaultRegistry(), classNameFqcn);
+            var libPirGenerator = PirGenerator.forCompilation(
+                    typeResolver, libSymbolTable, composedLookup,
+                    TypeMethodRegistry.defaultRegistry(), classNameFqcn, context);
 
             record LibCompiledField(String name, PirTerm initPir) {}
             var compiledLibFields = new ArrayList<LibCompiledField>();

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LoweringRequirements.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/LoweringRequirements.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.vm.ProtocolCapability;
+
+import java.util.Set;
+
+/** Explicit protocol requirements declared by one source-to-PIR lowering. */
+public record LoweringRequirements(
+        Set<DefaultFun> builtins,
+        Set<ProtocolCapability> capabilities) {
+
+    public static final LoweringRequirements NONE =
+            new LoweringRequirements(Set.of(), Set.of());
+
+    public LoweringRequirements {
+        builtins = Set.copyOf(builtins);
+        capabilities = Set.copyOf(capabilities);
+    }
+
+    public static LoweringRequirements builtin(DefaultFun builtin) {
+        return new LoweringRequirements(Set.of(builtin), Set.of());
+    }
+
+    public static LoweringRequirements builtins(DefaultFun... builtins) {
+        return new LoweringRequirements(Set.of(builtins), Set.of());
+    }
+
+    public static LoweringRequirements capability(ProtocolCapability capability) {
+        return new LoweringRequirements(Set.of(), Set.of(capability));
+    }
+
+    public boolean isEmpty() {
+        return builtins.isEmpty() && capabilities.isEmpty();
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/ResolvedCompilerTarget.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/ResolvedCompilerTarget.java
@@ -4,17 +4,34 @@ import com.bloxbean.cardano.julc.vm.ProtocolFeatureProfile;
 
 import java.util.Objects;
 
-/** One validated compiler target and its canonical protocol feature profile. */
-record ResolvedCompilerTarget(
-        CompilerTarget target,
-        ProtocolFeatureProfile featureProfile) {
+/**
+ * One validated compiler target and its canonical protocol feature profile.
+ *
+ * <p>This is compiler pipeline state. Obtain it through
+ * {@link CompilerTargetRegistry#resolve(CompilerTarget)} so the compiler support
+ * policy and VM feature registry cannot be bypassed.
+ */
+public final class ResolvedCompilerTarget {
 
-    ResolvedCompilerTarget {
-        Objects.requireNonNull(target, "target");
-        Objects.requireNonNull(featureProfile, "featureProfile");
+    private final CompilerTarget target;
+    private final ProtocolFeatureProfile featureProfile;
+
+    ResolvedCompilerTarget(
+            CompilerTarget target,
+            ProtocolFeatureProfile featureProfile) {
+        this.target = Objects.requireNonNull(target, "target");
+        this.featureProfile = Objects.requireNonNull(featureProfile, "featureProfile");
         if (!target.ledgerTarget().equals(featureProfile.target())) {
             throw new IllegalArgumentException(
                     "Compiler target and protocol feature profile do not match");
         }
+    }
+
+    public CompilerTarget target() {
+        return target;
+    }
+
+    public ProtocolFeatureProfile featureProfile() {
+        return featureProfile;
     }
 }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/ResolvedCompilerTarget.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/ResolvedCompilerTarget.java
@@ -1,0 +1,20 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.vm.ProtocolFeatureProfile;
+
+import java.util.Objects;
+
+/** One validated compiler target and its canonical protocol feature profile. */
+record ResolvedCompilerTarget(
+        CompilerTarget target,
+        ProtocolFeatureProfile featureProfile) {
+
+    ResolvedCompilerTarget {
+        Objects.requireNonNull(target, "target");
+        Objects.requireNonNull(featureProfile, "featureProfile");
+        if (!target.ledgerTarget().equals(featureProfile.target())) {
+            throw new IllegalArgumentException(
+                    "Compiler target and protocol feature profile do not match");
+        }
+    }
+}

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
@@ -37,6 +37,14 @@ public final class DiagnosticCodes {
             "Builtin {0} is not available for compiler target {1}",
             "Use an operation available in the selected target, or explicitly select a future compiler target after JuLC adds and verifies support for it.");
 
+    public static final DiagnosticInfo COMPILER_EVALUATION_TARGET_MISMATCH = new DiagnosticInfo(
+            "JULC0036",
+            "COMPILER_EVALUATION_TARGET_MISMATCH",
+            CompilerDiagnostic.Level.ERROR,
+            "TARGET",
+            "Compiled target {0} cannot be evaluated as {1}",
+            "Evaluate with CompileResult.target().ledgerTarget(), or recompile for an explicitly supported compiler target.");
+
     public static final DiagnosticInfo COMPILER_FEATURE_UNAVAILABLE = new DiagnosticInfo(
             "JULC0033",
             "COMPILER_FEATURE_UNAVAILABLE",
@@ -291,6 +299,7 @@ public final class DiagnosticCodes {
             BREAK_OUTSIDE_LOOP,
             CIRCULAR_TYPE_DEPENDENCY,
             COMPILER_BUILTIN_UNAVAILABLE,
+            COMPILER_EVALUATION_TARGET_MISMATCH,
             COMPILER_FEATURE_UNAVAILABLE,
             COMPILER_PROGRAM_VERSION_MISMATCH,
             COMPILER_TARGET_INVARIANT_VIOLATION,

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
@@ -229,6 +229,14 @@ public final class DiagnosticCodes {
             "Unknown method: {0}",
             "Check the stdlib catalog at https://julc.dev/ai/catalog.json or the stdlib reference at https://julc.dev/stdlib/stdlib-guide/. Common: `JulcList<T>` has `head/tail/get/size/isEmpty/contains/prepend/reverse/concat/take/drop/map/filter/any/all/find`.");
 
+    public static final DiagnosticInfo UNSUPPORTED_COMPILER_TARGET = new DiagnosticInfo(
+            "JULC0031",
+            "UNSUPPORTED_COMPILER_TARGET",
+            CompilerDiagnostic.Level.ERROR,
+            "CONFIG",
+            "Compiler target {0} is not supported. Supported targets: {1}",
+            "Select a listed compiler target. This release supports Plutus V3/PV11/UPLC 1.1.0 only; do not rely on fallback to another target.");
+
     public static final DiagnosticInfo VALIDATOR_ANNOTATION_MISSING = new DiagnosticInfo(
             "JULC0010",
             "VALIDATOR_ANNOTATION_MISSING",
@@ -275,6 +283,7 @@ public final class DiagnosticCodes {
             TYPE_RESOLUTION_FAILED,
             UNDEFINED_VARIABLE,
             UNKNOWN_METHOD_ON_TYPE,
+            UNSUPPORTED_COMPILER_TARGET,
             VALIDATOR_ANNOTATION_MISSING,
             VARIABLE_UNINITIALIZED
     );

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/error/DiagnosticCodes.java
@@ -29,6 +29,38 @@ public final class DiagnosticCodes {
             "Circular type dependency detected among: {0}",
             "Break the cycle by introducing a parameterized record or refactoring the involved types.");
 
+    public static final DiagnosticInfo COMPILER_BUILTIN_UNAVAILABLE = new DiagnosticInfo(
+            "JULC0032",
+            "COMPILER_BUILTIN_UNAVAILABLE",
+            CompilerDiagnostic.Level.ERROR,
+            "TARGET",
+            "Builtin {0} is not available for compiler target {1}",
+            "Use an operation available in the selected target, or explicitly select a future compiler target after JuLC adds and verifies support for it.");
+
+    public static final DiagnosticInfo COMPILER_FEATURE_UNAVAILABLE = new DiagnosticInfo(
+            "JULC0033",
+            "COMPILER_FEATURE_UNAVAILABLE",
+            CompilerDiagnostic.Level.ERROR,
+            "TARGET",
+            "Compiler feature {0} is not available for compiler target {1}",
+            "Use a portable lowering for the selected target, or add the future target through the reviewed compiler support process.");
+
+    public static final DiagnosticInfo COMPILER_PROGRAM_VERSION_MISMATCH = new DiagnosticInfo(
+            "JULC0034",
+            "COMPILER_PROGRAM_VERSION_MISMATCH",
+            CompilerDiagnostic.Level.ERROR,
+            "INTERNAL",
+            "Generated UPLC version {0} does not match compiler target {1}, which requires {2}",
+            "Report this as a JuLC compiler bug with the source, selected target, and verbose compiler log.");
+
+    public static final DiagnosticInfo COMPILER_TARGET_INVARIANT_VIOLATION = new DiagnosticInfo(
+            "JULC0035",
+            "COMPILER_TARGET_INVARIANT_VIOLATION",
+            CompilerDiagnostic.Level.ERROR,
+            "INTERNAL",
+            "Compiler stage {0} emitted target-illegal feature {1} for {2}",
+            "Report this as a JuLC compiler bug. Include the named compiler stage/pass, selected target, and a minimal reproducer.");
+
     public static final DiagnosticInfo C_STYLE_FOR_UNSUPPORTED = new DiagnosticInfo(
             "JULC0018",
             "C_STYLE_FOR_UNSUPPORTED",
@@ -258,6 +290,10 @@ public final class DiagnosticCodes {
             ARRAY_UNSUPPORTED,
             BREAK_OUTSIDE_LOOP,
             CIRCULAR_TYPE_DEPENDENCY,
+            COMPILER_BUILTIN_UNAVAILABLE,
+            COMPILER_FEATURE_UNAVAILABLE,
+            COMPILER_PROGRAM_VERSION_MISMATCH,
+            COMPILER_TARGET_INVARIANT_VIOLATION,
             C_STYLE_FOR_UNSUPPORTED,
             DO_WHILE_UNSUPPORTED,
             DUPLICATE_TYPE_DECLARATION,

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/CompositeStdlibLookup.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/CompositeStdlibLookup.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.compiler.pir;
 
 import com.bloxbean.cardano.julc.compiler.CompilationContext;
+import com.bloxbean.cardano.julc.compiler.LoweringRequirements;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,6 +65,17 @@ public class CompositeStdlibLookup implements StdlibLookup {
             }
         }
         return Optional.empty();
+    }
+
+    @Override
+    public LoweringRequirements requirements(String className, String methodName) {
+        for (var lookup : lookups) {
+            var requirements = lookup.requirements(className, methodName);
+            if (!requirements.isEmpty()) {
+                return requirements;
+            }
+        }
+        return LoweringRequirements.NONE;
     }
 
     @Override

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/CompositeStdlibLookup.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/CompositeStdlibLookup.java
@@ -1,5 +1,7 @@
 package com.bloxbean.cardano.julc.compiler.pir;
 
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +43,22 @@ public class CompositeStdlibLookup implements StdlibLookup {
                                       List<PirTerm> args, List<PirType> argTypes) {
         for (var lookup : lookups) {
             var result = lookup.lookup(className, methodName, args, argTypes);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<PirTerm> lookup(
+            CompilationContext context,
+            String className,
+            String methodName,
+            List<PirTerm> args,
+            List<PirType> argTypes) {
+        for (var lookup : lookups) {
+            var result = lookup.lookup(context, className, methodName, args, argTypes);
             if (result.isPresent()) {
                 return result;
             }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.julc.compiler.pir;
 
 import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetDiagnostics;
+import com.bloxbean.cardano.julc.compiler.LoweringRequirements;
 import com.bloxbean.cardano.julc.compiler.desugar.LoopDesugarer;
 import com.bloxbean.cardano.julc.compiler.desugar.PatternMatchDesugarer;
 import com.bloxbean.cardano.julc.compiler.error.CompilerDiagnostic;
@@ -179,6 +181,41 @@ public class PirGenerator {
             pirPositions.put(term, new SourceLocation(
                     fileName, range.begin.line, range.begin.column, fragment));
         });
+    }
+
+    private void validateLoweringRequirements(
+            LoweringRequirements requirements,
+            Node sourceNode) {
+        var profile = context.resolvedTarget().featureProfile();
+        var location = sourceLocation(sourceNode);
+        requirements.builtins().stream()
+                .sorted(Comparator.comparingInt(DefaultFun::flatCode))
+                .filter(builtin -> !profile.isBuiltinAvailable(builtin))
+                .findFirst()
+                .ifPresent(builtin -> {
+                    throw CompilerTargetDiagnostics.unavailableBuiltin(
+                            context, builtin, location);
+                });
+        requirements.capabilities().stream()
+                .sorted()
+                .filter(capability -> !context.supports(capability))
+                .findFirst()
+                .ifPresent(capability -> {
+                    throw CompilerTargetDiagnostics.unavailableCapability(
+                            context, capability, location);
+                });
+    }
+
+    private static SourceLocation sourceLocation(Node node) {
+        if (node == null || node.getRange().isEmpty()) {
+            return null;
+        }
+        var begin = node.getRange().orElseThrow().begin;
+        var fileName = node.findCompilationUnit()
+                .flatMap(cu -> cu.getStorage().map(s -> s.getFileName()))
+                .orElse("<source>");
+        return new SourceLocation(
+                fileName, begin.line, begin.column, node.toString());
     }
 
     /**
@@ -1014,6 +1051,8 @@ public class PirGenerator {
             }
         }
 
+        validateLoweringRequirements(
+                stdlibLookup.requirements(resolvedClassName, methodName), mce);
         var result = stdlibLookup.lookup(
                 context, resolvedClassName, methodName, compiledArgs, argPirTypes);
         if (result.isPresent()) {
@@ -1091,6 +1130,8 @@ public class PirGenerator {
                 return scope;
             }
 
+            validateLoweringRequirements(
+                    typeMethodRegistry.requirements(scopeType, methodName), mce);
             var registryResult = typeMethodRegistry.dispatch(
                     context, scope, methodName, compiledArgs, scopeType, argPirTypes);
             if (registryResult.isPresent()) return registryResult.get();

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/PirGenerator.java
@@ -14,6 +14,7 @@ import com.github.javaparser.ast.expr.*;
 import com.github.javaparser.ast.stmt.*;
 
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
 import com.bloxbean.cardano.julc.compiler.resolve.LibraryMethodRegistry;
 import com.bloxbean.cardano.julc.core.source.SourceLocation;
 import com.bloxbean.cardano.julc.compiler.util.StringUtils;
@@ -36,7 +37,7 @@ public class PirGenerator {
     private final TypeInferenceHelper typeInference;
     private final LoopBodyGenerator loopBody;
     private final String libraryClassName; // non-null when compiling library class methods
-    private final CompilerOptions options;
+    private final CompilationContext context;
     private final List<CompilerDiagnostic> collectedErrors = new ArrayList<>();
     private final LoopDesugarer loopDesugarer = new LoopDesugarer();
 
@@ -67,35 +68,59 @@ public class PirGenerator {
     private boolean booleanReturnGuard = false;
     private boolean booleanReturnGuardActive = false; // true when inside a boolean method with guard enabled
     public PirGenerator(TypeResolver typeResolver, SymbolTable symbolTable) {
-        this(typeResolver, symbolTable, null, TypeMethodRegistry.defaultRegistry(), null, new CompilerOptions());
+        this(typeResolver, symbolTable, null, TypeMethodRegistry.defaultRegistry(), null,
+                CompilationContext.pv11Defaults());
     }
 
     public PirGenerator(TypeResolver typeResolver, SymbolTable symbolTable, StdlibLookup stdlibLookup) {
-        this(typeResolver, symbolTable, stdlibLookup, TypeMethodRegistry.defaultRegistry(), null, new CompilerOptions());
+        this(typeResolver, symbolTable, stdlibLookup, TypeMethodRegistry.defaultRegistry(), null,
+                CompilationContext.pv11Defaults());
     }
 
     public PirGenerator(TypeResolver typeResolver, SymbolTable symbolTable,
                         StdlibLookup stdlibLookup, TypeMethodRegistry typeMethodRegistry) {
-        this(typeResolver, symbolTable, stdlibLookup, typeMethodRegistry, null, new CompilerOptions());
+        this(typeResolver, symbolTable, stdlibLookup, typeMethodRegistry, null,
+                CompilationContext.pv11Defaults());
     }
 
     public PirGenerator(TypeResolver typeResolver, SymbolTable symbolTable,
                         StdlibLookup stdlibLookup, TypeMethodRegistry typeMethodRegistry,
                         String libraryClassName) {
-        this(typeResolver, symbolTable, stdlibLookup, typeMethodRegistry, libraryClassName, new CompilerOptions());
+        this(typeResolver, symbolTable, stdlibLookup, typeMethodRegistry, libraryClassName,
+                CompilationContext.pv11Defaults());
     }
 
     public PirGenerator(TypeResolver typeResolver, SymbolTable symbolTable,
                         StdlibLookup stdlibLookup, TypeMethodRegistry typeMethodRegistry,
                         String libraryClassName, CompilerOptions options) {
+        this(typeResolver, symbolTable, stdlibLookup, typeMethodRegistry, libraryClassName,
+                CompilationContext.resolve(options));
+    }
+
+    private PirGenerator(TypeResolver typeResolver, SymbolTable symbolTable,
+                         StdlibLookup stdlibLookup, TypeMethodRegistry typeMethodRegistry,
+                         String libraryClassName, CompilationContext context) {
         this.typeResolver = typeResolver;
         this.symbolTable = symbolTable;
         this.stdlibLookup = stdlibLookup;
         this.typeMethodRegistry = typeMethodRegistry;
         this.libraryClassName = libraryClassName;
-        this.options = options != null ? options : new CompilerOptions();
+        this.context = Objects.requireNonNull(context, "context");
         this.typeInference = new TypeInferenceHelper(symbolTable, typeResolver, stdlibLookup, typeMethodRegistry);
         this.loopBody = new LoopBodyGenerator(this, symbolTable);
+    }
+
+    /** Create a PIR generator that shares an already-resolved compilation context. */
+    public static PirGenerator forCompilation(
+            TypeResolver typeResolver,
+            SymbolTable symbolTable,
+            StdlibLookup stdlibLookup,
+            TypeMethodRegistry typeMethodRegistry,
+            String libraryClassName,
+            CompilationContext context) {
+        return new PirGenerator(
+                typeResolver, symbolTable, stdlibLookup, typeMethodRegistry,
+                libraryClassName, context);
     }
 
     /**
@@ -141,7 +166,7 @@ public class PirGenerator {
      * Record the Java source position for a PIR term (only when source maps are enabled).
      */
     private void recordPosition(PirTerm term, Node javaNode) {
-        if (!options.isSourceMapEnabled() || term == null || javaNode == null) return;
+        if (!context.isSourceMapEnabled() || term == null || javaNode == null) return;
         javaNode.getRange().ifPresent(range -> {
             var fileName = javaNode.findCompilationUnit()
                     .flatMap(cu -> cu.getStorage().map(s -> s.getFileName()))
@@ -902,7 +927,7 @@ public class PirGenerator {
             var resolvedClassName = typeResolver.resolveClassName(ne.getNameAsString());
             var targetType = typeResolver.resolveNameToType(resolvedClassName);
             if (targetType.isPresent()) {
-                options.logf("Resolved fromPlutusData identity: %s.fromPlutusData", ne.getNameAsString());
+                context.logf("Resolved fromPlutusData identity: %s.fromPlutusData", ne.getNameAsString());
                 return generateExpression(args.get(0));
             }
         }
@@ -924,7 +949,7 @@ public class PirGenerator {
                 mce);
         }
         var classExpr = (ClassExpr) args.get(1);
-        options.logf("Resolved PlutusData.cast: %s", classExpr.getType());
+        context.logf("Resolved PlutusData.cast: %s", classExpr.getType());
         var inner = generateExpression(args.get(0));
         try {
             var castTargetType = typeResolver.resolve(classExpr.getType());
@@ -989,9 +1014,10 @@ public class PirGenerator {
             }
         }
 
-        var result = stdlibLookup.lookup(resolvedClassName, methodName, compiledArgs, argPirTypes);
+        var result = stdlibLookup.lookup(
+                context, resolvedClassName, methodName, compiledArgs, argPirTypes);
         if (result.isPresent()) {
-            options.logf("Resolved stdlib: %s.%s", className, methodName);
+            context.logf("Resolved stdlib: %s.%s", className, methodName);
             checkCrossLibraryTypeWarnings(className, methodName, mce, argPirTypes);
             return result.get();
         }
@@ -1065,7 +1091,8 @@ public class PirGenerator {
                 return scope;
             }
 
-            var registryResult = typeMethodRegistry.dispatch(scope, methodName, compiledArgs, scopeType, argPirTypes);
+            var registryResult = typeMethodRegistry.dispatch(
+                    context, scope, methodName, compiledArgs, scopeType, argPirTypes);
             if (registryResult.isPresent()) return registryResult.get();
 
             // Auto-recognize toPlutusData() — encode value as Data

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/StdlibLookup.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/StdlibLookup.java
@@ -1,5 +1,7 @@
 package com.bloxbean.cardano.julc.compiler.pir;
 
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +35,22 @@ public interface StdlibLookup {
      */
     Optional<PirTerm> lookup(String className, String methodName,
                              List<PirTerm> args, List<PirType> argTypes);
+
+    /**
+     * Target-aware lookup used by the compiler pipeline.
+     *
+     * <p>The compatibility default delegates to the existing lookup. Registries
+     * with target-gated lowerings can override this method without duplicating
+     * compiler target state.
+     */
+    default Optional<PirTerm> lookup(
+            CompilationContext context,
+            String className,
+            String methodName,
+            List<PirTerm> args,
+            List<PirType> argTypes) {
+        return lookup(className, methodName, args, argTypes);
+    }
 
     /**
      * Check if this lookup has any methods registered for the given class name.

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/StdlibLookup.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/StdlibLookup.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.compiler.pir;
 
 import com.bloxbean.cardano.julc.compiler.CompilationContext;
+import com.bloxbean.cardano.julc.compiler.LoweringRequirements;
 
 import java.util.List;
 import java.util.Optional;
@@ -50,6 +51,11 @@ public interface StdlibLookup {
             List<PirTerm> args,
             List<PirType> argTypes) {
         return lookup(className, methodName, args, argTypes);
+    }
+
+    /** Protocol requirements declared by a registered lowering, if any. */
+    default LoweringRequirements requirements(String className, String methodName) {
+        return LoweringRequirements.NONE;
     }
 
     /**

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.julc.compiler.pir;
 
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.DefaultFun;
@@ -35,6 +36,19 @@ public final class TypeMethodRegistry {
 
     public Optional<PirTerm> dispatch(PirTerm scope, String method,
                                        List<PirTerm> args, PirType scopeType, List<PirType> argTypes) {
+        return dispatch(
+                CompilationContext.pv11Defaults(), scope, method, args, scopeType, argTypes);
+    }
+
+    /** Dispatch an instance-method lowering under one resolved compiler target. */
+    public Optional<PirTerm> dispatch(
+            CompilationContext context,
+            PirTerm scope,
+            String method,
+            List<PirTerm> args,
+            PirType scopeType,
+            List<PirType> argTypes) {
+        Objects.requireNonNull(context, "context");
         // Try named key first for RecordType (e.g., "Value.lovelaceOf" before "RecordType.lovelaceOf")
         if (scopeType instanceof PirType.RecordType rt) {
             var namedReg = registry.get(rt.name() + "." + method);

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/pir/TypeMethodRegistry.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.compiler.pir;
 
 import com.bloxbean.cardano.julc.compiler.CompilationContext;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.LoweringRequirements;
 import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.DefaultFun;
 
@@ -24,14 +25,27 @@ public final class TypeMethodRegistry {
         PirType resolve(PirType scopeType);
     }
 
-    record MethodRegistration(InstanceMethodHandler handler, ReturnTypeResolver returnType) {}
+    record MethodRegistration(
+            InstanceMethodHandler handler,
+            ReturnTypeResolver returnType,
+            LoweringRequirements requirements) {}
 
     // Key: "IntegerType.abs", "ListType.contains", etc.
     private final Map<String, MethodRegistration> registry = new HashMap<>();
 
     public void register(String typeKey, String method,
                          InstanceMethodHandler handler, ReturnTypeResolver returnType) {
-        registry.put(typeKey + "." + method, new MethodRegistration(handler, returnType));
+        register(typeKey, method, handler, returnType, LoweringRequirements.NONE);
+    }
+
+    public void register(
+            String typeKey,
+            String method,
+            InstanceMethodHandler handler,
+            ReturnTypeResolver returnType,
+            LoweringRequirements requirements) {
+        registry.put(typeKey + "." + method,
+                new MethodRegistration(handler, returnType, requirements));
     }
 
     public Optional<PirTerm> dispatch(PirTerm scope, String method,
@@ -70,6 +84,18 @@ public final class TypeMethodRegistry {
         var reg = registry.get(key);
         if (reg == null) return Optional.empty();
         return Optional.of(reg.returnType().resolve(scopeType));
+    }
+
+    /** Protocol requirements declared by an instance-method lowering. */
+    public LoweringRequirements requirements(PirType scopeType, String method) {
+        if (scopeType instanceof PirType.RecordType rt) {
+            var namedReg = registry.get(rt.name() + "." + method);
+            if (namedReg != null) return namedReg.requirements();
+        }
+        var registration = registry.get(scopeType.getClass().getSimpleName() + "." + method);
+        return registration != null
+                ? registration.requirements()
+                : LoweringRequirements.NONE;
     }
 
     public boolean contains(String typeKey, String method) {
@@ -517,7 +543,8 @@ public final class TypeMethodRegistry {
         reg.register("ListType", "toArray",
                 (scope, args, scopeType, argTypes) ->
                         new PirTerm.App(new PirTerm.Builtin(DefaultFun.ListToArray), scope),
-                scopeType -> new PirType.ArrayType(((PirType.ListType) scopeType).elemType()));
+                scopeType -> new PirType.ArrayType(((PirType.ListType) scopeType).elemType()),
+                LoweringRequirements.builtin(DefaultFun.ListToArray));
     }
 
     // --- Array methods (2): length, get ---
@@ -527,7 +554,8 @@ public final class TypeMethodRegistry {
         reg.register("ArrayType", "length",
                 (scope, args, scopeType, argTypes) ->
                         new PirTerm.App(new PirTerm.Builtin(DefaultFun.LengthOfArray), scope),
-                scopeType -> new PirType.IntegerType());
+                scopeType -> new PirType.IntegerType(),
+                LoweringRequirements.builtin(DefaultFun.LengthOfArray));
 
         // get(index): wrapDecode(IndexArray(arr, index), elemType)
         reg.register("ArrayType", "get",
@@ -537,7 +565,8 @@ public final class TypeMethodRegistry {
                     var raw = PirHelpers.builtinApp2(DefaultFun.IndexArray, scope, args.get(0));
                     return PirHelpers.wrapDecode(raw, at.elemType());
                 },
-                scopeType -> ((PirType.ArrayType) scopeType).elemType());
+                scopeType -> ((PirType.ArrayType) scopeType).elemType(),
+                LoweringRequirements.builtin(DefaultFun.IndexArray));
     }
 
     // --- List HOF instance methods (5): map, filter, any, all, find ---

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/LibraryMethodRegistry.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/resolve/LibraryMethodRegistry.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.compiler.resolve;
 
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
 import com.bloxbean.cardano.julc.compiler.pir.PirHelpers;
 import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
@@ -32,14 +33,23 @@ public class LibraryMethodRegistry implements StdlibLookup {
     private final Map<String, LibraryMethod> methods = new LinkedHashMap<>();
     // Simple class name -> set of FQCNs (for backward-compat lookup)
     private final Map<String, Set<String>> classNameIndex = new LinkedHashMap<>();
-    private final CompilerOptions options;
+    private final CompilationContext context;
 
     public LibraryMethodRegistry() {
-        this(new CompilerOptions());
+        this(CompilationContext.pv11Defaults());
     }
 
     public LibraryMethodRegistry(CompilerOptions options) {
-        this.options = options != null ? options : new CompilerOptions();
+        this(CompilationContext.resolve(options));
+    }
+
+    private LibraryMethodRegistry(CompilationContext context) {
+        this.context = Objects.requireNonNull(context, "context");
+    }
+
+    /** Create a registry that shares an already-resolved compilation context. */
+    public static LibraryMethodRegistry forCompilation(CompilationContext context) {
+        return new LibraryMethodRegistry(context);
     }
 
     /**
@@ -84,14 +94,14 @@ public class LibraryMethodRegistry implements StdlibLookup {
         var expectedTypes = extractParamTypes(method.type());
 
         // Apply coercions where caller type differs from callee's expected type
-        options.logf("Resolving library method: %s.%s", className, methodName);
+        context.logf("Resolving library method: %s.%s", className, methodName);
         var coercedArgs = new ArrayList<PirTerm>(args.size());
         for (int i = 0; i < args.size(); i++) {
             var arg = args.get(i);
             var callerType = i < argTypes.size() ? argTypes.get(i) : new PirType.DataType();
             var calleeType = i < expectedTypes.size() ? expectedTypes.get(i) : new PirType.DataType();
             if (!callerType.equals(calleeType) && callerType instanceof PirType.DataType && isPrimitiveType(calleeType)) {
-                options.logf("Coercing arg %d: Data -> %s", i, pirTypeName(calleeType));
+                context.logf("Coercing arg %d: Data -> %s", i, pirTypeName(calleeType));
             }
             coercedArgs.add(coerceArg(arg, callerType, calleeType));
         }

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.julc.compiler.uplc;
 
 import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
 import com.bloxbean.cardano.julc.compiler.pir.PirSubstitution;
 import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
@@ -26,6 +27,9 @@ public class UplcGenerator {
 
     private final Deque<String> scope = new ArrayDeque<>();
 
+    /** The single resolved target shared by this lowering invocation. */
+    private final CompilationContext context;
+
     /** PIR term → source location (provided by PirGenerator when source maps are enabled). */
     private final Map<PirTerm, SourceLocation> pirPositions;
 
@@ -36,7 +40,7 @@ public class UplcGenerator {
     private final Deque<SourceLocation> locationStack = new ArrayDeque<>();
 
     public UplcGenerator() {
-        this(null);
+        this(CompilationContext.pv11Defaults(), null);
     }
 
     /**
@@ -45,6 +49,14 @@ public class UplcGenerator {
      * @param pirPositions PIR term to source location map from PirGenerator (nullable)
      */
     public UplcGenerator(Map<PirTerm, SourceLocation> pirPositions) {
+        this(CompilationContext.pv11Defaults(), pirPositions);
+    }
+
+    /** Create a target-aware UPLC generator with optional source positions. */
+    public UplcGenerator(
+            CompilationContext context,
+            Map<PirTerm, SourceLocation> pirPositions) {
+        this.context = Objects.requireNonNull(context, "context");
         this.pirPositions = pirPositions != null ? pirPositions : Map.of();
     }
 

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.compiler.uplc;
 
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.CompilationContext;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetDiagnostics;
 import com.bloxbean.cardano.julc.compiler.pir.PirSubstitution;
 import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
@@ -22,8 +23,6 @@ import java.util.*;
  * building an {@link IdentityHashMap} for runtime error location tracking.
  */
 public class UplcGenerator {
-
-    private static final int LAST_RELEASED_PV11_BUILTIN_TAG = DefaultFun.ScaleValue.flatCode();
 
     private final Deque<String> scope = new ArrayDeque<>();
 
@@ -519,28 +518,16 @@ public class UplcGenerator {
      * common lowering boundary. This catches direct PIR, public Builtins calls,
      * library wrappers, and every JulcCompiler entry point.
      */
-    private static Term generateBuiltin(DefaultFun fun) {
-        if (fun.flatCode() > LAST_RELEASED_PV11_BUILTIN_TAG) {
-            throw unsupportedTargetBuiltin(fun);
+    private Term generateBuiltin(DefaultFun fun) {
+        if (!context.resolvedTarget().featureProfile().isBuiltinAvailable(fun)) {
+            throw CompilerTargetDiagnostics.unavailableBuiltin(
+                    context, fun, currentSourceLocation());
         }
         return wrapForces(Term.builtin(fun), forceCount(fun));
     }
 
-    private static CompilerException unsupportedTargetBuiltin(DefaultFun fun) {
-        if (fun == DefaultFun.MultiIndexArray) {
-            return new CompilerException(
-                    "Cannot compile " + fun + " (FLAT tag " + fun.flatCode()
-                            + "): it is a future/unreleased "
-                            + "CIP-156 builtin and is not available in Plutus V3 at protocol "
-                            + "version 11. Use IndexArray repeatedly "
-                            + "for PV11, or wait for a compiler target that explicitly enables CIP-156.");
-        }
-        return new CompilerException(
-                "Cannot compile " + fun + " (FLAT tag " + fun.flatCode()
-                        + "): it is not available in the current Plutus V3/PV11 target. "
-                        + "This compiler supports released builtins through "
-                        + DefaultFun.ScaleValue + " (FLAT tag "
-                        + LAST_RELEASED_PV11_BUILTIN_TAG + ").");
+    private SourceLocation currentSourceLocation() {
+        return locationStack.isEmpty() ? null : locationStack.peek();
     }
 
     private static Term wrapForces(Term term, int count) {

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcOptimizer.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcOptimizer.java
@@ -8,8 +8,10 @@ import com.bloxbean.cardano.julc.core.Term;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.UnaryOperator;
 
 /**
  * Multi-pass UPLC optimizer. Runs optimization passes iteratively until fixpoint.
@@ -51,30 +53,55 @@ public class UplcOptimizer {
         this.context = Objects.requireNonNull(context, "context");
     }
 
+    /** Optimized term plus the stable identities of passes that changed it. */
+    public record OptimizationResult(Term term, List<String> appliedPasses) {
+        public OptimizationResult {
+            Objects.requireNonNull(term, "term");
+            appliedPasses = List.copyOf(appliedPasses);
+        }
+    }
+
     /**
      * Optimize a UPLC term by running all passes until fixpoint.
      */
     public Term optimize(Term term) {
+        return optimizeWithReport(term).term();
+    }
+
+    public OptimizationResult optimizeWithReport(Term term) {
         Term current = term;
+        var appliedPasses = new LinkedHashSet<String>();
         for (int i = 0; i < MAX_ITERATIONS; i++) {
-            Term optimized = runAllPasses(current);
+            Term optimized = runAllPasses(current, appliedPasses);
             if (optimized.equals(current)) {
                 break; // Fixpoint reached
             }
             current = optimized;
         }
-        return current;
+        return new OptimizationResult(current, List.copyOf(appliedPasses));
     }
 
-    private Term runAllPasses(Term term) {
+    private Term runAllPasses(Term term, LinkedHashSet<String> appliedPasses) {
         Term t = term;
-        t = forceDelayCancel(t);
-        t = constantFold(t);
-        t = deadCodeElimination(t);
-        t = betaReduce(t);
-        t = etaReduce(t);
-        t = constrCaseReduce(t);
+        t = applyPass("force-delay-cancel", t, this::forceDelayCancel, appliedPasses);
+        t = applyPass("constant-fold", t, this::constantFold, appliedPasses);
+        t = applyPass("dead-code-elimination", t, this::deadCodeElimination, appliedPasses);
+        t = applyPass("beta-reduce", t, this::betaReduce, appliedPasses);
+        t = applyPass("eta-reduce", t, this::etaReduce, appliedPasses);
+        t = applyPass("constr-case-reduce", t, this::constrCaseReduce, appliedPasses);
         return t;
+    }
+
+    private static Term applyPass(
+            String passName,
+            Term input,
+            UnaryOperator<Term> pass,
+            LinkedHashSet<String> appliedPasses) {
+        var output = pass.apply(input);
+        if (!output.equals(input)) {
+            appliedPasses.add(passName);
+        }
+        return output;
     }
 
     // ---- Pass 1: Force/Delay cancellation ----
@@ -139,6 +166,9 @@ public class UplcOptimizer {
      * cannot-fail check on the operand values.
      */
     private Term foldBinaryOp(DefaultFun fun, Constant a, Constant b) {
+        if (!context.resolvedTarget().featureProfile().isBuiltinAvailable(fun)) {
+            return null;
+        }
         if (a instanceof Constant.IntegerConst(var va) && b instanceof Constant.IntegerConst(var vb)) {
             return switch (fun) {
                 case AddInteger -> Term.const_(Constant.integer(va.add(vb)));

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcOptimizer.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcOptimizer.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.julc.compiler.uplc;
 
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
 import com.bloxbean.cardano.julc.core.BuiltinSemantics;
 import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.DefaultFun;
@@ -8,6 +9,7 @@ import com.bloxbean.cardano.julc.core.Term;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Multi-pass UPLC optimizer. Runs optimization passes iteratively until fixpoint.
@@ -39,6 +41,15 @@ import java.util.List;
 public class UplcOptimizer {
 
     private static final int MAX_ITERATIONS = 20;
+    private final CompilationContext context;
+
+    public UplcOptimizer() {
+        this(CompilationContext.pv11Defaults());
+    }
+
+    public UplcOptimizer(CompilationContext context) {
+        this.context = Objects.requireNonNull(context, "context");
+    }
 
     /**
      * Optimize a UPLC term by running all passes until fixpoint.

--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcTargetValidator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcTargetValidator.java
@@ -1,0 +1,132 @@
+package com.bloxbean.cardano.julc.compiler.uplc;
+
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetDiagnostics;
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultUni;
+import com.bloxbean.cardano.julc.core.Program;
+import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.vm.ProtocolCapability;
+import com.bloxbean.cardano.julc.vm.UplcVersion;
+
+import java.util.ArrayDeque;
+import java.util.Objects;
+
+/** Final target-legality check for generated, and potentially optimized, UPLC. */
+public final class UplcTargetValidator {
+
+    private UplcTargetValidator() {
+    }
+
+    public static void validate(
+            Program program,
+            CompilationContext context,
+            String producingStage) {
+        Objects.requireNonNull(program, "program");
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(producingStage, "producingStage");
+
+        var actualVersion = UplcVersion.from(program);
+        if (!actualVersion.equals(context.target().uplcVersion())) {
+            throw CompilerTargetDiagnostics.programVersionMismatch(context, actualVersion);
+        }
+
+        var profile = context.resolvedTarget().featureProfile();
+        var pending = new ArrayDeque<Term>();
+        pending.push(program.term());
+        while (!pending.isEmpty()) {
+            switch (pending.pop()) {
+                case Term.Var _, Term.Error _ -> {
+                }
+                case Term.Const constant -> validateConstant(
+                        constant.value(), context, producingStage);
+                case Term.Builtin builtin -> {
+                    if (!profile.isBuiltinAvailable(builtin.fun())) {
+                        throw CompilerTargetDiagnostics.invariantViolation(
+                                context,
+                                producingStage,
+                                "builtin " + builtin.fun()
+                                        + " (FLAT tag " + builtin.fun().flatCode() + ")");
+                    }
+                }
+                case Term.Lam lam -> pending.push(lam.body());
+                case Term.Apply apply -> {
+                    pending.push(apply.argument());
+                    pending.push(apply.function());
+                }
+                case Term.Force force -> pending.push(force.term());
+                case Term.Delay delay -> pending.push(delay.term());
+                case Term.Constr constr -> {
+                    requireCapability(
+                            context, producingStage, ProtocolCapability.CONSTR_CASE);
+                    for (var field : constr.fields()) pending.push(field);
+                }
+                case Term.Case caseTerm -> {
+                    requireCapability(
+                            context, producingStage, ProtocolCapability.CONSTR_CASE);
+                    if (caseTerm.scrutinee() instanceof Term.Const
+                            && !context.supports(
+                                    ProtocolCapability.CASE_ON_BUILTIN_CONSTANTS)) {
+                        throw CompilerTargetDiagnostics.invariantViolation(
+                                context,
+                                producingStage,
+                                "case on builtin constant");
+                    }
+                    for (var branch : caseTerm.branches()) pending.push(branch);
+                    pending.push(caseTerm.scrutinee());
+                }
+            }
+        }
+    }
+
+    private static void validateConstant(
+            Constant constant,
+            CompilationContext context,
+            String producingStage) {
+        validateUni(constant.type(), context, producingStage);
+        switch (constant) {
+            case Constant.ListConst list -> list.values().forEach(
+                    value -> validateConstant(value, context, producingStage));
+            case Constant.PairConst pair -> {
+                validateConstant(pair.first(), context, producingStage);
+                validateConstant(pair.second(), context, producingStage);
+            }
+            case Constant.ArrayConst array -> array.values().forEach(
+                    value -> validateConstant(value, context, producingStage));
+            default -> {
+            }
+        }
+    }
+
+    private static void validateUni(
+            DefaultUni uni,
+            CompilationContext context,
+            String producingStage) {
+        switch (uni) {
+            case DefaultUni.Bls12_381_G1_Element _,
+                 DefaultUni.Bls12_381_G2_Element _,
+                 DefaultUni.Bls12_381_MlResult _ -> requireCapability(
+                    context, producingStage, ProtocolCapability.BLS_CONSTANTS);
+            case DefaultUni.ProtoArray _ -> requireCapability(
+                    context, producingStage, ProtocolCapability.ARRAY_CONSTANTS);
+            case DefaultUni.ProtoValue _ -> requireCapability(
+                    context, producingStage, ProtocolCapability.VALUE_CONSTANTS);
+            case DefaultUni.Apply apply -> {
+                validateUni(apply.f(), context, producingStage);
+                validateUni(apply.arg(), context, producingStage);
+            }
+            default -> {
+            }
+        }
+    }
+
+    private static void requireCapability(
+            CompilationContext context,
+            String producingStage,
+            ProtocolCapability capability) {
+        if (!context.supports(capability)) {
+            throw CompilerTargetDiagnostics.invariantViolation(
+                    context, producingStage, capability.name());
+        }
+    }
+}

--- a/julc-compiler/src/main/resources/diagnostics.json
+++ b/julc-compiler/src/main/resources/diagnostics.json
@@ -416,6 +416,17 @@
       "template": "Compiler stage {0} emitted target-illegal feature {1} for {2}",
       "summary": "Final post-lowering validation found a builtin, term form, or constant universe that an earlier compiler stage should have rejected.",
       "fix": "Report this as a JuLC compiler bug. Include the named compiler stage/pass, selected target, and a minimal reproducer."
+    },
+    {
+      "code": "JULC0036",
+      "constant": "COMPILER_EVALUATION_TARGET_MISMATCH",
+      "status": "emitted",
+      "title": "Compile and evaluation targets do not match",
+      "category": "TARGET",
+      "severity": "error",
+      "template": "Compiled target {0} cannot be evaluated as {1}",
+      "summary": "The evaluator must use the exact ledger language and protocol version retained by the compiler result.",
+      "fix": "Evaluate with CompileResult.target().ledgerTarget(), or recompile for an explicitly supported compiler target."
     }
   ]
 }

--- a/julc-compiler/src/main/resources/diagnostics.json
+++ b/julc-compiler/src/main/resources/diagnostics.json
@@ -372,6 +372,50 @@
       "template": "Compiler target {0} is not supported. Supported targets: {1}",
       "summary": "JuLC compilation is pinned to an explicit ledger language, protocol version, and UPLC version. Evaluator support for another profile does not imply compiler support.",
       "fix": "Select a listed compiler target. This release supports Plutus V3/PV11/UPLC 1.1.0 only; do not rely on fallback to another target."
+    },
+    {
+      "code": "JULC0032",
+      "constant": "COMPILER_BUILTIN_UNAVAILABLE",
+      "status": "emitted",
+      "title": "Builtin unavailable for compiler target",
+      "category": "TARGET",
+      "severity": "error",
+      "template": "Builtin {0} is not available for compiler target {1}",
+      "summary": "A source lowering or low-level PIR route requested a builtin that is not in the canonical protocol feature profile selected for this compilation.",
+      "fix": "Use an operation available in the selected target, or explicitly select a future compiler target after JuLC adds and verifies support for it."
+    },
+    {
+      "code": "JULC0033",
+      "constant": "COMPILER_FEATURE_UNAVAILABLE",
+      "status": "emitted",
+      "title": "Term or constant feature unavailable for compiler target",
+      "category": "TARGET",
+      "severity": "error",
+      "template": "Compiler feature {0} is not available for compiler target {1}",
+      "summary": "A lowering requires a UPLC term form or constant universe that the canonical protocol feature profile does not authorize.",
+      "fix": "Use a portable lowering for the selected target, or add the future target through the reviewed compiler support process."
+    },
+    {
+      "code": "JULC0034",
+      "constant": "COMPILER_PROGRAM_VERSION_MISMATCH",
+      "status": "emitted",
+      "title": "Generated UPLC version does not match compiler target",
+      "category": "INTERNAL",
+      "severity": "error",
+      "template": "Generated UPLC version {0} does not match compiler target {1}, which requires {2}",
+      "summary": "Program construction and the resolved compiler target disagreed. This is a compiler invariant violation, not a user source error.",
+      "fix": "Report this as a JuLC compiler bug with the source, selected target, and verbose compiler log."
+    },
+    {
+      "code": "JULC0035",
+      "constant": "COMPILER_TARGET_INVARIANT_VIOLATION",
+      "status": "emitted",
+      "title": "Compiler stage emitted a target-illegal feature",
+      "category": "INTERNAL",
+      "severity": "error",
+      "template": "Compiler stage {0} emitted target-illegal feature {1} for {2}",
+      "summary": "Final post-lowering validation found a builtin, term form, or constant universe that an earlier compiler stage should have rejected.",
+      "fix": "Report this as a JuLC compiler bug. Include the named compiler stage/pass, selected target, and a minimal reproducer."
     }
   ]
 }

--- a/julc-compiler/src/main/resources/diagnostics.json
+++ b/julc-compiler/src/main/resources/diagnostics.json
@@ -361,6 +361,17 @@
       "template": "Circular type dependency detected among: {0}",
       "summary": "Type registration found a cycle that cannot be resolved.",
       "fix": "Break the cycle by introducing a parameterized record or refactoring the involved types."
+    },
+    {
+      "code": "JULC0031",
+      "constant": "UNSUPPORTED_COMPILER_TARGET",
+      "status": "emitted",
+      "title": "Unsupported compiler target",
+      "category": "CONFIG",
+      "severity": "error",
+      "template": "Compiler target {0} is not supported. Supported targets: {1}",
+      "summary": "JuLC compilation is pinned to an explicit ledger language, protocol version, and UPLC version. Evaluator support for another profile does not imply compiler support.",
+      "fix": "Select a listed compiler target. This release supports Plutus V3/PV11/UPLC 1.1.0 only; do not rely on fallback to another target."
     }
   ]
 }

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CompilerTargetPropagationTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CompilerTargetPropagationTest.java
@@ -1,0 +1,135 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.Program;
+import com.bloxbean.cardano.julc.core.flat.UplcFlatEncoder;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.UplcVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompilerTargetPropagationTest {
+
+    private static final String SIMPLE_VALIDATOR = """
+            @SpendingValidator
+            class TargetValidator {
+                @Entrypoint
+                static boolean validate(PlutusData redeemer, ScriptContext context) {
+                    return true;
+                }
+            }
+            """;
+
+    @Test
+    void defaultAndExplicitPv11ProduceIdenticalProgramsAndBytes() {
+        var defaultResult = new JulcCompiler().compile(SIMPLE_VALIDATOR);
+        var explicitResult = new JulcCompiler(null, new CompilerOptions()
+                .setTarget(CompilerTarget.PLUTUS_V3_PV11))
+                .compile(SIMPLE_VALIDATOR);
+
+        assertEquals(defaultResult.program(), explicitResult.program());
+        assertArrayEquals(
+                UplcFlatEncoder.encodeProgram(defaultResult.program()),
+                UplcFlatEncoder.encodeProgram(explicitResult.program()));
+        assertSame(CompilerTarget.PLUTUS_V3_PV11, defaultResult.target());
+        assertSame(CompilerTarget.PLUTUS_V3_PV11, explicitResult.target());
+        assertEquals("1.1.0", defaultResult.program().versionString());
+    }
+
+    @Test
+    void compilationSnapshotsOptionsAndResolvesTargetExactlyOnce() {
+        var options = new CompilerOptions().setVerbose(true);
+        var changed = new AtomicBoolean();
+        options.setLogger(message -> {
+            if (message.contains("Compiler target") && changed.compareAndSet(false, true)) {
+                options.setTarget(new CompilerTarget(
+                        LedgerEvaluationTarget.pv10(PlutusLanguage.PLUTUS_V3),
+                        UplcVersion.V1_1_0));
+                options.setSourceMapEnabled(true);
+            }
+        });
+        var compiler = new JulcCompiler(null, options);
+
+        var result = compiler.compile(SIMPLE_VALIDATOR);
+
+        assertTrue(changed.get());
+        assertSame(CompilerTarget.PLUTUS_V3_PV11, result.target());
+        assertNull(result.sourceMap(), "source-map mutation must not affect an active compilation");
+
+        var nextError = assertThrows(CompilerException.class,
+                () -> compiler.compile(SIMPLE_VALIDATOR));
+        assertEquals("JULC0031", nextError.diagnostics().getFirst().code());
+    }
+
+    @Test
+    void unsupportedTargetFailsBeforeInvalidSourceIsParsed() {
+        var unsupported = new CompilerTarget(
+                LedgerEvaluationTarget.pv10(PlutusLanguage.PLUTUS_V3),
+                UplcVersion.V1_1_0);
+        var compiler = new JulcCompiler(null, new CompilerOptions().setTarget(unsupported));
+
+        var error = assertThrows(CompilerException.class,
+                () -> compiler.compile("this is not Java"));
+
+        assertEquals("JULC0031", error.diagnostics().getFirst().code());
+        assertFalse(error.getMessage().contains("Parse error"));
+    }
+
+    @Test
+    void allCompileEntryPathsUseTheResolvedProgramVersionAndProvenance() {
+        var compiler = new JulcCompiler();
+        var methodSource = """
+                class TargetMethod {
+                    static long answer() { return 42; }
+                }
+                """;
+
+        var detailed = compiler.compileWithDetails(SIMPLE_VALIDATOR);
+        var method = compiler.compileMethod(methodSource, "answer");
+        Program directPir = compiler.compilePirToProgram(
+                new PirTerm.Const(Constant.integer(42)));
+
+        assertSame(CompilerTarget.PLUTUS_V3_PV11, detailed.target());
+        assertSame(CompilerTarget.PLUTUS_V3_PV11, method.target());
+        assertEquals("1.1.0", detailed.program().versionString());
+        assertEquals("1.1.0", method.program().versionString());
+        assertEquals("1.1.0", directPir.versionString());
+    }
+
+    @Test
+    void compatibilityConstructorsRetainPinnedPv11Provenance() {
+        var program = Program.plutusV3(new com.bloxbean.cardano.julc.core.Term.Error());
+
+        assertSame(CompilerTarget.PLUTUS_V3_PV11,
+                new CompileResult(program, java.util.List.of()).target());
+        assertThrows(NullPointerException.class,
+                () -> new CompileResult(
+                        program, java.util.List.of(), java.util.List.of(),
+                        null, null, null, null));
+    }
+
+    @Test
+    void verboseLogReportsStableTargetBeforePipelineStages() {
+        var logs = new ArrayList<String>();
+        var compiler = new JulcCompiler(null, new CompilerOptions()
+                .setVerbose(true)
+                .setLogger(logs::add));
+
+        compiler.compile(SIMPLE_VALIDATOR);
+
+        assertTrue(logs.getFirst().contains(
+                "Compiler target: plutus-v3-pv11-uplc-1.1.0"));
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistryTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistryTest.java
@@ -57,6 +57,22 @@ class CompilerTargetRegistryTest {
         assertFalse(CompilerTargetRegistry.isSupported(null));
         assertThrows(UnsupportedOperationException.class,
                 () -> CompilerTargetRegistry.supportedTargets().clear());
+        assertSame(CompilerTarget.PLUTUS_V3_PV11,
+                CompilerTargetRegistry.targetForProfileId(
+                        "plutus-v3-pv11-uplc-1.1.0"));
+    }
+
+    @Test
+    void profileIdLookupIsExactAndFailsClosed() {
+        for (var profileId : Set.of(
+                "PLUTUS-V3-PV11-UPLC-1.1.0",
+                "plutus-v3-pv12-uplc-1.1.0",
+                "latest")) {
+            var error = assertThrows(CompilerException.class,
+                    () -> CompilerTargetRegistry.targetForProfileId(profileId));
+            assertEquals("JULC0031", error.diagnostics().getFirst().code());
+            assertTrue(error.getMessage().contains(profileId));
+        }
     }
 
     @Test

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistryTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/CompilerTargetRegistryTest.java
@@ -1,0 +1,103 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import com.bloxbean.cardano.julc.vm.ProtocolVersion;
+import com.bloxbean.cardano.julc.vm.UplcVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompilerTargetRegistryTest {
+
+    @Test
+    void pv11TargetHasStableIdentity() {
+        var target = CompilerTarget.PLUTUS_V3_PV11;
+
+        assertEquals(PlutusLanguage.PLUTUS_V3, target.ledgerTarget().ledgerLanguage());
+        assertEquals(ProtocolVersion.PV11, target.ledgerTarget().protocolVersion());
+        assertEquals(UplcVersion.V1_1_0, target.uplcVersion());
+        assertEquals("plutus-v3-pv11-uplc-1.1.0", target.profileId());
+        assertEquals(target.profileId(), target.toString());
+    }
+
+    @Test
+    void optionsDefaultToNamedPv11Target() {
+        assertSame(CompilerTarget.PLUTUS_V3_PV11, new CompilerOptions().getTarget());
+    }
+
+    @Test
+    void optionsRetainExplicitTargetWithoutResolvingOrFallingBack() {
+        var unsupported = new CompilerTarget(
+                LedgerEvaluationTarget.pv10(PlutusLanguage.PLUTUS_V3),
+                UplcVersion.V1_1_0);
+        var options = new CompilerOptions().setTarget(unsupported);
+
+        assertSame(unsupported, options.getTarget());
+        assertThrows(NullPointerException.class, () -> options.setTarget(null));
+    }
+
+    @Test
+    void registryResolvesOneCanonicalProfile() {
+        var resolved = CompilerTargetRegistry.resolve(CompilerTarget.PLUTUS_V3_PV11);
+
+        assertSame(CompilerTarget.PLUTUS_V3_PV11, resolved.target());
+        assertEquals(resolved.target().ledgerTarget(), resolved.featureProfile().target());
+        assertTrue(resolved.featureProfile().isUplcVersionAvailable(UplcVersion.V1_1_0));
+        assertEquals(Set.of(CompilerTarget.PLUTUS_V3_PV11),
+                CompilerTargetRegistry.supportedTargets());
+        assertTrue(CompilerTargetRegistry.isSupported(CompilerTarget.PLUTUS_V3_PV11));
+        assertFalse(CompilerTargetRegistry.isSupported(null));
+        assertThrows(UnsupportedOperationException.class,
+                () -> CompilerTargetRegistry.supportedTargets().clear());
+    }
+
+    @Test
+    void unsupportedTargetsFailWithStableDiagnosticAndNoFallback() {
+        var targets = Set.of(
+                new CompilerTarget(
+                        LedgerEvaluationTarget.pv10(PlutusLanguage.PLUTUS_V3),
+                        UplcVersion.V1_1_0),
+                new CompilerTarget(
+                        LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V1),
+                        UplcVersion.V1_1_0),
+                new CompilerTarget(
+                        LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V2),
+                        UplcVersion.V1_1_0),
+                new CompilerTarget(
+                        LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3),
+                        UplcVersion.V1_0_0),
+                new CompilerTarget(
+                        new LedgerEvaluationTarget(
+                                PlutusLanguage.PLUTUS_V3, new ProtocolVersion(12, 0)),
+                        UplcVersion.V1_1_0));
+
+        for (var target : targets) {
+            var error = assertThrows(CompilerException.class,
+                    () -> CompilerTargetRegistry.resolve(target));
+
+            assertTrue(error.getMessage().contains(target.profileId()));
+            assertTrue(error.getMessage().contains(
+                    CompilerTarget.PLUTUS_V3_PV11.profileId()));
+            assertEquals(1, error.diagnostics().size());
+            assertEquals("JULC0031", error.diagnostics().getFirst().code());
+        }
+    }
+
+    @Test
+    void targetComponentsAreRequired() {
+        assertThrows(NullPointerException.class,
+                () -> new CompilerTarget(null, UplcVersion.V1_1_0));
+        assertThrows(NullPointerException.class,
+                () -> new CompilerTarget(
+                        LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3), null));
+        assertNotNull(CompilerTarget.PLUTUS_V3_PV11);
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LoweringRequirementsTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/LoweringRequirementsTest.java
@@ -1,0 +1,61 @@
+package com.bloxbean.cardano.julc.compiler;
+
+import com.bloxbean.cardano.julc.compiler.pir.PirType;
+import com.bloxbean.cardano.julc.compiler.pir.TypeMethodRegistry;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LoweringRequirementsTest {
+
+    private static final String BUILTINS =
+            "com.bloxbean.cardano.julc.stdlib.Builtins";
+
+    @Test
+    void stdlibDeclaresEveryInitiallyTargetGatedBuiltinRoute() {
+        var registry = StdlibRegistry.defaultRegistry();
+        var expected = Map.ofEntries(
+                Map.entry("dropList", DefaultFun.DropList),
+                Map.entry("listToArray", DefaultFun.ListToArray),
+                Map.entry("lengthOfArray", DefaultFun.LengthOfArray),
+                Map.entry("indexArray", DefaultFun.IndexArray),
+                Map.entry("multiIndexArray", DefaultFun.MultiIndexArray),
+                Map.entry("bls12_381_G1_multiScalarMul",
+                        DefaultFun.Bls12_381_G1_multiScalarMul),
+                Map.entry("bls12_381_G2_multiScalarMul",
+                        DefaultFun.Bls12_381_G2_multiScalarMul),
+                Map.entry("expModInteger", DefaultFun.ExpModInteger),
+                Map.entry("insertCoin", DefaultFun.InsertCoin),
+                Map.entry("lookupCoin", DefaultFun.LookupCoin),
+                Map.entry("unionValue", DefaultFun.UnionValue),
+                Map.entry("valueContains", DefaultFun.ValueContains),
+                Map.entry("valueData", DefaultFun.ValueData),
+                Map.entry("unValueData", DefaultFun.UnValueData),
+                Map.entry("scaleValue", DefaultFun.ScaleValue));
+
+        expected.forEach((method, builtin) -> assertEquals(
+                LoweringRequirements.builtin(builtin),
+                registry.requirements(BUILTINS, method),
+                method));
+    }
+
+    @Test
+    void arrayTypeMethodsDeclareTheirExactBuiltinRequirements() {
+        var registry = TypeMethodRegistry.defaultRegistry();
+        var listType = new PirType.ListType(new PirType.DataType());
+        var arrayType = new PirType.ArrayType(new PirType.DataType());
+
+        assertEquals(LoweringRequirements.builtin(DefaultFun.ListToArray),
+                registry.requirements(listType, "toArray"));
+        assertEquals(LoweringRequirements.builtin(DefaultFun.LengthOfArray),
+                registry.requirements(arrayType, "length"));
+        assertEquals(LoweringRequirements.builtin(DefaultFun.IndexArray),
+                registry.requirements(arrayType, "get"));
+        assertEquals(LoweringRequirements.NONE,
+                registry.requirements(listType, "length"));
+    }
+}

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/Pv11CompilerContractTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/Pv11CompilerContractTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -73,10 +74,14 @@ class Pv11CompilerContractTest {
                 () -> compiler.compileMethod(source, "select"));
 
         assertFutureBuiltinDiagnostic(error);
+        assertTrue(error.diagnostics().getFirst().line() > 0);
+        assertTrue(error.diagnostics().getFirst().column() > 0);
+        assertEquals("FutureArrayCall.java", error.diagnostics().getFirst().fileName());
     }
 
     private static void assertFutureBuiltinDiagnostic(CompilerException error) {
         assertAll(
+                () -> assertEquals("JULC0032", error.diagnostics().getFirst().code()),
                 () -> assertTrue(error.getMessage().contains("MultiIndexArray (FLAT tag 101)")),
                 () -> assertTrue(error.getMessage().contains("future/unreleased")),
                 () -> assertTrue(error.getMessage().contains("protocol version 11")),

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/uplc/UplcTargetValidatorTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/uplc/UplcTargetValidatorTest.java
@@ -1,0 +1,89 @@
+package com.bloxbean.cardano.julc.compiler.uplc;
+
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
+import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.DefaultUni;
+import com.bloxbean.cardano.julc.core.Program;
+import com.bloxbean.cardano.julc.core.Term;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UplcTargetValidatorTest {
+
+    private final CompilationContext context = CompilationContext.pv11Defaults();
+
+    @Test
+    void acceptsEveryReleasedPv11BuiltinAndCurrentTermForms() {
+        var builtinTerms = Arrays.stream(DefaultFun.values())
+                .filter(context.resolvedTarget().featureProfile()::isBuiltinAvailable)
+                .map(Term::builtin)
+                .toList();
+        var program = Program.plutusV3(new Term.Case(
+                new Term.Constr(0, builtinTerms),
+                List.of(Term.lam("x", Term.var(1)))));
+
+        assertDoesNotThrow(() -> UplcTargetValidator.validate(
+                program, context, "test lowering"));
+    }
+
+    @Test
+    void acceptsAllCurrentPv11ConstantUniverses() {
+        var constants = List.<Term>of(
+                Term.const_(new Constant.Bls12_381_G1Element(new byte[0])),
+                Term.const_(new Constant.Bls12_381_G2Element(new byte[0])),
+                Term.const_(new Constant.Bls12_381_MlResult(new byte[0])),
+                Term.const_(new Constant.ArrayConst(
+                        DefaultUni.INTEGER,
+                        List.of(Constant.integer(1)))),
+                Term.const_(new Constant.ValueConst(List.of())));
+        var program = Program.plutusV3(new Term.Constr(0, constants));
+
+        assertDoesNotThrow(() -> UplcTargetValidator.validate(
+                program, context, "constant lowering"));
+    }
+
+    @Test
+    void rejectsFutureBuiltinSurvivingAnOptimizerPass() {
+        var program = Program.plutusV3(Term.builtin(DefaultFun.MultiIndexArray));
+
+        var error = assertThrows(CompilerException.class,
+                () -> UplcTargetValidator.validate(
+                        program, context, "test-illegal-optimizer-pass"));
+
+        assertEquals("JULC0035", error.diagnostics().getFirst().code());
+        assertTrue(error.getMessage().contains("test-illegal-optimizer-pass"));
+        assertTrue(error.getMessage().contains("MultiIndexArray"));
+        assertTrue(error.getMessage().contains(context.target().profileId()));
+    }
+
+    @Test
+    void rejectsProgramVersionDifferentFromExactCompilerTarget() {
+        var program = Program.plutusV1(Term.const_(Constant.unit()));
+
+        var error = assertThrows(CompilerException.class,
+                () -> UplcTargetValidator.validate(program, context, "program construction"));
+
+        assertEquals("JULC0034", error.diagnostics().getFirst().code());
+        assertTrue(error.getMessage().contains("1.0.0"));
+        assertTrue(error.getMessage().contains("1.1.0"));
+    }
+
+    @Test
+    void optimizerReportsStablePassIdentitiesForInvariantDiagnostics() {
+        var input = Term.force(Term.delay(Term.const_(Constant.integer(1))));
+
+        var result = new UplcOptimizer(context).optimizeWithReport(input);
+
+        assertEquals(Term.const_(Constant.integer(1)), result.term());
+        assertEquals(List.of("force-delay-cancel"), result.appliedPasses());
+    }
+}

--- a/julc-examples/README.md
+++ b/julc-examples/README.md
@@ -32,9 +32,9 @@ Example validators demonstrating JuLC features. Each example is a JUnit test tha
 Each example follows the same pattern:
 
 1. Define the validator source as a Java string with `@SpendingValidator`/`@MintingValidator`/etc.
-2. Compile with `ValidatorTest.compile(source)` or `ValidatorTest.compile(source, stdlib)`
+2. Compile with `ValidatorTest.compileWithDetails(source)` to retain target provenance
 3. Build a mock `ScriptContext` as `PlutusData`
-4. Evaluate with `ValidatorTest.evaluate(program, ctx)`
+4. Evaluate with `ValidatorTest.evaluate(compiledResult, ctx)` so the exact compiler target reaches the VM
 5. Assert results with `BudgetAssertions.assertSuccess(result)`
 
 See `VestingValidatorTest.java` for the simplest starting point.

--- a/julc-examples/build.gradle
+++ b/julc-examples/build.gradle
@@ -13,5 +13,6 @@ dependencies {
     testImplementation project(':julc-testkit-jqwik')
     testImplementation project(':julc-vm')
     testImplementation "net.jqwik:jqwik:${jqwikVersion}"
+    testRuntimeOnly project(':julc-vm-java')
     testRuntimeOnly project(':julc-vm-scalus')
 }

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/CompileJulcTask.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/CompileJulcTask.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.julc.blueprint.BlueprintFileWriter;
 import com.bloxbean.cardano.julc.blueprint.BlueprintGenerator;
 import com.bloxbean.cardano.julc.clientlib.JulcScriptAdapter;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetRegistry;
 import com.bloxbean.cardano.julc.compiler.JavaSourceIntrospector;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.compiler.ScriptPurposeMetadata;
@@ -53,6 +54,9 @@ public abstract class CompileJulcTask extends DefaultTask {
     @Optional
     public abstract Property<Boolean> getBlueprint();
 
+    @Input
+    public abstract Property<String> getTarget();
+
     @TaskAction
     public void compile() throws IOException {
         File srcDir = getSourceDir().get().getAsFile();
@@ -60,9 +64,10 @@ public abstract class CompileJulcTask extends DefaultTask {
         outDir.mkdirs();
         boolean blueprintEnabled = Boolean.TRUE.equals(getBlueprint().getOrElse(true));
         boolean sourceMapEnabled = Boolean.TRUE.equals(getSourceMap().getOrElse(false));
+        var compilerTarget = CompilerTargetRegistry.targetForProfileId(getTarget().get());
 
         var stdlib = StdlibRegistry.defaultRegistry();
-        var options = new CompilerOptions();
+        var options = new CompilerOptions().setTarget(compilerTarget);
         if (sourceMapEnabled) {
             options.setSourceMapEnabled(true);
         }
@@ -171,9 +176,9 @@ public abstract class CompileJulcTask extends DefaultTask {
                         outDir.toPath().resolve(pending.validatorName() + ".sourcemap.json"),
                         pending.sourceMapJson());
             }
-            getLogger().lifecycle("Compiled {} → {}.json (hash: {}, size: {})",
+            getLogger().lifecycle("Compiled {} → {}.json (target: {}, hash: {}, size: {})",
                     pending.sourceFileName(), pending.validatorName(),
-                    pending.scriptHash(), pending.size());
+                    compilerTarget.profileId(), pending.scriptHash(), pending.size());
         }
         cleanupStaleOutputs(outDir, pendingOutputs);
 

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/JulcExtension.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/JulcExtension.java
@@ -14,6 +14,7 @@ import org.gradle.api.provider.Property;
  *   <li>{@code outputDir} — directory for compiled JSON output (default: {@code build/plutus})</li>
  *   <li>{@code sourceMap} — enable source map generation for debugging (default: {@code false})</li>
  *   <li>{@code blueprint} — generate strict CIP-57 metadata (default: {@code true})</li>
+ *   <li>{@code target} — exact compiler target profile ID (default: PV11)</li>
  * </ul>
  * <p>
  * Example:
@@ -29,6 +30,7 @@ public class JulcExtension {
     private final DirectoryProperty outputDir;
     private final Property<Boolean> sourceMap;
     private final Property<Boolean> blueprint;
+    private final Property<String> target;
 
     public JulcExtension(Project project) {
         ObjectFactory objects = project.getObjects();
@@ -38,6 +40,8 @@ public class JulcExtension {
                 .convention(project.getLayout().getBuildDirectory().dir("plutus"));
         sourceMap = objects.property(Boolean.class).convention(false);
         blueprint = objects.property(Boolean.class).convention(true);
+        target = objects.property(String.class)
+                .convention("plutus-v3-pv11-uplc-1.1.0");
     }
 
     public DirectoryProperty getSourceDir() {
@@ -60,5 +64,10 @@ public class JulcExtension {
     /** Whether compilation must also produce a complete CIP-57 blueprint. */
     public Property<Boolean> getBlueprint() {
         return blueprint;
+    }
+
+    /** Exact, fail-closed compiler target profile ID. */
+    public Property<String> getTarget() {
+        return target;
     }
 }

--- a/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/JulcPlugin.java
+++ b/julc-gradle-plugin/src/main/java/com/bloxbean/cardano/julc/gradle/JulcPlugin.java
@@ -45,6 +45,7 @@ public class JulcPlugin implements Plugin<Project> {
             task.getOutputDir().set(extension.getOutputDir());
             task.getSourceMap().set(extension.getSourceMap());
             task.getBlueprint().set(extension.getBlueprint());
+            task.getTarget().set(extension.getTarget());
         });
 
         // 3. Register bundleJulcSources task
@@ -73,6 +74,8 @@ public class JulcPlugin implements Plugin<Project> {
                         if (Boolean.TRUE.equals(extension.getSourceMap().getOrElse(false))) {
                             task.getOptions().getCompilerArgs().add("-Ajulc.sourceMap=true");
                         }
+                        task.getOptions().getCompilerArgs().add(
+                                "-Ajulc.target=" + extension.getTarget().get());
                         if (!Boolean.TRUE.equals(extension.getBlueprint().getOrElse(true))) {
                             task.getOptions().getCompilerArgs().add("-Ajulc.blueprint=false");
                             // Filer cannot delete a resource from an earlier invocation.

--- a/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/JulcPluginTest.java
+++ b/julc-gradle-plugin/src/test/java/com/bloxbean/cardano/julc/gradle/JulcPluginTest.java
@@ -80,6 +80,42 @@ class JulcPluginTest {
     }
 
     @Test
+    void targetPropertyIsExactAndReported() throws IOException {
+        Files.writeString(buildFile, """
+                plugins {
+                    id 'com.bloxbean.cardano.julc'
+                }
+                julc {
+                    target = 'plutus-v3-pv11-uplc-1.1.0'
+                }
+                """);
+        writeAlwaysTrueValidator();
+
+        var result = createRunner("compileJulc").build();
+
+        assertTrue(result.getOutput().contains(
+                "target: plutus-v3-pv11-uplc-1.1.0"));
+    }
+
+    @Test
+    void unknownFutureTargetFailsClosed() throws IOException {
+        Files.writeString(buildFile, """
+                plugins {
+                    id 'com.bloxbean.cardano.julc'
+                }
+                julc {
+                    target = 'plutus-v3-pv12-uplc-1.1.0'
+                }
+                """);
+        writeAlwaysTrueValidator();
+
+        var result = createRunner("compileJulc").buildAndFail();
+
+        assertTrue(result.getOutput().contains("JULC0031")
+                || result.getOutput().contains("Compiler target"));
+    }
+
+    @Test
     void compilesMintingValidator() throws IOException {
         Files.writeString(buildFile, """
                 plugins {

--- a/julc-jrl/julc-jrl-core/src/main/java/com/bloxbean/cardano/julc/jrl/JrlCompiler.java
+++ b/julc-jrl/julc-jrl-core/src/main/java/com/bloxbean/cardano/julc/jrl/JrlCompiler.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.jrl;
 
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
+import com.bloxbean.cardano.julc.compiler.CompilerOptions;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.jrl.ast.ContractNode;
 import com.bloxbean.cardano.julc.jrl.check.JrlDiagnostic;
@@ -12,6 +13,7 @@ import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * JRL (JuLC Rule Language) compiler facade.
@@ -23,13 +25,20 @@ import java.util.List;
 public class JrlCompiler {
 
     private final StdlibRegistry stdlib;
+    private final CompilerOptions compilerOptions;
 
     public JrlCompiler() {
-        this(StdlibRegistry.defaultRegistry());
+        this(StdlibRegistry.defaultRegistry(), new CompilerOptions());
     }
 
     public JrlCompiler(StdlibRegistry stdlib) {
-        this.stdlib = stdlib;
+        this(stdlib, new CompilerOptions());
+    }
+
+    /** Create a JRL compiler using the same explicit target/options as Java compilation. */
+    public JrlCompiler(StdlibRegistry stdlib, CompilerOptions compilerOptions) {
+        this.stdlib = Objects.requireNonNull(stdlib, "stdlib");
+        this.compilerOptions = Objects.requireNonNull(compilerOptions, "compilerOptions");
     }
 
     /**
@@ -73,7 +82,7 @@ public class JrlCompiler {
 
         // 4. Compile Java -> UPLC via JulcCompiler
         try {
-            var julcCompiler = new JulcCompiler(stdlib);
+            var julcCompiler = new JulcCompiler(stdlib, compilerOptions);
             if (captureContractSchema) {
                 var compiled = julcCompiler.compileContract(javaSource);
                 return new JrlCompileResult(

--- a/julc-jrl/julc-jrl-core/src/test/java/com/bloxbean/cardano/julc/jrl/JrlIntegrationTest.java
+++ b/julc-jrl/julc-jrl-core/src/test/java/com/bloxbean/cardano/julc/jrl/JrlIntegrationTest.java
@@ -1,8 +1,11 @@
 package com.bloxbean.cardano.julc.jrl;
 
+import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilerTarget;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.stdlib.StdlibRegistry;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -89,6 +92,22 @@ class JrlIntegrationTest {
 
     @Nested
     class TranspilationTests {
+
+        @Test
+        void explicitCompilerTargetReachesJrlJavaLowering() {
+            var options = new CompilerOptions()
+                    .setTarget(CompilerTarget.PLUTUS_V3_PV11);
+            var result = new JrlCompiler(StdlibRegistry.defaultRegistry(), options)
+                    .compile("""
+                            contract "Targeted" version "1" purpose spending
+                            rule "always" when Condition( true ) then allow
+                            default: deny
+                            """, "targeted.jrl");
+
+            assertFalse(result.hasErrors(), result.jrlDiagnostics().toString());
+            assertSame(CompilerTarget.PLUTUS_V3_PV11,
+                    result.compileResult().target());
+        }
 
         @Test
         void simpleContract_compilesToUplc() {

--- a/julc-stdlib/build.gradle
+++ b/julc-stdlib/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 
     testImplementation project(':julc-vm')
     testImplementation project(':julc-testkit')
+    testRuntimeOnly project(':julc-vm-java')
     testRuntimeOnly project(':julc-vm-scalus')
 }
 

--- a/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
+++ b/julc-stdlib/src/main/java/com/bloxbean/cardano/julc/stdlib/StdlibRegistry.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.julc.stdlib;
 
+import com.bloxbean.cardano.julc.compiler.LoweringRequirements;
 import com.bloxbean.cardano.julc.compiler.pir.PirHelpers;
 import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
@@ -47,7 +48,11 @@ public final class StdlibRegistry implements StdlibLookup {
         PirTerm build(List<PirTerm> args);
     }
 
-    private final Map<String, PirTermBuilder> registry = new HashMap<>();
+    private record Registration(
+            PirTermBuilder builder,
+            LoweringRequirements requirements) {}
+
+    private final Map<String, Registration> registry = new HashMap<>();
 
     /**
      * Creates a new empty registry.
@@ -62,8 +67,19 @@ public final class StdlibRegistry implements StdlibLookup {
      * @param builder    the PIR term builder
      */
     public void register(String className, String methodName, PirTermBuilder builder) {
+        register(className, methodName, builder, LoweringRequirements.NONE);
+    }
+
+    /** Register a lowering with explicit target requirements. */
+    public void register(
+            String className,
+            String methodName,
+            PirTermBuilder builder,
+            LoweringRequirements requirements) {
         String key = className + "." + methodName;
-        registry.put(key, builder);
+        registry.put(key, new Registration(
+                java.util.Objects.requireNonNull(builder, "builder"),
+                java.util.Objects.requireNonNull(requirements, "requirements")));
     }
 
     /**
@@ -77,11 +93,11 @@ public final class StdlibRegistry implements StdlibLookup {
     @Override
     public Optional<PirTerm> lookup(String className, String methodName, List<PirTerm> args) {
         String key = className + "." + methodName;
-        PirTermBuilder builder = registry.get(key);
-        if (builder == null) {
+        Registration registration = registry.get(key);
+        if (registration == null) {
             return Optional.empty();
         }
-        return Optional.of(builder.build(args));
+        return Optional.of(registration.builder().build(args));
     }
 
     @Override
@@ -227,7 +243,15 @@ public final class StdlibRegistry implements StdlibLookup {
      */
     public Optional<PirTermBuilder> lookupBuilder(String className, String methodName) {
         String key = className + "." + methodName;
-        return Optional.ofNullable(registry.get(key));
+        return Optional.ofNullable(registry.get(key)).map(Registration::builder);
+    }
+
+    @Override
+    public LoweringRequirements requirements(String className, String methodName) {
+        var registration = registry.get(className + "." + methodName);
+        return registration != null
+                ? registration.requirements()
+                : LoweringRequirements.NONE;
     }
 
     /**
@@ -467,7 +491,7 @@ public final class StdlibRegistry implements StdlibLookup {
             reg.register(B, method, args -> {
                 requireArgs("Builtins." + method, args, 1);
                 return builtinApp1(fun, args.get(0));
-            });
+            }, LoweringRequirements.builtin(fun));
         }
         for (var entry : BUILTIN_2_ARG) {
             var method = (String) entry[0];
@@ -475,7 +499,7 @@ public final class StdlibRegistry implements StdlibLookup {
             reg.register(B, method, args -> {
                 requireArgs("Builtins." + method, args, 2);
                 return builtinApp2(fun, args.get(0), args.get(1));
-            });
+            }, LoweringRequirements.builtin(fun));
         }
         for (var entry : BUILTIN_3_ARG) {
             var method = (String) entry[0];
@@ -483,7 +507,7 @@ public final class StdlibRegistry implements StdlibLookup {
             reg.register(B, method, args -> {
                 requireArgs("Builtins." + method, args, 3);
                 return builtinApp3(fun, args.get(0), args.get(1), args.get(2));
-            });
+            }, LoweringRequirements.builtin(fun));
         }
 
         // Special cases that don't follow the standard builtin pattern
@@ -548,7 +572,7 @@ public final class StdlibRegistry implements StdlibLookup {
         reg.register(B, "insertCoin", args -> {
             requireArgs("Builtins.insertCoin", args, 4);
             return builtinApp4(DefaultFun.InsertCoin, args.get(0), args.get(1), args.get(2), args.get(3));
-        });
+        }, LoweringRequirements.builtin(DefaultFun.InsertCoin));
     }
 
     /**
@@ -689,7 +713,7 @@ public final class StdlibRegistry implements StdlibLookup {
         reg.register("JulcArray", "fromList", args -> {
             requireArgs("JulcArray.fromList", args, 1);
             return builtinApp1(DefaultFun.ListToArray, args.get(0));
-        });
+        }, LoweringRequirements.builtin(DefaultFun.ListToArray));
     }
 
     /**

--- a/julc-testkit/build.gradle
+++ b/julc-testkit/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     api project(':julc-stdlib')
     api project(':julc-ledger-api')
     implementation 'org.bouncycastle:bcprov-jdk18on:1.83'
-    testImplementation project(':julc-vm-scalus')
+    testImplementation project(':julc-vm-java')
+    testRuntimeOnly project(':julc-vm-scalus')
 }
 
 publishing {

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ContractTest.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ContractTest.java
@@ -99,6 +99,11 @@ public abstract class ContractTest {
         return ValidatorTest.evaluate(program, args);
     }
 
+    /** Evaluate compiler output using its retained compiler target. */
+    protected EvalResult evaluate(CompileResult compiled, PlutusData... args) {
+        return ValidatorTest.evaluate(compiled, args);
+    }
+
     /**
      * Compile Java source to a UPLC program.
      *
@@ -300,7 +305,7 @@ public abstract class ContractTest {
      * Usage:
      * <pre>{@code
      * var compiled = compileValidatorWithSourceMap(SwapOrder.class);
-     * var result = evaluate(compiled.program(), ctx);
+     * var result = evaluate(compiled, ctx);
      * assertFailure(result, compiled.sourceMap());
      * }</pre>
      *
@@ -412,9 +417,12 @@ public abstract class ContractTest {
                 .withTracing(tracing);
         EvalResult result;
         if (args.length == 0) {
-            result = v.evaluate(compiled.program(), options);
+            result = v.evaluate(
+                    compiled.program(), compiled.target().ledgerTarget(), null, options);
         } else {
-            result = v.evaluateWithArgs(compiled.program(), java.util.List.of(args), options);
+            result = v.evaluateWithArgs(
+                    compiled.program(), compiled.target().ledgerTarget(),
+                    java.util.List.of(args), null, options);
         }
         this.lastResult = result;
         return result;

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/JulcEval.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/JulcEval.java
@@ -302,9 +302,12 @@ public final class JulcEval {
         var allArgs = MethodEvaluator.buildAllArgs(params, args);
         EvalResult result;
         if (allArgs.isEmpty()) {
-            result = vm.evaluate(compiled.program(), evalOpts);
+            result = vm.evaluate(
+                    compiled.program(), compiled.target().ledgerTarget(), null, evalOpts);
         } else {
-            result = vm.evaluateWithArgs(compiled.program(), allArgs, evalOpts);
+            result = vm.evaluateWithArgs(
+                    compiled.program(), compiled.target().ledgerTarget(),
+                    allArgs, null, evalOpts);
         }
         this.lastExecutionTrace = result.executionTrace();
         this.lastBuiltinTrace = result.builtinTrace();

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/MethodEvaluator.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/MethodEvaluator.java
@@ -63,13 +63,8 @@ public final class MethodEvaluator {
     public static EvalResult evaluateRaw(String javaSource, String methodName, PlutusData[] params, PlutusData... args) {
         Objects.requireNonNull(javaSource, "javaSource must not be null");
         Objects.requireNonNull(methodName, "methodName must not be null");
-        var program = compileMethod(javaSource, methodName);
-        var vm = JulcVm.create();
-        var allArgs = buildAllArgs(params, args);
-        if (allArgs.isEmpty()) {
-            return vm.evaluate(program);
-        }
-        return vm.evaluateWithArgs(program, allArgs);
+        var compiled = compileMethodResult(javaSource, methodName);
+        return evaluateCompiled(compiled, buildAllArgs(params, args));
     }
 
     /**
@@ -168,12 +163,17 @@ public final class MethodEvaluator {
      * Compile a single static method to a UPLC Program.
      */
     public static Program compileMethod(String javaSource, String methodName) {
+        return compileMethodResult(javaSource, methodName).program();
+    }
+
+    /** Compile a method while retaining the exact target needed for evaluation. */
+    public static CompileResult compileMethodResult(String javaSource, String methodName) {
         var compiler = new JulcCompiler(StdlibRegistry.defaultRegistry());
         CompileResult result = compiler.compileMethod(javaSource, methodName);
         if (result.hasErrors()) {
             throw new AssertionError("Compilation produced errors: " + result.diagnostics());
         }
-        return result.program();
+        return result;
     }
 
     // --- File-based overloads (Class<?>) ---
@@ -219,13 +219,8 @@ public final class MethodEvaluator {
         Objects.requireNonNull(sourceClass, "sourceClass must not be null");
         Objects.requireNonNull(sourceRoot, "sourceRoot must not be null");
         Objects.requireNonNull(methodName, "methodName must not be null");
-        var program = compileMethod(sourceClass, sourceRoot, methodName);
-        var vm = JulcVm.create();
-        var allArgs = buildAllArgs(params, args);
-        if (allArgs.isEmpty()) {
-            return vm.evaluate(program);
-        }
-        return vm.evaluateWithArgs(program, allArgs);
+        var compiled = SourceDiscovery.compileMethod(sourceClass, sourceRoot, methodName);
+        return evaluateCompiled(compiled, buildAllArgs(params, args));
     }
 
     /**
@@ -418,5 +413,20 @@ public final class MethodEvaluator {
             java.util.Collections.addAll(allArgs, args);
         }
         return allArgs;
+    }
+
+    private static EvalResult evaluateCompiled(
+            CompileResult compiled,
+            List<PlutusData> args) {
+        var vm = JulcVm.create();
+        var target = compiled.target().ledgerTarget();
+        if (args.isEmpty()) {
+            return vm.evaluate(
+                    compiled.program(), target, null,
+                    com.bloxbean.cardano.julc.vm.EvalOptions.DEFAULT);
+        }
+        return vm.evaluateWithArgs(
+                compiled.program(), target, args, null,
+                com.bloxbean.cardano.julc.vm.EvalOptions.DEFAULT);
     }
 }

--- a/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ValidatorTest.java
+++ b/julc-testkit/src/main/java/com/bloxbean/cardano/julc/testkit/ValidatorTest.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.julc.testkit;
 
 import com.bloxbean.cardano.julc.compiler.CompileResult;
 import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.CompilerTargetDiagnostics;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
@@ -12,6 +13,7 @@ import com.bloxbean.cardano.julc.vm.EvalOptions;
 import com.bloxbean.cardano.julc.vm.EvalResult;
 import com.bloxbean.cardano.julc.vm.ExBudget;
 import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
 import com.bloxbean.cardano.julc.vm.trace.FailureReport;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportBuilder;
 import com.bloxbean.cardano.julc.vm.trace.FailureReportFormatter;
@@ -84,6 +86,37 @@ public final class ValidatorTest {
     }
 
     /**
+     * Evaluate compiler output using the exact ledger target retained in its provenance.
+     */
+    public static EvalResult evaluate(CompileResult compiled, PlutusData... args) {
+        Objects.requireNonNull(compiled, "compiled must not be null");
+        return evaluate(compiled, compiled.target().ledgerTarget(), args);
+    }
+
+    /**
+     * Evaluate compiler output under an explicitly requested ledger target.
+     * A target different from the compiled provenance fails before VM execution.
+     */
+    public static EvalResult evaluate(
+            CompileResult compiled,
+            LedgerEvaluationTarget evaluationTarget,
+            PlutusData... args) {
+        Objects.requireNonNull(compiled, "compiled must not be null");
+        Objects.requireNonNull(evaluationTarget, "evaluationTarget must not be null");
+        if (!compiled.target().ledgerTarget().equals(evaluationTarget)) {
+            throw CompilerTargetDiagnostics.evaluationTargetMismatch(
+                    compiled.target(), evaluationTarget);
+        }
+        var vm = JulcVm.create();
+        if (args.length == 0) {
+            return vm.evaluate(
+                    compiled.program(), evaluationTarget, null, EvalOptions.DEFAULT);
+        }
+        return vm.evaluateWithArgs(
+                compiled.program(), evaluationTarget, List.of(args), null, EvalOptions.DEFAULT);
+    }
+
+    /**
      * Compile Java source to a UPLC program, then evaluate with the given arguments.
      *
      * @param javaSource the Java source code containing a supported JuLC validator class
@@ -93,8 +126,7 @@ public final class ValidatorTest {
      */
     public static EvalResult evaluate(String javaSource, PlutusData... args) {
         Objects.requireNonNull(javaSource, "javaSource must not be null");
-        var program = compile(javaSource);
-        return evaluate(program, args);
+        return evaluate(compileResult(javaSource, StdlibRegistry.defaultRegistry()), args);
     }
 
     /**
@@ -145,8 +177,7 @@ public final class ValidatorTest {
                                       com.bloxbean.cardano.julc.compiler.pir.StdlibLookup stdlibLookup,
                                       PlutusData... args) {
         Objects.requireNonNull(javaSource, "javaSource must not be null");
-        var program = compile(javaSource, stdlibLookup);
-        return evaluate(program, args);
+        return evaluate(compileResult(javaSource, stdlibLookup), args);
     }
 
     /**
@@ -179,6 +210,24 @@ public final class ValidatorTest {
         }
     }
 
+    /** Assert success while preserving the compiler-to-evaluator target handoff. */
+    public static void assertValidates(CompileResult compiled, PlutusData... args) {
+        var result = evaluate(compiled, args);
+        if (!result.isSuccess()) {
+            throw new AssertionError("Expected validator to succeed, but got: "
+                    + formatResult(result));
+        }
+    }
+
+    /** Assert failure while preserving the compiler-to-evaluator target handoff. */
+    public static void assertRejects(CompileResult compiled, PlutusData... args) {
+        var result = evaluate(compiled, args);
+        if (result.isSuccess()) {
+            throw new AssertionError("Expected validator to reject, but it succeeded: "
+                    + formatResult(result));
+        }
+    }
+
     /**
      * Assert that compiling and evaluating Java source succeeds.
      *
@@ -186,8 +235,11 @@ public final class ValidatorTest {
      * @param args       the arguments to apply
      */
     public static void assertValidates(String javaSource, PlutusData... args) {
-        var program = compile(javaSource);
-        assertValidates(program, args);
+        var result = evaluate(javaSource, args);
+        if (!result.isSuccess()) {
+            throw new AssertionError("Expected validator to succeed, but got: "
+                    + formatResult(result));
+        }
     }
 
     /**
@@ -197,8 +249,11 @@ public final class ValidatorTest {
      * @param args       the arguments to apply
      */
     public static void assertRejects(String javaSource, PlutusData... args) {
-        var program = compile(javaSource);
-        assertRejects(program, args);
+        var result = evaluate(javaSource, args);
+        if (result.isSuccess()) {
+            throw new AssertionError("Expected validator to reject, but it succeeded: "
+                    + formatResult(result));
+        }
     }
 
     // --- Detailed compilation (with PIR/UPLC inspection) ---
@@ -292,7 +347,7 @@ public final class ValidatorTest {
         if (result.hasErrors()) {
             throw new AssertionError("Compilation produced errors: " + result.diagnostics());
         }
-        return evaluate(result.program(), args);
+        return evaluate(result, args);
     }
 
     // --- Class-based compilation ---
@@ -436,7 +491,7 @@ public final class ValidatorTest {
      * Usage:
      * <pre>{@code
      * var compiled = ValidatorTest.compileValidatorWithSourceMap(MyValidator.class);
-     * var result = ValidatorTest.evaluate(compiled.program(), datum, redeemer, ctx);
+     * var result = ValidatorTest.evaluate(compiled, datum, redeemer, ctx);
      * var location = ValidatorTest.resolveErrorLocation(result, compiled.sourceMap());
      * // location = "MyValidator.java:42 (amount < 0)"
      * }</pre>
@@ -488,7 +543,7 @@ public final class ValidatorTest {
      */
     public static EvalResult evaluateWithSourceMap(String javaSource, PlutusData... args) {
         var compiled = compileWithSourceMap(javaSource);
-        return evaluate(compiled.program(), args);
+        return evaluate(compiled, args);
     }
 
     /**
@@ -515,7 +570,7 @@ public final class ValidatorTest {
      * @param args          the arguments to apply
      */
     public static void assertValidatesWithSourceMap(CompileResult compileResult, PlutusData... args) {
-        var result = evaluate(compileResult.program(), args);
+        var result = evaluate(compileResult, args);
         BudgetAssertions.assertSuccess(result, compileResult.sourceMap());
     }
 
@@ -526,7 +581,7 @@ public final class ValidatorTest {
      * @param args          the arguments to apply
      */
     public static void assertRejectsWithSourceMap(CompileResult compileResult, PlutusData... args) {
-        var result = evaluate(compileResult.program(), args);
+        var result = evaluate(compileResult, args);
         BudgetAssertions.assertFailure(result, compileResult.sourceMap());
     }
 
@@ -613,10 +668,24 @@ public final class ValidatorTest {
                 .withSourceMap(compiled.sourceMap())
                 .withTracing(tracing);
         if (args.length == 0) {
-            return vm.evaluate(compiled.program(), options);
+            return vm.evaluate(
+                    compiled.program(), compiled.target().ledgerTarget(), null, options);
         } else {
-            return vm.evaluateWithArgs(compiled.program(), List.of(args), options);
+            return vm.evaluateWithArgs(
+                    compiled.program(), compiled.target().ledgerTarget(),
+                    List.of(args), null, options);
         }
+    }
+
+    private static CompileResult compileResult(
+            String javaSource,
+            com.bloxbean.cardano.julc.compiler.pir.StdlibLookup stdlibLookup) {
+        var compiler = new JulcCompiler(stdlibLookup);
+        var result = compiler.compile(javaSource);
+        if (result.hasErrors()) {
+            throw new AssertionError("Compilation produced errors: " + result.diagnostics());
+        }
+        return result;
     }
 
     /**

--- a/julc-testkit/src/test/java/com/bloxbean/cardano/julc/testkit/TestkitTest.java
+++ b/julc-testkit/src/test/java/com/bloxbean/cardano/julc/testkit/TestkitTest.java
@@ -5,7 +5,10 @@ import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.PlutusData;
 import com.bloxbean.cardano.julc.core.Program;
 import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -75,6 +78,21 @@ class TestkitTest {
         void assertRejectsThrowsOnSuccess() {
             var program = Program.plutusV3(Term.const_(Constant.unit()));
             assertThrows(AssertionError.class, () -> ValidatorTest.assertRejects(program));
+        }
+
+        @Test
+        void compileResultEvaluationUsesExactTargetAndRejectsMismatch() {
+            var compiled = MethodEvaluator.compileMethodResult(
+                    "class Targeted { static BigInteger answer() { return 42; } }",
+                    "answer");
+
+            assertTrue(ValidatorTest.evaluate(compiled).isSuccess());
+            var error = assertThrows(CompilerException.class,
+                    () -> ValidatorTest.evaluate(
+                            compiled,
+                            LedgerEvaluationTarget.pv10(PlutusLanguage.PLUTUS_V3)));
+            assertEquals("JULC0036", error.diagnostics().getFirst().code());
+            assertTrue(error.getMessage().contains(compiled.target().profileId()));
         }
     }
 

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/ProtocolCapability.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/ProtocolCapability.java
@@ -1,0 +1,10 @@
+package com.bloxbean.cardano.julc.vm;
+
+/** Named protocol capabilities used by evaluators, compilers, and tooling. */
+public enum ProtocolCapability {
+    CONSTR_CASE,
+    CASE_ON_BUILTIN_CONSTANTS,
+    BLS_CONSTANTS,
+    ARRAY_CONSTANTS,
+    VALUE_CONSTANTS
+}

--- a/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureProfile.java
+++ b/julc-vm/src/main/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureProfile.java
@@ -37,6 +37,22 @@ public record ProtocolFeatureProfile(
         return availableUplcVersions.contains(version);
     }
 
+    /**
+     * Query a named protocol capability without recreating version thresholds
+     * in compiler or evaluator consumers.
+     */
+    public boolean supports(ProtocolCapability capability) {
+        Objects.requireNonNull(capability, "capability");
+        return switch (capability) {
+            case CONSTR_CASE -> availableUplcVersions.stream()
+                    .anyMatch(UplcVersion::supportsConstrAndCase);
+            case CASE_ON_BUILTIN_CONSTANTS -> caseOnBuiltinConstants;
+            case BLS_CONSTANTS -> isBuiltinAvailable(DefaultFun.Bls12_381_G1_add);
+            case ARRAY_CONSTANTS -> isBuiltinAvailable(DefaultFun.ListToArray);
+            case VALUE_CONSTANTS -> isBuiltinAvailable(DefaultFun.ValueData);
+        };
+    }
+
     /** Validate the program version before CEK execution. */
     public void validateProgramVersion(Program program) {
         var version = UplcVersion.from(program);

--- a/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureRegistryTest.java
+++ b/julc-vm/src/test/java/com/bloxbean/cardano/julc/vm/ProtocolFeatureRegistryTest.java
@@ -121,6 +121,21 @@ class ProtocolFeatureRegistryTest {
     }
 
     @Test
+    void namedCapabilitiesAreDerivedFromTheCanonicalProfile() {
+        var pv10 = profile(PlutusLanguage.PLUTUS_V3, 10);
+        assertTrue(pv10.supports(ProtocolCapability.CONSTR_CASE));
+        assertTrue(pv10.supports(ProtocolCapability.BLS_CONSTANTS));
+        assertFalse(pv10.supports(ProtocolCapability.CASE_ON_BUILTIN_CONSTANTS));
+        assertFalse(pv10.supports(ProtocolCapability.ARRAY_CONSTANTS));
+        assertFalse(pv10.supports(ProtocolCapability.VALUE_CONSTANTS));
+
+        var pv11 = profile(PlutusLanguage.PLUTUS_V3, 11);
+        for (var capability : ProtocolCapability.values()) {
+            assertTrue(pv11.supports(capability), capability::name);
+        }
+    }
+
+    @Test
     void exactKnownSchemaIsPartOfEveryProfile() {
         assertEquals(CostModelSchema.PLUTUS_V1_LEGACY,
                 profile(PlutusLanguage.PLUTUS_V1, 10).costModelSchema());


### PR DESCRIPTION
## Summary

Implements ADR-031 and closes ADR-029 Phase 4 for the deliberately narrow V3/PV11 compiler profile.

- introduces an immutable compiler target for Plutus V3 / PV11 / UPLC 1.1.0 and rejects every unknown or future profile without fallback
- snapshots and propagates the resolved target through compiler discovery, PIR lowering, UPLC generation, optimization, and final program construction
- uses the VM protocol feature registry as the canonical capability source, with lowering metadata and source-located diagnostics
- validates the final optimized UPLC program so optimizers and direct emission paths cannot bypass target legality
- exposes exact target selection and provenance through CompileResult, CLI, Gradle, annotation processing, JRL, MCP, and testkit evaluation
- documents the process for adding later protocol versions as new pinned profiles; there is no LATEST alias or implicit compatibility assumption

## Compatibility and correctness

- existing compile entry points retain the exact V3/PV11 default
- default and explicitly selected PV11 compilation are byte-identical and hash-stable in regression tests
- existing CompileResult construction remains source-compatible through compatibility constructors
- UPLC encoding and artifact schemas are unchanged; provenance is carried in APIs and tooling output
- compile-result-aware evaluation uses the Java VM target-aware SPI; Scalus remains available for its compatibility paths and fails closed for uncertified explicit-target evaluation
- V1/V2 generation, PV10 lowerings, future protocol profiles, and Phase 5 cost-directed optimization remain out of scope

## Milestones

1. target values, policy, exact registry, and unsupported-target diagnostics
2. immutable compilation context, stage propagation, result provenance, and byte-stability tests
3. canonical capabilities, lowering enforcement, optimizer reporting, and final UPLC validation
4. CLI/build/AP/JRL/MCP/testkit integration and documentation
5. repository-wide regression hardening for target-aware VM provider wiring

Each implementation milestone was developed and tested on a separate branch, reviewed, and merged into this integration branch.

## Verification

- focused compiler registry, propagation, lowering, final-validator, optimizer, diagnostics, and byte-stability tests
- CLI and MCP compile/evaluate tests
- Gradle plugin TestKit and annotation-processor tests
- JRL, testkit, examples, stdlib, and Cardano client integration suites
- `./gradlew build --no-daemon --console=plain` — BUILD SUCCESSFUL (213 tasks)
- final diff whitespace check and audit for raw protocol-version threshold checks

Closes #76
Related to #65
