### PR TITLE
Recover native Pair Case constructor dispatch in the decompiler (#130)

### DIFF
--- a/adr/039-decompiler-constructor-pair-dispatch.md
+++ b/adr/039-decompiler-constructor-pair-dispatch.md
@@ -1,0 +1,97 @@
+# ADR-039: Conservative constructor-pair dispatch recovery
+
+**Date:** 2026-09-06
+**Status:** Implemented and validated; independent review pending
+**Issue:** #130; stacked on PR #129 / ADR-038
+
+## Context
+
+ADR-038's native pair Case misses the legacy DataMatch recognizer. Generic Case
+recovery presents the pair's tag/list as constructor fields. The old recognizer
+also accepts unrelated projection variables and loses the final fallback.
+Existing HIR Switch has neither explicit tag/list bindings nor a default body.
+FLAT erases lambda names, so name-based recovery cannot prove lexical binding.
+
+## Goals and non-goals
+
+Recognize compiler-owned native and legacy UnConstrData decomposition, preserve
+raw field extraction and fallback, and improve readable output after FLAT
+round-trip. Do not change compiler output, infer Java record schemas, promise
+recompilable Java, repair every existing decompiler heuristic, or certify HIR
+as a general executable representation of arbitrary UPLC.
+
+## Decision and invariants
+
+- Add a distinct HIR DataMatch with explicit pair/tag/fields names, ordered
+  BigInteger tag branches and a residual/default body. The existing SOP Switch
+  remains separate. Singleton matches have no invented tag check.
+- Native recognition requires exactly one Case branch with two leading lambdas
+  and a directly saturated UnConstrData scrutinee. Legacy recognition verifies
+  FstPair index 1 then SndPair index 2 of the same once-bound pair.
+- Parse only saturated EqualsInteger against the exact tag binder (index 2),
+  in correctly shaped lazy IfThenElse or Case Bool dispatch. Preserve the entire
+  unmatched remainder as fallback; do not drop errors, traces or computations.
+- Require at least one proven tag comparison when the body begins with a
+  conditional; otherwise ambiguous lookalikes retain generic recovery. Direct
+  singleton bodies and leading field-decode Lets remain valid decomposition.
+- Keep raw branch terms unchanged. Lift each body in its original binding
+  context, without pulling partial field decoders out of selected branches.
+- Resolve names from de Bruijn indices with unique synthetic binder names before
+  lifting programs containing a recognized match. This is a names-only copy:
+  indices, structure and serialized FLAT bytes stay identical. Other programs
+  retain the existing naming path. Unique names protect captures through nested
+  matches and the existing naming/type passes.
+- Run the strict recognizer before generic SOP recovery. Keep the old public
+  recognizer API for compatibility; use the new strict entry point for lifting.
+- Render explicit UnConstrData/projection bindings and ordered integer equality
+  dispatch, including the fallback. Do not invent record constructor names or
+  narrow arbitrary tags to int. Render singleton bodies without a tag guard.
+
+## Alternatives
+
+Extending generic SOP recovery misidentifies native pair Case as a sum type.
+Reusing HIR Switch would omit fallback and explicit raw bindings. Guessing names
+from lambda debug strings fails after serialization. Expanding compiler scope
+or rewriting existing scripts is unnecessary for a decompiler-only correction.
+
+## Affected modules and compatibility
+
+julc-decompiler: recognition, name resolution, HIR, naming/type consumers and
+Java rendering; julc-analysis traversal and conditional-guard classification;
+docs and tests. A new public sealed HIR variant is deliberate:
+external exhaustive visitors must handle DataMatch. Compiler APIs, bytes and
+costs are unchanged. Existing legacy recognizer API remains available.
+
+## Risks and verification
+
+Test exact binder identity, reversed comparisons, nested capture/shadowing,
+wrong force/arity/producer/projection shapes, huge tags, fallback traces/errors,
+unused malformed fields, singleton and fieldless matches. Compile real source
+at NONE/BASELINE/PV11_SAFE and repeat after FLAT serialization. Use a bounded
+HIR-to-UPLC test interpreter/reconstruction for the new representation to check
+results, failures and traces, not just node shapes. Run the decompiler suite,
+consumer tests and full build; inspect all HIR consumers and diff against PR129.
+
+## Milestones
+
+- [x] Inspect current representation and review design invariants.
+- [x] Implement strict recovery and explicit HIR/rendering.
+- [x] Add source, adversarial and semantic regression coverage.
+- [x] Run affected and full validation; review and record limitations.
+- [ ] Open separate PR targeting feat/125-switch-pair-case.
+
+## Review refinements
+
+Self-review identified two consumer details beyond matching syntax. The
+analyzer's recursion heuristic must count a non-empty tag dispatch as a guard,
+but not unconditional singleton decomposition. Name/type consumers must restore
+match scope separately for each branch and fallback. Both have been handled;
+analysis traversal visits the scrutinee, every branch and the fallback.
+
+Rendering uses explicit `BigInteger.equals(new BigInteger("tag"))`, avoiding
+both integer narrowing and the general renderer's arithmetic-operator heuristic.
+The recovered representation intentionally renders as decomposition plus ordered
+if/else dispatch, rather than fictitious record-pattern cases. Schema names,
+recompilable Java and general executable-HIR equivalence remain non-goals.
+
+See [validation evidence](evidence/039-decompiler-constructor-pair-dispatch.md).

--- a/adr/039-decompiler-constructor-pair-dispatch.md
+++ b/adr/039-decompiler-constructor-pair-dispatch.md
@@ -78,7 +78,7 @@ consumer tests and full build; inspect all HIR consumers and diff against PR129.
 - [x] Implement strict recovery and explicit HIR/rendering.
 - [x] Add source, adversarial and semantic regression coverage.
 - [x] Run affected and full validation; review and record limitations.
-- [ ] Open separate PR targeting feat/125-switch-pair-case.
+- [x] Open [PR #131](https://github.com/bloxbean/julc/pull/131) targeting feat/125-switch-pair-case.
 
 ## Review refinements
 

--- a/adr/evidence/039-decompiler-constructor-pair-dispatch.md
+++ b/adr/evidence/039-decompiler-constructor-pair-dispatch.md
@@ -1,0 +1,100 @@
+# Issue #130 / ADR-039 evidence
+
+## Scope and stack
+
+Base: PR #129 branch `feat/125-switch-pair-case` at `397abf51`.
+Implementation branch: `fix/130-pair-case-decompiler`.
+The new PR targets that branch, not main. Compiler, core, VM and ledger sources
+are unchanged relative to the parent; there is no new script-byte/hash migration.
+
+## Recognition and preservation
+
+The new strict entry point recognizes either a directly saturated UnConstrData
+native pair Case with exactly one branch and two leading lambdas, or the legacy
+pair/tag/fields Let chain. Legacy FstPair must reference index 1 and SndPair
+index 2 with exactly two forces each. It never trusts debug names.
+
+Dispatch recognition accepts EqualsInteger with the tag at index 2 and a literal
+BigInteger in either argument position. Native Case Bool order is false/true;
+the legacy chooser must have one force, three applications, delayed branches
+and the final force. Tag constants are never narrowed to int. Repeated tags
+retain order. The entire residual term remains a fallback, including errors,
+traces and further computation. A conditional with no proven tag comparison
+is not promoted. Singleton/unconditional decomposition has zero tag branches,
+not a fictitious tag-zero case.
+
+HIR DataMatch explicitly binds native pair, tag and raw fields. Its scrutinee
+is outside their scope. Fields remain decoded only in their selected branch;
+unused field decoding is not removed. Native matches receive a fresh pair name
+for readable projection rendering; legacy matches retain their visible pair
+binding. The names-only preprocessing pass follows original de Bruijn indices
+and assigns unique binder names, preserving indices and serialized FLAT bytes.
+This avoids capture and name loss after FLAT decoding. Other programs keep the
+previous naming path.
+
+The legacy public `DataMatchRecognizer.match` API is retained and documented as
+a heuristic; the production lifter now uses `matchConstructorDispatch` before
+generic SOP recovery. Existing HIR Switch still represents generic constructor
+cases. The new sealed HIR variant deliberately requires external exhaustive
+visitors to add a DataMatch case.
+
+## Tests and review
+
+`ConstructorDispatchTest` checks native and legacy shapes, wrong producers,
+branch arity/count, projection indices/force counts, malformed chooser forces,
+wrong tag bindings, reversed/huge tags, residual identity, duplicate-tag order,
+singletons, nested matches, match-in-scrutinee, field/tag/pair capture and
+closures. Invalid and malformed selected fields fail with the same trace order;
+an unselected partial decoder stays unobserved.
+
+The semantic oracle reconstructs supported structured and typed/named HIR into
+PIR/UPLC, then compares original/reconstructed result, failure text and traces
+on Java at explicit PV11 and Scalus's language-only API. It runs both before and
+after FLAT round-trip; unsupported HIR fails the test instead of approximating
+it. This is bounded differential evidence, not an interpreter/certification for
+all existing decompiler heuristics. Scalus is not a ledger-certification claim.
+
+Fresh source fixtures cover ordinary Pay/Cancel dispatch, nested capture and a
+fieldless singleton at NONE, BASELINE and PV11_SAFE. Tests require actual
+DataMatch recovery, exercise malformed and unknown-tag inputs, and check
+rendering retains decomposition and fallback without invented Case0 records.
+Names-only rewriting must reproduce identical FLAT bytes.
+
+The analyzer walker visits match scrutinee, branch bodies and fallback. A
+regression distinguishes a non-empty tag-dispatch guard from unconditional
+singleton decomposition in the existing recursion heuristic. Neither is a
+termination proof. Type/naming passes restore match scope across branches and
+fallback.
+
+Self-review also replaced the general renderer's arithmetic equality path with
+explicit BigInteger value equality for recovered tag dispatch. Output is
+readable reconstruction, not promised recompilable Java or original schema
+recovery; existing generic decompiler limitations remain.
+
+## Validation commands
+
+```sh
+./gradlew :julc-decompiler:test :julc-analysis:test \
+  :julc-analyzer-cli:test :julc-cli:test -PskipSigning=true
+./gradlew build -PskipSigning=true --rerun-tasks
+npm run build --prefix docs
+```
+
+Validation completed:
+
+- Fresh full build: all 218 tasks executed, **10,832 cases: 10,301 passed,
+  531 existing/profile skips, zero failures/errors**. Counts include only tasks
+  executed by that build, excluding stale optional E2E reports.
+- Decompiler: **105 passed**; analysis: **82 passed, 2 existing skips**;
+  analyzer CLI: **96 passed, 4 existing skips**; compiler CLI: **442 passed**.
+- Compiler: 1,483 regular tests and 21 pair tests passed, including parent PR
+  historical-byte fixtures. Java and Truffle each passed all **999 PV11
+  conformance vectors**, without PV11 skips or failures.
+- Documentation: 32 pages built successfully.
+- Final diff review: production changes are limited to julc-decompiler and
+  its julc-analysis HIR consumers. No compiler/core/VM/ledger implementation
+  changes relative to PR #129; no parent files or commits were rewritten.
+
+No devnet mutation or Maven-local publication is needed for this decompiler-only
+change. Independent review of this new PR remains pending; Claude's approval of
+PR #129 does not cover it.

--- a/docs/src/content/docs/reference/release-notes.md
+++ b/docs/src/content/docs/reference/release-notes.md
@@ -37,8 +37,13 @@ decoding, including errors in unused fields. The measured switch fixtures save
 10 bytes per site compared with the previous safe output; NONE/BASELINE remain
 byte-identical. Direct PIR DataMatch callers also receive this safe-profile
 change. The switch extension passed its own independent correctness review in
-PR #129. Decompilation currently uses generic Case recovery; dedicated switch
-recognition is tracked in [#130](https://github.com/bloxbean/julc/issues/130).
+PR #129. The decompiler follow-up [#130](https://github.com/bloxbean/julc/issues/130)
+recovers native pair and verified legacy constructor decomposition as explicit
+HIR `DataMatch`, preserving raw fields, ordered integer tag tests and the final
+fallback. Readable output uses decomposition and if/else dispatch; it does not
+invent Java record schemas. FLAT-erased bindings are recovered from de Bruijn
+indices. External exhaustive HIR visitors must handle the new `DataMatch` node;
+the compiler's output bytes and costs are unaffected by this decompiler change.
 
 ## Upcoming preview: stable typed formal-verification API v1
 

--- a/julc-analysis/src/main/java/com/bloxbean/cardano/julc/analysis/rules/HirTreeWalker.java
+++ b/julc-analysis/src/main/java/com/bloxbean/cardano/julc/analysis/rules/HirTreeWalker.java
@@ -41,6 +41,11 @@ public final class HirTreeWalker {
                 walk(iff.thenBranch(), visitor);
                 walk(iff.elseBranch(), visitor);
             }
+            case HirTerm.DataMatch m -> {
+                walk(m.scrutinee(), visitor);
+                m.branches().forEach(b -> walk(b.body(), visitor));
+                walk(m.fallback(), visitor);
+            }
             case HirTerm.Switch sw -> {
                 walk(sw.scrutinee(), visitor);
                 for (var branch : sw.branches()) {

--- a/julc-analysis/src/main/java/com/bloxbean/cardano/julc/analysis/rules/UnboundedRecursionRule.java
+++ b/julc-analysis/src/main/java/com/bloxbean/cardano/julc/analysis/rules/UnboundedRecursionRule.java
@@ -35,7 +35,8 @@ public final class UnboundedRecursionRule implements SecurityRule {
             var lr = (HirTerm.LetRec) node;
             // Check if the recursive value body contains a conditional guard
             boolean hasGuard = HirTreeWalker.anyMatch(lr.value(),
-                    n -> n instanceof HirTerm.If || n instanceof HirTerm.Switch);
+                    n -> n instanceof HirTerm.If || n instanceof HirTerm.Switch
+                            || n instanceof HirTerm.DataMatch m && !m.branches().isEmpty());
 
             // Also check for NullList (list termination check)
             boolean hasNullCheck = HirTreeWalker.anyMatch(lr.value(),

--- a/julc-analysis/src/test/java/com/bloxbean/cardano/julc/analysis/rules/HirTreeWalkerTest.java
+++ b/julc-analysis/src/test/java/com/bloxbean/cardano/julc/analysis/rules/HirTreeWalkerTest.java
@@ -13,6 +13,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class HirTreeWalkerTest {
 
     @Test
+    void dataMatchVisitsScrutineeEveryBranchAndFallback() {
+        var error = new HirTerm.Error();
+        var tree = new HirTerm.DataMatch(error, "pair", "tag", "fields",
+                List.of(new HirTerm.DataMatchBranch(BigInteger.ZERO, error)), error);
+        assertEquals(3, HirTreeWalker.count(tree, node -> node instanceof HirTerm.Error));
+    }
+
+    @Test
     void walk_visitsAllNodes() {
         var inner = new HirTerm.IntLiteral(BigInteger.TEN);
         var tree = new HirTerm.Let("x", inner,

--- a/julc-analysis/src/test/java/com/bloxbean/cardano/julc/analysis/rules/RuleEngineTest.java
+++ b/julc-analysis/src/test/java/com/bloxbean/cardano/julc/analysis/rules/RuleEngineTest.java
@@ -210,6 +210,17 @@ class RuleEngineTest {
     // ==== UnboundedRecursionRule ====
 
     @Test
+    void unboundedRecursionDistinguishesTagDispatchFromUnconditionalDecomposition() {
+        for (boolean guarded : List.of(false, true)) {
+            var match = new HirTerm.DataMatch(new HirTerm.Var("data", HirType.DATA), "pair", "tag", "fields",
+                    guarded ? List.of(new HirTerm.DataMatchBranch(BigInteger.ZERO, new HirTerm.UnitLiteral())) : List.of(),
+                    new HirTerm.FunCall("loop", List.of()));
+            var recursive = new HirTerm.LetRec("loop", match, new HirTerm.UnitLiteral());
+            assertEquals(guarded ? 0 : 1, new UnboundedRecursionRule().analyze(mockResult(recursive)).size());
+        }
+    }
+
+    @Test
     void unboundedRecursion_flagsUnguardedLetRec() {
         // LetRec with no If/Switch guard in value
         var hir = new HirTerm.LetRec("loop",

--- a/julc-decompiler/build.gradle
+++ b/julc-decompiler/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     testImplementation project(':julc-stdlib')
     testImplementation project(':julc-vm')
     testImplementation project(':julc-vm-scalus')
+    testRuntimeOnly project(':julc-vm-java')
 }
 
 publishing {

--- a/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/codegen/JavaCodeGenerator.java
+++ b/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/codegen/JavaCodeGenerator.java
@@ -116,6 +116,8 @@ public final class JavaCodeGenerator {
                     sb.append("}\n");
                 }
 
+                case HirTerm.DataMatch m -> emitDataMatchBody(m);
+
                 case HirTerm.Switch sw -> {
                     emitIndent();
                     sb.append("switch (");
@@ -359,6 +361,14 @@ public final class JavaCodeGenerator {
 
                 case HirTerm.Let let -> emitLetExpr(let);
                 case HirTerm.LetRec letRec -> emitLetRecExpr(letRec);
+                case HirTerm.DataMatch m -> {
+                    sb.append("((java.util.function.Supplier<Object>) () -> {\n");
+                    indent++;
+                    emitDataMatchBody(m);
+                    indent--;
+                    emitIndent();
+                    sb.append("}).get()");
+                }
                 case HirTerm.Switch sw -> emitSwitchExpr(sw);
 
                 case HirTerm.ConstValue cv -> sb.append("/* const ").append(cv.value().type()).append(" */");
@@ -450,6 +460,35 @@ public final class JavaCodeGenerator {
             indent--;
             emitIndent();
             sb.append("}).get()");
+        }
+
+        // Keep integer equality explicit: native tags are BigInteger, not int/long or Java record tags.
+        private void emitDataMatchBody(HirTerm.DataMatch m) {
+            emitIndent();
+            sb.append("var ").append(m.pairName()).append(" = Builtins.unConstrData(");
+            emitExpr(m.scrutinee());
+            sb.append(");\n");
+            emitIndent();
+            sb.append("var ").append(m.tagName()).append(" = Builtins.fstPair(").append(m.pairName()).append(");\n");
+            emitIndent();
+            sb.append("var ").append(m.fieldsName()).append(" = Builtins.sndPair(").append(m.pairName()).append(");\n");
+            for (var branch : m.branches()) {
+                emitIndent();
+                sb.append("if (").append(m.tagName()).append(".equals(new BigInteger(\"")
+                        .append(branch.tag()).append("\"))) {\n");
+                indent++;
+                emitBody(branch.body());
+                indent--;
+                emitIndent();
+                sb.append("} else {\n");
+                indent++;
+            }
+            emitBody(m.fallback());
+            for (int i = 0; i < m.branches().size(); i++) {
+                indent--;
+                emitIndent();
+                sb.append("}\n");
+            }
         }
 
         void emitSwitchExpr(HirTerm.Switch sw) {
@@ -581,6 +620,11 @@ public final class JavaCodeGenerator {
                 case HirTerm.Let let -> { collectImports(let.value()); collectImports(let.body()); }
                 case HirTerm.LetRec lr -> { collectImports(lr.value()); collectImports(lr.body()); }
                 case HirTerm.If iff -> { collectImports(iff.condition()); collectImports(iff.thenBranch()); collectImports(iff.elseBranch()); }
+                case HirTerm.DataMatch m -> {
+                    collectImports(m.scrutinee());
+                    m.branches().forEach(b -> collectImports(b.body()));
+                    collectImports(m.fallback());
+                }
                 case HirTerm.Switch sw -> { collectImports(sw.scrutinee()); sw.branches().forEach(b -> collectImports(b.body())); }
                 case HirTerm.Lambda lam -> collectImports(lam.body());
                 case HirTerm.FunCall fc -> fc.args().forEach(this::collectImports);

--- a/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/hir/HirTerm.java
+++ b/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/hir/HirTerm.java
@@ -5,6 +5,8 @@ import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.Term;
 
 import java.util.List;
+import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * High-level Intermediate Representation for decompiled UPLC.
@@ -67,6 +69,29 @@ public sealed interface HirTerm {
     /** A single branch in a switch statement. */
     record SwitchBranch(int tag, String constructorName, List<String> fieldNames, HirTerm body) {
         public SwitchBranch { fieldNames = List.copyOf(fieldNames); }
+    }
+
+    /** Strict UnConstrData decomposition and ordered tag tests, with an explicit residual body.
+     * Pair/tag/fields bind only in branches and fallback, never in the scrutinee.
+     * Empty branches mean unconditional decomposition, not an invented tag-zero test.
+     */
+    record DataMatch(HirTerm scrutinee, String pairName, String tagName, String fieldsName,
+                     List<DataMatchBranch> branches, HirTerm fallback) implements HirTerm {
+        public DataMatch {
+            Objects.requireNonNull(scrutinee, "scrutinee");
+            Objects.requireNonNull(fallback, "fallback");
+            Objects.requireNonNull(pairName, "pairName");
+            Objects.requireNonNull(tagName, "tagName");
+            Objects.requireNonNull(fieldsName, "fieldsName");
+            if (pairName.equals(tagName) || pairName.equals(fieldsName) || tagName.equals(fieldsName)) {
+                throw new IllegalArgumentException("DataMatch binders must be distinct");
+            }
+            branches = List.copyOf(branches);
+        }
+    }
+
+    record DataMatchBranch(BigInteger tag, HirTerm body) {
+        public DataMatchBranch { Objects.requireNonNull(tag, "tag"); Objects.requireNonNull(body, "body"); }
     }
 
     /** For-each loop over a list. */

--- a/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/lift/DataMatchRecognizer.java
+++ b/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/lift/DataMatchRecognizer.java
@@ -27,8 +27,9 @@ public final class DataMatchRecognizer {
     private DataMatchRecognizer() {}
 
     /**
-     * Try to match a data pattern-match chain.
-     * Returns null if the term doesn't match the pattern.
+     * Legacy heuristic retained for source compatibility. It does not prove lexical
+     * binding relationships. The lifter uses {@link #matchConstructorDispatch(Term)}.
+     * Returns null if the term doesn't match the legacy pattern.
      */
     public static DataMatchResult match(Term term) {
         // Step 1: Look for Let(d, scrutinee, Let(p, UnConstrData(d), ...))
@@ -164,6 +165,81 @@ public final class DataMatchRecognizer {
         var fb = ForceCollapser.matchForcedBuiltinPartial(term);
         return fb != null && fb.fun() == DefaultFun.SndPair && fb.args().size() == 1;
     }
+
+    /** Strict ADR-039 entry point. All relationships are checked by index, never debug names. */
+    public static ConstructorMatch matchConstructorDispatch(Term term) {
+        Term data, body;
+        String pair, tag, fields;
+        if (term instanceof Term.Case c && c.branches().size() == 1
+                && c.scrutinee() instanceof Term.Apply a
+                && a.function() instanceof Term.Builtin b && b.fun() == DefaultFun.UnConstrData
+                && c.branches().getFirst() instanceof Term.Lam first
+                && first.body() instanceof Term.Lam second) {
+            data = a.argument();
+            pair = null; // Native pair Case has no pair binder visible in its body.
+            tag = first.paramName();
+            fields = second.paramName();
+            body = second.body();
+        } else {
+            var p = LetRecognizer.match(term);
+            if (p == null || !(p.value() instanceof Term.Apply a)
+                    || !(a.function() instanceof Term.Builtin b) || b.fun() != DefaultFun.UnConstrData) return null;
+            var t = LetRecognizer.match(p.body());
+            if (t == null || !projection(t.value(), DefaultFun.FstPair, 1)) return null;
+            var f = LetRecognizer.match(t.body());
+            if (f == null || !projection(f.value(), DefaultFun.SndPair, 2)) return null;
+            data = a.argument(); pair = p.name(); tag = t.name(); fields = f.name(); body = f.body();
+        }
+        List<TagBranch> branches = new ArrayList<>();
+        Term rest = body;
+        while (true) {
+            var conditional = tagConditional(rest);
+            if (conditional == null) break;
+            branches.add(new TagBranch(conditional.tag(), conditional.yes()));
+            rest = conditional.no();
+        }
+        // A conditional without a proven tag test is ambiguous. In particular, do not
+        // recover a "constructor dispatch" from a comparison against fields or a capture.
+        if (branches.isEmpty() && (body instanceof Term.Case || IfThenElseRecognizer.match(body) != null)) return null;
+        return new ConstructorMatch(data, pair, tag, fields, branches, rest);
+    }
+
+    private static boolean projection(Term term, DefaultFun fun, int index) {
+        return term instanceof Term.Apply a && a.argument() instanceof Term.Var v && v.name().index() == index
+                && a.function() instanceof Term.Force f && f.term() instanceof Term.Force g
+                && g.term() instanceof Term.Builtin b && b.fun() == fun;
+    }
+
+    private record TagConditional(BigInteger tag, Term yes, Term no) {}
+
+    private static TagConditional tagConditional(Term term) {
+        Term condition, yes, no;
+        if (term instanceof Term.Case c && c.branches().size() == 2) {
+            condition = c.scrutinee(); no = c.branches().getFirst(); yes = c.branches().get(1);
+        } else if (term instanceof Term.Force force && force.term() instanceof Term.Apply last
+                && last.argument() instanceof Term.Delay otherwise && last.function() instanceof Term.Apply middle
+                && middle.argument() instanceof Term.Delay then && middle.function() instanceof Term.Apply first
+                && first.function() instanceof Term.Force f && f.term() instanceof Term.Builtin b
+                && b.fun() == DefaultFun.IfThenElse) {
+            condition = first.argument(); yes = then.term(); no = otherwise.term();
+        } else return null;
+        if (!(condition instanceof Term.Apply a) || !(a.function() instanceof Term.Apply b)
+                || !(b.function() instanceof Term.Builtin fun) || fun.fun() != DefaultFun.EqualsInteger) return null;
+        var tag = comparedTag(b.argument(), a.argument());
+        if (tag == null) tag = comparedTag(a.argument(), b.argument());
+        return tag == null ? null : new TagConditional(tag, yes, no);
+    }
+
+    private static BigInteger comparedTag(Term variable, Term constant) {
+        return variable instanceof Term.Var v && v.name().index() == 2
+                && constant instanceof Term.Const c && c.value() instanceof Constant.IntegerConst n ? n.value() : null;
+    }
+
+    public record ConstructorMatch(Term scrutinee, String pairName, String tagName, String fieldsName,
+                                   List<TagBranch> branches, Term fallback) {
+        public ConstructorMatch { branches = List.copyOf(branches); }
+    }
+    public record TagBranch(BigInteger tag, Term body) {}
 
     public record DataMatchResult(Term scrutinee, String dataVarName, String fieldsVarName,
                                   List<DataMatchBranch> branches) {

--- a/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/lift/ScopedNames.java
+++ b/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/lift/ScopedNames.java
@@ -1,0 +1,39 @@
+package com.bloxbean.cardano.julc.decompiler.lift;
+
+import com.bloxbean.cardano.julc.core.NamedDeBruijn;
+import com.bloxbean.cardano.julc.core.Term;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Names-only copy for matches: FLAT indices, structure and evaluation stay unchanged. */
+final class ScopedNames {
+    private final List<String> scope = new ArrayList<>();
+    private int next;
+
+    static Term resolve(Term term) { return new ScopedNames().visit(term); }
+
+    private Term visit(Term term) {
+        return switch (term) {
+            case Term.Var v -> {
+                int index = v.name().index();
+                String name = index > 0 && index <= scope.size() ? scope.get(scope.size() - index)
+                        : "_free" + Math.max(0, index - scope.size());
+                yield Term.var(new NamedDeBruijn(name, index));
+            }
+            case Term.Lam l -> {
+                String name = "_uplc" + next++;
+                scope.add(name);
+                var body = visit(l.body());
+                scope.removeLast();
+                yield Term.lam(name, body);
+            }
+            case Term.Apply a -> Term.apply(visit(a.function()), visit(a.argument()));
+            case Term.Force f -> Term.force(visit(f.term()));
+            case Term.Delay d -> Term.delay(visit(d.term()));
+            case Term.Case c -> new Term.Case(visit(c.scrutinee()), c.branches().stream().map(this::visit).toList());
+            case Term.Constr c -> new Term.Constr(c.tag(), c.fields().stream().map(this::visit).toList());
+            default -> term;
+        };
+    }
+}

--- a/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/lift/UplcLifter.java
+++ b/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/lift/UplcLifter.java
@@ -15,8 +15,8 @@ import java.util.List;
  * Main UPLC to HIR lifter.
  * <p>
  * Orchestrates pattern recognizers in priority order to convert raw UPLC terms
- * into structured HIR nodes. The lifting proceeds in a single recursive pass,
- * trying recognizers from most specific to least specific at each node.
+ * into structured HIR nodes. Programs with constructor matches first receive
+ * a names-only de Bruijn resolution pass. Recursive lifting then tries recognizers from most specific to least specific at each node.
  */
 public final class UplcLifter {
 
@@ -28,10 +28,31 @@ public final class UplcLifter {
      * Lift a UPLC term to HIR.
      */
     public static HirTerm lift(Term term) {
-        return new UplcLifter().liftTerm(term);
+        return new UplcLifter().liftTerm(containsConstructorMatch(term) ? ScopedNames.resolve(term) : term);
+    }
+
+    private static boolean containsConstructorMatch(Term term) {
+        if (DataMatchRecognizer.matchConstructorDispatch(term) != null) return true;
+        return switch (term) {
+            case Term.Apply a -> containsConstructorMatch(a.function()) || containsConstructorMatch(a.argument());
+            case Term.Lam l -> containsConstructorMatch(l.body());
+            case Term.Force f -> containsConstructorMatch(f.term());
+            case Term.Delay d -> containsConstructorMatch(d.term());
+            case Term.Case c -> containsConstructorMatch(c.scrutinee()) || c.branches().stream().anyMatch(UplcLifter::containsConstructorMatch);
+            case Term.Constr c -> c.fields().stream().anyMatch(UplcLifter::containsConstructorMatch);
+            default -> false;
+        };
     }
 
     private HirTerm liftTerm(Term term) {
+        var constructorMatch = DataMatchRecognizer.matchConstructorDispatch(term);
+        if (constructorMatch != null) {
+            return new HirTerm.DataMatch(liftTerm(constructorMatch.scrutinee()),
+                    constructorMatch.pairName() != null ? constructorMatch.pairName() : freshVar("constrPair"),
+                    constructorMatch.tagName(), constructorMatch.fieldsName(),
+                    constructorMatch.branches().stream().map(b -> new HirTerm.DataMatchBranch(b.tag(), liftTerm(b.body()))).toList(),
+                    liftTerm(constructorMatch.fallback()));
+        }
         // Priority 1: PV11 Case Bool. Only recover an If when the scrutinee is
         // statically known to return Bool; an arbitrary two-branch SOP case is
         // not enough evidence in untyped UPLC.
@@ -64,12 +85,6 @@ public final class UplcLifter {
         var zMatch = LoopRecognizer.match(term);
         if (zMatch != null) {
             return liftZCombinator(zMatch);
-        }
-
-        // Priority 5: Data pattern matching (UnConstrData + tag dispatch)
-        var dataMatch = DataMatchRecognizer.match(term);
-        if (dataMatch != null) {
-            return liftDataMatch(dataMatch);
         }
 
         // Priority 6: Let binding
@@ -295,24 +310,6 @@ public final class UplcLifter {
         return new HirTerm.LetRec(z.name(), body, continuation);
     }
 
-    private HirTerm liftDataMatch(DataMatchRecognizer.DataMatchResult match) {
-        HirTerm scrutinee = liftTerm(match.scrutinee());
-        List<HirTerm.SwitchBranch> branches = new ArrayList<>();
-
-        for (var branch : match.branches()) {
-            HirTerm body = liftTerm(branch.body());
-            // Extract field names from the branch body's Let bindings
-            List<String> fieldNames = extractFieldNames(branch.body());
-            branches.add(new HirTerm.SwitchBranch(
-                    branch.tag(),
-                    "Case" + branch.tag(),
-                    fieldNames,
-                    body));
-        }
-
-        return new HirTerm.Switch(scrutinee, "", branches);
-    }
-
     private HirTerm liftConstr(SopRecognizer.ConstrResult constr) {
         List<HirTerm> fields = constr.fields().stream().map(this::liftTerm).toList();
         return new HirTerm.Constructor("Constr" + constr.tag(), constr.tag(), fields);
@@ -332,24 +329,6 @@ public final class UplcLifter {
         }
 
         return new HirTerm.Switch(scrutinee, "", branches);
-    }
-
-    /**
-     * Try to extract field variable names from Let bindings in a branch body
-     * that use HeadList/TailList patterns.
-     */
-    private List<String> extractFieldNames(Term branchBody) {
-        List<String> names = new ArrayList<>();
-        Term current = branchBody;
-        while (current instanceof Term.Apply app && app.function() instanceof Term.Lam lam) {
-            // This is a Let binding
-            var fa = FieldAccessRecognizer.match(app.argument());
-            if (fa != null) {
-                names.add(lam.paramName());
-            }
-            current = lam.body();
-        }
-        return names;
     }
 
     private String freshVar(String prefix) {

--- a/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/naming/NameAssigner.java
+++ b/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/naming/NameAssigner.java
@@ -99,6 +99,26 @@ public final class NameAssigner {
                 case HirTerm.If iff -> new HirTerm.If(
                         rename(iff.condition()), rename(iff.thenBranch()), rename(iff.elseBranch()));
 
+                case HirTerm.DataMatch m -> {
+                    var scrutinee = rename(m.scrutinee());
+                    // Match binders are local; preserve mappings even for hand-built HIR.
+                    var saved = new HashMap<>(renames);
+                    String pair = makeUnique("constrPair"), tag = makeUnique("tag"), fields = makeUnique("fields");
+                    renames.put(m.pairName(), pair);
+                    renames.put(m.tagName(), tag);
+                    renames.put(m.fieldsName(), fields);
+                    var matchScope = new HashMap<>(renames);
+                    var branches = m.branches().stream().map(b -> {
+                        renames.clear(); renames.putAll(matchScope);
+                        return new HirTerm.DataMatchBranch(b.tag(), rename(b.body()));
+                    }).toList();
+                    renames.clear(); renames.putAll(matchScope);
+                    var fallback = rename(m.fallback());
+                    renames.clear();
+                    renames.putAll(saved);
+                    yield new HirTerm.DataMatch(scrutinee, pair, tag, fields, branches, fallback);
+                }
+
                 case HirTerm.Switch sw -> {
                     HirTerm scrutinee = rename(sw.scrutinee());
                     List<HirTerm.SwitchBranch> branches = sw.branches().stream()

--- a/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/typing/TypeInferenceEngine.java
+++ b/julc-decompiler/src/main/java/com/bloxbean/cardano/julc/decompiler/typing/TypeInferenceEngine.java
@@ -86,6 +86,24 @@ public final class TypeInferenceEngine {
                     inferTerm(iff.thenBranch()),
                     inferTerm(iff.elseBranch()));
 
+            case HirTerm.DataMatch m -> {
+                var scrutinee = inferTerm(m.scrutinee());
+                var saved = new HashMap<>(typeEnv);
+                var fieldsType = new HirType.ListType(HirType.DATA);
+                typeEnv.put(m.pairName(), new HirType.PairType(HirType.INTEGER, fieldsType));
+                typeEnv.put(m.tagName(), HirType.INTEGER);
+                typeEnv.put(m.fieldsName(), fieldsType);
+                var matchScope = new HashMap<>(typeEnv);
+                var branches = m.branches().stream().map(b -> {
+                    typeEnv.clear(); typeEnv.putAll(matchScope);
+                    return new HirTerm.DataMatchBranch(b.tag(), inferTerm(b.body()));
+                }).toList();
+                typeEnv.clear(); typeEnv.putAll(matchScope);
+                var fallback = inferTerm(m.fallback());
+                typeEnv.clear(); typeEnv.putAll(saved);
+                yield new HirTerm.DataMatch(scrutinee, m.pairName(), m.tagName(), m.fieldsName(), branches, fallback);
+            }
+
             case HirTerm.Switch sw -> {
                 HirTerm scrutinee = inferTerm(sw.scrutinee());
                 List<HirTerm.SwitchBranch> branches = sw.branches().stream()

--- a/julc-decompiler/src/test/java/com/bloxbean/cardano/julc/decompiler/lift/ConstructorDispatchTest.java
+++ b/julc-decompiler/src/test/java/com/bloxbean/cardano/julc/decompiler/lift/ConstructorDispatchTest.java
@@ -1,0 +1,237 @@
+package com.bloxbean.cardano.julc.decompiler.lift;
+
+import com.bloxbean.cardano.julc.compiler.CompilationContext;
+import com.bloxbean.cardano.julc.compiler.CompilerOptions;
+import com.bloxbean.cardano.julc.compiler.OptimizationLevel;
+import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
+import com.bloxbean.cardano.julc.compiler.pir.PirType;
+import com.bloxbean.cardano.julc.compiler.uplc.UplcGenerator;
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.Program;
+import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.core.flat.UplcFlatDecoder;
+import com.bloxbean.cardano.julc.core.flat.UplcFlatEncoder;
+import com.bloxbean.cardano.julc.decompiler.DecompileOptions;
+import com.bloxbean.cardano.julc.decompiler.JulcDecompiler;
+import com.bloxbean.cardano.julc.decompiler.hir.HirTerm;
+import com.bloxbean.cardano.julc.vm.EvalOptions;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConstructorDispatchTest {
+    @Test
+    void strictRecognitionChecksIndicesForceCountsAndExactProducerShape() {
+        var condition = call(DefaultFun.EqualsInteger, Term.var(2), integer(0));
+        var dispatch = Term.case_(condition, Term.error(), Term.var(1));
+        var nativeMatch = nativeMatch(data(PlutusData.constr(0)), dispatch);
+        var match = DataMatchRecognizer.matchConstructorDispatch(nativeMatch);
+        assertNotNull(match);
+        assertEquals(BigInteger.ZERO, match.branches().getFirst().tag());
+        assertSame(((Term.Case) dispatch).branches().get(1), match.branches().getFirst().body());
+        assertInstanceOf(Term.Error.class, match.fallback());
+        assertNotNull(DataMatchRecognizer.matchConstructorDispatch(legacy(data(PlutusData.constr(0)), dispatch, 1, 2)));
+        var malformedChooser = Term.force(Term.apply(Term.apply(Term.apply(
+                Term.force(Term.force(Term.builtin(DefaultFun.IfThenElse))), condition), Term.delay(integer(7))), Term.delay(Term.error())));
+        assertNull(DataMatchRecognizer.matchConstructorDispatch(nativeMatch(data(PlutusData.constr(0)), malformedChooser)));
+        var wrongProjectionForces = Term.apply(Term.lam("pair", Term.apply(Term.lam("tag",
+                        Term.apply(Term.lam("fields", dispatch), call(DefaultFun.SndPair, Term.var(2)))),
+                Term.apply(Term.force(Term.builtin(DefaultFun.FstPair)), Term.var(1)))), call(DefaultFun.UnConstrData, data(PlutusData.constr(0))));
+        assertNull(DataMatchRecognizer.matchConstructorDispatch(wrongProjectionForces));
+        for (Term wrong : List.of(
+                Term.case_(data(PlutusData.constr(0)), Term.lam("tag", Term.lam("fields", dispatch))),
+                Term.case_(call(DefaultFun.UnMapData, data(PlutusData.map())), Term.lam("tag", Term.lam("fields", dispatch))),
+                Term.case_(call(DefaultFun.UnConstrData, data(PlutusData.constr(0))), Term.lam("tag", dispatch)),
+                Term.case_(call(DefaultFun.UnConstrData, data(PlutusData.constr(0))), Term.lam("t", Term.lam("f", dispatch)), Term.error()),
+                nativeMatch(data(PlutusData.constr(0)), Term.case_(call(DefaultFun.EqualsInteger, Term.var(1), integer(0)), Term.error(), integer(7))),
+                nativeMatch(data(PlutusData.constr(0)), Term.case_(call(DefaultFun.EqualsInteger, Term.var(3), integer(0)), Term.error(), integer(7))),
+                legacy(data(PlutusData.constr(0)), dispatch, 2, 2),
+                legacy(data(PlutusData.constr(0)), dispatch, 1, 1))) {
+            assertNull(DataMatchRecognizer.matchConstructorDispatch(wrong), wrong.toString());
+        }
+    }
+
+    @Test
+    void recoversHugeReversedTagsAndRetainsResidualFallbackByIdentity() {
+        var huge = BigInteger.ONE.shiftLeft(70);
+        var fallback = trace("fallback", integer(19));
+        var dispatch = Term.case_(call(DefaultFun.EqualsInteger, Term.const_(Constant.integer(huge)), Term.var(2)),
+                fallback, integer(7));
+        var match = DataMatchRecognizer.matchConstructorDispatch(nativeMatch(data(PlutusData.constr(0)), dispatch));
+        assertEquals(huge, match.branches().getFirst().tag());
+        assertSame(fallback, match.fallback());
+        var rendered = JulcDecompiler.decompile(Program.plutusV3(nativeMatch(data(PlutusData.constr(0)), dispatch)),
+                DecompileOptions.defaults()).javaSource();
+        assertTrue(rendered.contains(".equals(new BigInteger(\"" + huge + "\"))"), rendered);
+        assertEquals(Term.const_(Constant.integer(19)), ((EvalResult.Success) equivalent(
+                nativeMatch(data(PlutusData.constr(0)), dispatch))).resultTerm());
+    }
+
+    @Test
+    void preservesStrictDecodeAndBranchLazinessWithMalformedInputs() {
+        var first = call(DefaultFun.UnIData, call(DefaultFun.HeadList, Term.var(1)));
+        var second = call(DefaultFun.UnIData, call(DefaultFun.HeadList, call(DefaultFun.TailList, Term.var(2))));
+        var body = Term.apply(Term.lam("x", Term.apply(Term.lam("unused", trace("selected", Term.var(2))), second)), first);
+        var dispatch = Term.case_(call(DefaultFun.EqualsInteger, Term.var(2), integer(0)), trace("fallback", integer(42)), body);
+        for (var input : List.of(PlutusData.constr(0, PlutusData.integer(7), PlutusData.integer(9)),
+                PlutusData.constr(0, PlutusData.integer(7), PlutusData.bytes(new byte[0])),
+                PlutusData.constr(0), PlutusData.constr(1), PlutusData.integer(0))) {
+            for (boolean nativeCase : List.of(false, true)) {
+                var scrutinee = trace("input", data(input));
+                var term = nativeCase ? nativeMatch(scrutinee, dispatch) : legacy(scrutinee, dispatch, 1, 2);
+                var result = equivalent(term);
+                if (input.equals(PlutusData.constr(1))) assertEquals(List.of("input", "fallback"), result.traces());
+                else if (input.equals(PlutusData.constr(0, PlutusData.integer(7), PlutusData.integer(9)))) {
+                    assertEquals(Term.const_(Constant.integer(7)), ((EvalResult.Success) result).resultTerm());
+                    assertEquals(List.of("input", "selected"), result.traces());
+                } else {
+                    assertInstanceOf(EvalResult.Failure.class, result);
+                    assertEquals(List.of("input"), result.traces());
+                }
+            }
+        }
+        assertInstanceOf(EvalResult.Failure.class, equivalent(nativeMatch(Term.error(), dispatch)));
+    }
+
+    @Test
+    void singletonDoesNotInventTagZeroAndKeepsCapturedNamesAcrossNestedMatches() {
+        var singleton = nativeMatch(data(PlutusData.constr(99)), Term.var(2));
+        var recovered = assertInstanceOf(HirTerm.DataMatch.class, UplcLifter.lift(singleton));
+        assertTrue(recovered.branches().isEmpty());
+        assertEquals(Term.const_(Constant.integer(99)), ((EvalResult.Success) equivalent(singleton)).resultTerm());
+        // Both matches reuse debug names; beneath the extra user lambda, the outer tag is index 5.
+        var inner = nativeMatch(data(PlutusData.constr(5)), call(DefaultFun.AddInteger, Term.var(2), Term.var(5)));
+        var outer = nativeMatch(data(PlutusData.constr(7)), Term.apply(Term.lam("tag", inner), integer(100)));
+        assertEquals(Term.const_(Constant.integer(12)), ((EvalResult.Success) equivalent(outer)).resultTerm());
+        var closure = nativeMatch(data(PlutusData.constr(8)), Term.lam("tag", call(DefaultFun.AddInteger, Term.var(1), Term.var(3))));
+        var applied = Term.apply(closure, integer(4));
+        assertEquals(Term.const_(Constant.integer(12)), ((EvalResult.Success) equivalent(applied)).resultTerm());
+    }
+
+    @Test
+    void capturesFieldsAndLegacyPairAndMatchesInsideScrutinee() {
+        var fieldsClosure = nativeMatch(data(PlutusData.constr(0, PlutusData.integer(9))),
+                Term.lam("fields", call(DefaultFun.UnIData, call(DefaultFun.HeadList, Term.var(2)))));
+        assertEquals(integer(9), ((EvalResult.Success) equivalent(Term.apply(fieldsClosure, integer(100)))).resultTerm());
+        var inner = nativeMatch(data(PlutusData.constr(5)), Term.var(4));
+        assertEquals(integer(7), ((EvalResult.Success) equivalent(legacy(data(PlutusData.constr(7)), inner, 1, 2))).resultTerm());
+        var pairUse = legacy(data(PlutusData.constr(12)), call(DefaultFun.FstPair, Term.var(3)), 1, 2);
+        assertEquals(integer(12), ((EvalResult.Success) equivalent(pairUse)).resultTerm());
+        var input = nativeMatch(trace("inner", data(PlutusData.constr(0))), data(PlutusData.constr(7)));
+        assertEquals(integer(7), ((EvalResult.Success) equivalent(nativeMatch(input, Term.var(2)))).resultTerm());
+    }
+
+    @Test
+    void duplicateTagsAndErrorsKeepOrderedDispatchAndRenderingKeepsFallback() {
+        var dispatch = Term.case_(call(DefaultFun.EqualsInteger, Term.var(2), integer(0)),
+                Term.case_(call(DefaultFun.EqualsInteger, Term.var(2), integer(0)), trace("unknown", Term.error()), Term.error()), integer(7));
+        var term = nativeMatch(data(PlutusData.constr(0)), dispatch);
+        assertEquals(2, DataMatchRecognizer.matchConstructorDispatch(term).branches().size());
+        assertEquals(integer(7), ((EvalResult.Success) equivalent(term)).resultTerm());
+        assertInstanceOf(EvalResult.Failure.class, equivalent(nativeMatch(data(PlutusData.constr(99)), dispatch)));
+        var source = JulcDecompiler.decompile(Program.plutusV3(term), DecompileOptions.defaults()).javaSource();
+        assertTrue(source.contains("unConstrData"), source);
+        assertTrue(source.contains("fstPair"), source);
+        assertTrue(source.contains("sndPair"), source);
+        assertTrue(source.contains("unknown"), source);
+        assertTrue(source.contains("Builtins.error()"), source);
+        assertFalse(source.contains("case Case0"), source);
+    }
+
+    static EvalResult equivalent(Term term) {
+        EvalResult result = null;
+        for (var input : List.of(term, UplcFlatDecoder.decodeProgram(UplcFlatEncoder.encodeProgram(Program.plutusV3(term))).term())) {
+            assertArrayEquals(UplcFlatEncoder.encodeProgram(Program.plutusV3(input)),
+                    UplcFlatEncoder.encodeProgram(Program.plutusV3(ScopedNames.resolve(input))));
+            for (var level : List.of(DecompileOptions.OutputLevel.STRUCTURED, DecompileOptions.OutputLevel.TYPED)) {
+                var options = new DecompileOptions(level, null);
+                var hir = JulcDecompiler.decompile(Program.plutusV3(input), options).hir();
+                var restored = new UplcGenerator(CompilationContext.resolve(new CompilerOptions()
+                        .setOptimizationLevel(OptimizationLevel.BASELINE)), null).generate(toPir(hir));
+                for (String provider : List.of("Java", "Scalus")) {
+                    var vm = JulcVm.create(provider);
+                    var target = LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3);
+                    var before = provider.equals("Java") ? vm.evaluate(Program.plutusV3(input), target, null, EvalOptions.DEFAULT)
+                            : vm.evaluate(Program.plutusV3(input));
+                    result = provider.equals("Java") ? vm.evaluate(Program.plutusV3(restored), target, null, EvalOptions.DEFAULT)
+                            : vm.evaluate(Program.plutusV3(restored));
+                    assertEquals(before.getClass(), result.getClass(), provider);
+                    assertEquals(before.traces(), result.traces(), provider);
+                    if (before instanceof EvalResult.Success s) assertEquals(s.resultTerm(), ((EvalResult.Success) result).resultTerm(), provider);
+                    if (before instanceof EvalResult.Failure f) assertEquals(f.error(), ((EvalResult.Failure) result).error(), provider);
+                }
+            }
+        }
+        return result;
+    }
+
+    // Bounded reconstruction oracle; unsupported HIR fails the test instead of silently approximating it.
+    private static PirTerm toPir(HirTerm h) {
+        var data = new PirType.DataType();
+        return switch (h) {
+            case HirTerm.Var v -> new PirTerm.Var(v.name(), data);
+            case HirTerm.IntLiteral n -> new PirTerm.Const(Constant.integer(n.value()));
+            case HirTerm.BoolLiteral b -> new PirTerm.Const(Constant.bool(b.value()));
+            case HirTerm.DataLiteral d -> new PirTerm.Const(Constant.data(d.value()));
+            case HirTerm.StringLiteral s -> new PirTerm.Const(Constant.string(s.value()));
+            case HirTerm.Error _ -> new PirTerm.Error(data);
+            case HirTerm.Let l -> new PirTerm.Let(l.name(), toPir(l.value()), toPir(l.body()));
+            case HirTerm.Lambda l -> {
+                var body = toPir(l.body());
+                for (var p : l.params().reversed()) body = new PirTerm.Lam(p, data, body);
+                yield body;
+            }
+            case HirTerm.If i -> new PirTerm.IfThenElse(toPir(i.condition()), toPir(i.thenBranch()), toPir(i.elseBranch()));
+            case HirTerm.Trace t -> new PirTerm.Trace(toPir(t.message()), toPir(t.body()));
+            case HirTerm.DataDecode d -> pirCall(d.decoder(), toPir(d.operand()));
+            case HirTerm.DataEncode d -> pirCall(d.encoder(), toPir(d.operand()));
+            case HirTerm.BuiltinCall b -> pirCall(b.fun(), b.args().stream().map(ConstructorDispatchTest::toPir).toArray(PirTerm[]::new));
+            case HirTerm.FunCall f -> {
+                var args = f.args().stream().map(ConstructorDispatchTest::toPir).toList();
+                PirTerm call = f.name().equals("_apply") ? args.getFirst() : new PirTerm.Var(f.name(), data);
+                for (var a : f.name().equals("_apply") ? args.subList(1, args.size()) : args) call = new PirTerm.App(call, a);
+                yield call;
+            }
+            case HirTerm.DataMatch m -> {
+                var fallback = toPir(m.fallback());
+                for (var b : m.branches().reversed()) fallback = new PirTerm.IfThenElse(pirCall(DefaultFun.EqualsInteger,
+                        new PirTerm.Var(m.tagName(), data), new PirTerm.Const(Constant.integer(b.tag()))), toPir(b.body()), fallback);
+                var pair = new PirTerm.Var(m.pairName(), data);
+                yield new PirTerm.Let(m.pairName(), pirCall(DefaultFun.UnConstrData, toPir(m.scrutinee())),
+                        new PirTerm.Let(m.tagName(), pirCall(DefaultFun.FstPair, pair),
+                                new PirTerm.Let(m.fieldsName(), pirCall(DefaultFun.SndPair, pair), fallback)));
+            }
+            default -> throw new AssertionError("Unsupported reconstruction: " + h);
+        };
+    }
+
+    private static PirTerm pirCall(DefaultFun f, PirTerm... args) {
+        PirTerm t = new PirTerm.Builtin(f);
+        for (var a : args) t = new PirTerm.App(t, a);
+        return t;
+    }
+    static Term nativeMatch(Term data, Term body) { return Term.case_(call(DefaultFun.UnConstrData, data), Term.lam("tag", Term.lam("fields", body))); }
+    static Term legacy(Term data, Term body, int first, int second) {
+        return Term.apply(Term.lam("pair", Term.apply(Term.lam("tag", Term.apply(Term.lam("fields", body),
+                call(DefaultFun.SndPair, Term.var(second)))), call(DefaultFun.FstPair, Term.var(first)))), call(DefaultFun.UnConstrData, data));
+    }
+    static Term call(DefaultFun f, Term... args) {
+        Term t = Term.builtin(f);
+        int forces = switch (f) { case FstPair, SndPair -> 2; case HeadList, TailList, NullList, Trace, IfThenElse -> 1; default -> 0; };
+        for (int i = 0; i < forces; i++) t = Term.force(t);
+        for (var a : args) t = Term.apply(t, a);
+        return t;
+    }
+    static Term integer(long n) { return Term.const_(Constant.integer(n)); }
+    static Term data(PlutusData d) { return Term.const_(Constant.data(d)); }
+    static Term trace(String message, Term body) { return call(DefaultFun.Trace, Term.const_(Constant.string(message)), body); }
+}

--- a/julc-decompiler/src/test/java/com/bloxbean/cardano/julc/decompiler/lift/SwitchPairCaseRecognitionTest.java
+++ b/julc-decompiler/src/test/java/com/bloxbean/cardano/julc/decompiler/lift/SwitchPairCaseRecognitionTest.java
@@ -4,6 +4,10 @@ import com.bloxbean.cardano.julc.compiler.CompilerOptions;
 import com.bloxbean.cardano.julc.compiler.JulcCompiler;
 import com.bloxbean.cardano.julc.compiler.OptimizationLevel;
 import com.bloxbean.cardano.julc.core.flat.UplcFlatDecoder;
+import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.decompiler.hir.HirTerm;
 import com.bloxbean.cardano.julc.core.flat.UplcFlatEncoder;
 import com.bloxbean.cardano.julc.decompiler.DecompileOptions;
 import com.bloxbean.cardano.julc.decompiler.JulcDecompiler;
@@ -35,7 +39,63 @@ class SwitchPairCaseRecognitionTest {
             var decoded = UplcFlatDecoder.decodeProgram(UplcFlatEncoder.encodeProgram(compiled.program()));
             var decompiled = JulcDecompiler.decompile(decoded, DecompileOptions.defaults());
             assertNotNull(decompiled.hir());
+            assertTrue(hasMatch(decompiled.hir()), level.toString());
+            assertTrue(decompiled.javaSource().contains("unConstrData"), decompiled.javaSource());
+            assertTrue(decompiled.javaSource().contains("if ("), decompiled.javaSource());
+            for (var input : List.of(PlutusData.constr(0, PlutusData.integer(7)), PlutusData.constr(1),
+                    PlutusData.constr(99), PlutusData.constr(0), PlutusData.constr(0, PlutusData.bytes(new byte[0])))) {
+                ConstructorDispatchTest.equivalent(Term.apply(decoded.term(), Term.const_(Constant.data(input))));
+            }
             assertFalse(decompiled.javaSource().isBlank());
         }
     }
+    @Test
+    void nestedAndSingletonSourcesKeepCaptureAndDoNotInventChecks() {
+        String nested = """
+                class Nested {
+                    sealed interface Action permits Pay, Cancel {}
+                    record Pay(long amount) implements Action {}
+                    record Cancel() implements Action {}
+                    static long run(Action a, Action b) {
+                        return switch (a) {
+                            case Pay outer -> switch (b) {
+                                case Pay inner -> outer.amount() + inner.amount();
+                                case Cancel c -> outer.amount();
+                            };
+                            case Cancel c -> 0;
+                        };
+                    }
+                }
+                """;
+        String singleton = """
+                class Single {
+                    sealed interface Action permits Only {}
+                    record Only() implements Action {}
+                    static long run(Action a) { return switch (a) { case Only o -> 7; }; }
+                }
+                """;
+        for (String source : List.of(nested, singleton)) {
+            for (var level : List.of(OptimizationLevel.NONE, OptimizationLevel.BASELINE, OptimizationLevel.PV11_SAFE)) {
+                var compiled = new JulcCompiler(StdlibRegistry.defaultRegistry(), new CompilerOptions().setOptimizationLevel(level))
+                        .compileMethod(source, "run");
+                assertFalse(compiled.hasErrors(), compiled.diagnostics().toString());
+                var term = compiled.program().term();
+                assertTrue(hasMatch(UplcLifter.lift(term)), level + source);
+                term = Term.apply(term, Term.const_(Constant.data(PlutusData.constr(0, PlutusData.integer(7)))));
+                if (source.equals(nested)) term = Term.apply(term, Term.const_(Constant.data(PlutusData.constr(0, PlutusData.integer(9)))));
+                ConstructorDispatchTest.equivalent(term);
+            }
+        }
+    }
+
+    private static boolean hasMatch(HirTerm h) {
+        return switch (h) {
+            case HirTerm.DataMatch _ -> true;
+            case HirTerm.Lambda l -> hasMatch(l.body());
+            case HirTerm.Let l -> hasMatch(l.value()) || hasMatch(l.body());
+            case HirTerm.If i -> hasMatch(i.thenBranch()) || hasMatch(i.elseBranch());
+            default -> false;
+        };
+    }
+
 }


### PR DESCRIPTION
ADR-038's native Pair Case bypasses the legacy DataMatch recognizer, so sealed-interface switches fall through to generic SOP recovery. This adds conservative constructor-dispatch recovery with explicit pair/tag/fields bindings and a retained fallback, for both native and verified legacy shapes.

Closes #130.

**Stacked PR:** base is `feat/125-switch-pair-case` (PR #129), as requested. Review this diff against that branch. PR #129's earlier approval does not cover these changes.

## Design and behavior

- Verify a saturated UnConstrData producer, native branch shape, legacy projection indices/force counts, and exact de Bruijn tag relationships. Ambiguous comparisons retain generic recovery.
- Add HIR `DataMatch` with ordered BigInteger tag branches and an explicit residual/default body. Singleton decomposition has no invented tag-zero test. Partial field decoding stays in its branch.
- Resolve unique names from original de Bruijn indices before lifting programs containing a recognized match. This names-only copy preserves FLAT bytes and captures through serialization, nesting and closures.
- Render explicit decomposition and BigInteger equality dispatch with fallback, rather than inventing Java record schemas. Update naming, type inference, analyzer traversal and the recursion heuristic for the new HIR node.
- Retain the old public recognizer API for compatibility; production lifting uses the new strict entry point.

**Compatibility:** external exhaustive HIR visitors must handle the new sealed `DataMatch` variant. Decompiled names/output can change. Compiler/core/VM/ledger implementation and generated script bytes/costs are unchanged. Output remains readable reconstruction, not promised recompilable Java or original-schema recovery.

## Validation

- Fresh `./gradlew build -PskipSigning=true --rerun-tasks`: all 218 tasks executed; **10,301 passed, 531 existing/profile skips, zero failures/errors**.
- Decompiler: **105 passed**. Analysis: **82 passed, 2 existing skips**. Analyzer CLI: **96 passed, 4 existing skips**. Compiler CLI: **442 passed**.
- Parent compiler regressions: 1,483 regular and 21 pair tests passed. Java/Truffle each passed **999/999 PV11 conformance cases**, without PV11 skips.
- Bounded HIR reconstruction tests compare original/reconstructed values, failure text and traces on explicit-PV11 Java and language-only Scalus, at structured and typed/named levels, before and after FLAT round-trip.
- Source fixtures cover NONE/BASELINE/PV11_SAFE, Pay/Cancel, nested captures and fieldless singletons. Adversarial tests cover wrong producers/bindings/forces/arity, large/reversed/duplicate tags, unknown-tag fallback, strict unused-field failures, captured pair/tag/fields and matches inside scrutinees.
- Documentation build passed (32 pages). No devnet mutation or Maven-local publication was needed for this decompiler-only change.

## Review focus

Please review the strict index/force checks, names-only scope resolution, preservation of residual fallback and selected decoding, and all new HIR consumers. Semantic tests are bounded evidence, not a certification of every existing decompiler heuristic.

[ADR-039](https://github.com/bloxbean/julc/blob/fix/130-pair-case-decompiler/adr/039-decompiler-constructor-pair-dispatch.md) · [Validation evidence](https://github.com/bloxbean/julc/blob/fix/130-pair-case-decompiler/adr/evidence/039-decompiler-constructor-pair-dispatch.md)
