### PR TITLE
test(compiler): guard against builtin force-count drift

### DIFF
--- a/docs/src/content/docs/internals/compiler-developer-guide.md
+++ b/docs/src/content/docs/internals/compiler-developer-guide.md
@@ -1003,8 +1003,13 @@ Polymorphic builtins need `Force` wrappers to instantiate type variables:
 | Forces | Builtins |
 |--------|----------|
 | 2 (∀ a b) | `FstPair`, `SndPair`, `ChooseList` |
-| 1 (∀ a) | `IfThenElse`, `ChooseUnit`, `Trace`, `ChooseData`, `SerialiseData`, `MkCons`, `HeadList`, `TailList`, `NullList` |
-| 0 (mono) | All arithmetic, comparisons, Data encode/decode, crypto, string/bytestring ops |
+| 1 (∀ a) | `IfThenElse`, `ChooseUnit`, `Trace`, `ChooseData`, `MkCons`, `HeadList`, `TailList`, `NullList`, `DropList`, `LengthOfArray`, `ListToArray`, `IndexArray` |
+| 0 (mono) | All arithmetic, comparisons, Data encode/decode, `SerialiseData`, crypto, string/bytestring ops |
+
+`UplcGeneratorTest.ForceCountTable` checks every `DefaultFun` against
+`BuiltinSemantics.Sig.typeArity`; the VM's `BuiltinSemanticsCrossCheckTest` checks
+that metadata against runtime signatures. Experimental `MultiIndexArray` also
+requires one force, but is unavailable to the current compiler target.
 
 ### 12.2 UplcOptimizer
 

--- a/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGeneratorTest.java
+++ b/julc-compiler/src/test/java/com/bloxbean/cardano/julc/compiler/uplc/UplcGeneratorTest.java
@@ -3,12 +3,15 @@ package com.bloxbean.cardano.julc.compiler.uplc;
 import com.bloxbean.cardano.julc.compiler.CompilerException;
 import com.bloxbean.cardano.julc.compiler.pir.PirTerm;
 import com.bloxbean.cardano.julc.compiler.pir.PirType;
+import com.bloxbean.cardano.julc.core.BuiltinSemantics;
 import com.bloxbean.cardano.julc.core.Constant;
 import com.bloxbean.cardano.julc.core.DefaultFun;
 import com.bloxbean.cardano.julc.core.Term;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -148,6 +151,17 @@ class UplcGeneratorTest {
 
     @Nested
     class ForceCountTable {
+        // BuiltinSemanticsCrossCheckTest separately checks this metadata against the VM.
+        // Include every enum entry, even builtins gated out of the current compiler target.
+        @ParameterizedTest
+        @EnumSource(DefaultFun.class)
+        void matchesBuiltinSemantics(DefaultFun fun) {
+            var signature = BuiltinSemantics.find(fun);
+            assertNotNull(signature, "Missing builtin semantics for " + fun);
+            assertEquals(signature.typeArity(), UplcGenerator.forceCount(fun),
+                    "Compiler force count must match builtin type arity for " + fun);
+        }
+
         @Test void ifThenElse() { assertEquals(1, UplcGenerator.forceCount(DefaultFun.IfThenElse)); }
         @Test void trace() { assertEquals(1, UplcGenerator.forceCount(DefaultFun.Trace)); }
         @Test void chooseData() { assertEquals(1, UplcGenerator.forceCount(DefaultFun.ChooseData)); }


### PR DESCRIPTION
The compiler's force-count table was not covered by the existing shared-metadata/VM cross-check, allowing the invalid force on `SerialiseData` fixed in #133 to go unnoticed. Add an enum-parameterized assertion comparing `UplcGenerator.forceCount` with `BuiltinSemantics.Sig.typeArity` for every builtin, with an explicit failure for missing metadata. This covers all 102 current entries, including target-gated entries, and automatically includes future enum additions.

Correct the developer guide's `SerialiseData` classification, document PV11 list/array force counts, and describe the compiler → shared metadata → VM checks. Production code, public APIs, and generated scripts are unchanged.

Validation:
- Focused `UplcGeneratorTest` suite passed.
- Temporarily restored the extra force on `SerialiseData` and removed the required force on `HeadList`: the new 102-case guard failed on exactly those two entries. Both mutations were reverted.
- `./gradlew :julc-compiler:test :julc-vm-java:test --tests '*' -PskipSigning=true` passed: 1,587 compiler tests (no skips); 2,439 Java VM cases (262 skipped, no failures/errors).
- `git diff --check` passed.
