### PR TITLE
fix(compiler): emit serialiseData without a force wrapper

### DIFF
--- a/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
+++ b/julc-compiler/src/main/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGenerator.java
@@ -580,7 +580,7 @@ public class UplcGenerator {
             case FstPair, SndPair, ChooseList -> 2;
             // 1 Force (1 type variable: ∀ a)
             case IfThenElse, ChooseUnit, Trace, ChooseData,
-                 SerialiseData, MkCons, HeadList, TailList, NullList,
+                 MkCons, HeadList, TailList, NullList,
                  DropList, LengthOfArray, ListToArray, IndexArray, MultiIndexArray -> 1;
             // 0 Forces (monomorphic)
             default -> 0;

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/uplc/SerialiseDataLoweringTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/uplc/SerialiseDataLoweringTest.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.julc.compiler.uplc;
+
+import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
+import com.bloxbean.cardano.julc.core.Constant;
+import com.bloxbean.cardano.julc.core.DefaultFun;
+import com.bloxbean.cardano.julc.core.PlutusData;
+import com.bloxbean.cardano.julc.core.Program;
+import com.bloxbean.cardano.julc.core.Term;
+import com.bloxbean.cardano.julc.vm.EvalResult;
+import com.bloxbean.cardano.julc.vm.JulcVm;
+import com.bloxbean.cardano.julc.vm.LedgerEvaluationTarget;
+import com.bloxbean.cardano.julc.vm.PlutusLanguage;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HexFormat;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class SerialiseDataLoweringTest {
+    @ParameterizedTest
+    @ValueSource(ints = {10, 11})
+    void generatedSerialiseDataEvaluatesToExpectedCbor(int protocolVersion) {
+        var values = List.of(PlutusData.integer(0), PlutusData.integer(-1),
+                PlutusData.bytes(new byte[0]), PlutusData.constr(0));
+        var expectedCbor = List.of("00", "20", "40", "d87980");
+        for (int i = 0; i < values.size(); i++) {
+            var pir = new PirTerm.App(new PirTerm.Builtin(DefaultFun.SerialiseData),
+                    new PirTerm.Const(Constant.data(values.get(i))));
+            var program = Program.plutusV3(new UplcGenerator().generate(pir));
+            var target = protocolVersion == 10 ? LedgerEvaluationTarget.pv10(PlutusLanguage.PLUTUS_V3)
+                    : LedgerEvaluationTarget.pv11(PlutusLanguage.PLUTUS_V3);
+            var result = JulcVm.create("Java").evaluate(program, target);
+            var success = assertInstanceOf(EvalResult.Success.class, result, protocolVersion + ": " + result);
+            assertEquals(Term.const_(Constant.byteString(HexFormat.of().parseHex(expectedCbor.get(i)))),
+                    success.resultTerm(), protocolVersion + " vector " + i);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #132.

`serialiseData` currently compiles to a forced builtin and fails when evaluated, blocking hash/signature validators that serialize typed intents. Remove `SerialiseData` from the compiler's one-force case so it receives its Data argument directly, as required for this monomorphic builtin.

Add a regression that evaluates compiler-generated programs on Java VM PV10 and PV11 and checks exact CBOR for zero, a negative integer, empty bytes and an empty constructor. Both protocol-version cases failed before the fix and pass afterward. No VM behavior or protocol encoding is changed; emitted script hashes for affected programs change as a consequence of correcting the compiler output.

### Validation

- `./gradlew :julc-compiler:test :julc-annotation-processor:test -PskipSigning=true`: 1,485 compiler tests and 20 annotation-processor tests passed; no skipped tests.
- Kavach consumer using locally published `0.1.0-pre17-1a46882-SNAPSHOT` and CCL `0.8.0-pre5`: 20 conformance tests plus the positive toolchain-acceptance test passed without AST rewriting.
- Yaci DevKit, Plutus V3/PV11, node `11.0.1`: normally compiled withdrawal confirmed in transaction `4ae1b9b48a6f445283c5cc39371d831ac1fc0cb6247049322895e77b96b00020`; wrong-key authorization rejected by the evaluation endpoint; replay rejected on submission because inputs were spent. Confirmed transaction execution units: 88,435,135 CPU steps and 84,445 memory units.

The local checks cover the compiler and annotation-processor test tasks, not every repository task. Repository CI will run the broader build. The DevKit scenario is a Kavach Phase 0 experiment, not a production-safety claim.
